### PR TITLE
fix: cli server clippy error

### DIFF
--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -17,6 +17,7 @@ use cli_server::redis::RedisMessenger;
 
 use crate::{flags::OutputFormat, jsonl::JSONLineMessenger, result_formatting::FormattedMessager};
 
+#[allow(clippy::large_enum_variant)]
 pub enum MessengerVariant<'a> {
     Formatted(FormattedMessager<'a>),
     JsonLine(JSONLineMessenger<'a>),


### PR DESCRIPTION
It is not possible to enforce clippy for the server feature in this repo because it doesn't build at all.