### PR TITLE
feat: match ignores against directly invoked paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,6 +2117,7 @@ dependencies = [
  "tree-sitter-vue",
  "tree-sitter-yaml",
  "trim-margin",
+ "walkdir",
  "web-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,6 +2093,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "marzano-util",
+ "path-absolutize",
  "regex",
  "serde",
  "serde_json",

--- a/crates/cli/src/analyze.rs
+++ b/crates/cli/src/analyze.rs
@@ -13,13 +13,13 @@ use grit_cache::paths::cache_for_cwd;
 use ignore::Walk;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 
+#[allow(unused_imports)]
+use marzano_core::pattern::built_in_functions::BuiltIns;
 use marzano_core::pattern::{
     api::{AnalysisLog, DoneFile, MatchResult},
     compiler::CompilationResult,
     Problem,
 };
-#[allow(unused_imports)]
-use marzano_core::pattern::built_in_functions::BuiltIns;
 use marzano_language::target_language::PatternLanguage;
 use marzano_util::cache::GritCache;
 use marzano_util::position::Position;

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -374,6 +374,19 @@ pub(crate) async fn run_apply_pattern(
         expand_paths(&my_input.paths, Some(&[(&compiled.language).into()]))
     );
 
+    if file_walker.is_none() {
+        let all_done = MatchResult::AllDone(AllDone {
+            processed: 0,
+            found: 0,
+            reason: AllDoneReason::AllPathsIgnored,
+        });
+        emitter.emit(&all_done, min_level).unwrap();
+        emitter.flush().await?;
+
+        return Ok(());
+    }
+    let file_walker = file_walker.unwrap();
+
     let processed = AtomicI32::new(0);
 
     let mut emitter = par_apply_pattern(

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -153,7 +153,10 @@ pub(crate) async fn run_check(
     let found_files: DashMap<String, Vec<RichPath>> = DashMap::new();
 
     for language in target_languages {
-        let file_walker = expand_paths(&paths, Some(&[language]))?;
+        let file_walker = match expand_paths(&paths, Some(&[language]))? {
+            Some(walker) => walker,
+            None => continue,
+        };
         let mut language_paths = Vec::new();
         for file in file_walker {
             let file = file?;

--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -785,10 +785,13 @@ mod tests {
         let cli_release_date = updater._get_app_release_date(SupportedApp::Cli)?;
         assert_eq!(
             cli_release_date,
-            DateTime::<Utc>::from_naive_utc_and_offset(NaiveDate::from_ymd_opt(2023, 7, 12)
-                .unwrap()
-                .and_hms_opt(5, 2, 9)
-                .unwrap(), Utc),
+            DateTime::<Utc>::from_naive_utc_and_offset(
+                NaiveDate::from_ymd_opt(2023, 7, 12)
+                    .unwrap()
+                    .and_hms_opt(5, 2, 9)
+                    .unwrap(),
+                Utc
+            ),
         );
 
         Ok(())

--- a/crates/cli/tests/plumbing.rs
+++ b/crates/cli/tests/plumbing.rs
@@ -103,7 +103,11 @@ fn returns_check_results_for_level() -> Result<()> {
 
     let input = format!(r#"{{ "paths" : [{:?}] }}"#, "check.ts");
 
-    cmd.arg("plumbing").arg("check").arg("--level").arg("error").current_dir(fixtures_root);
+    cmd.arg("plumbing")
+        .arg("check")
+        .arg("--level")
+        .arg("error")
+        .current_dir(fixtures_root);
     cmd.write_stdin(input);
 
     let output = cmd.output()?;

--- a/crates/core/src/pattern/api.rs
+++ b/crates/core/src/pattern/api.rs
@@ -555,6 +555,7 @@ pub struct AllDone {
 #[serde(rename_all = "camelCase")]
 pub enum AllDoneReason {
     NoInputPaths,
+    AllPathsIgnored,
     AllMatchesFound,
     MaxResultsReached,
     Aborted,

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -36,6 +36,7 @@ web-sys = { version = "0.3.66", features = ["console"], optional = true }
 tree-sitter-traversal = { version = "0.1.2", default-features = false }
 enum_dispatch = "0.3.12"
 walkdir = "2.3.3"
+path-absolutize = "3.1.1"
 
 [dev-dependencies]
 insta = "1.26.0"

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -35,6 +35,7 @@ ignore = { version = "0.4.21", optional = true }
 web-sys = { version = "0.3.66", features = ["console"], optional = true }
 tree-sitter-traversal = { version = "0.1.2", default-features = false }
 enum_dispatch = "0.3.12"
+walkdir = "2.3.3"
 
 [dev-dependencies]
 insta = "1.26.0"

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -389,8 +389,7 @@ fn find_ignore_files(start_path: &Path, name: &str) -> Result<Vec<PathBuf>> {
         current_path = parent.to_path_buf();
     }
 
-    let root_path = current_path;
-    for entry in WalkDir::new(root_path).into_iter().filter_map(|e| e.ok()) {
+    for entry in WalkDir::new(start_path).into_iter().filter_map(|e| e.ok()) {
         let path = entry.path();
         if path.file_name() == Some(std::ffi::OsStr::new(name)) {
             gitignore_files.push(path.to_path_buf());

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -464,7 +464,7 @@ pub fn expand_paths(
     let grit = OverrideBuilder::new(".").add("!**/.grit/**")?.build()?;
     file_walker.overrides(grit);
 
-    let final_walker = file_walker.standard_filters(true).hidden(false).build();
+    let final_walker = file_walker.standard_filters(true).parents(true).hidden(false).build();
     Ok(final_walker)
 }
 

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -415,6 +415,7 @@ fn is_file_ignored(path: &Path) -> Result<bool> {
             return Ok(true);
         }
     }
+    println!("Is file ignored returning false for {}, grit ignores were {:?}", path.display(), grit_ignores);
     Ok(false)
 }
 
@@ -506,6 +507,7 @@ pub fn expand_paths(
     let mut file_walker = WalkBuilder::new(start_paths[0].clone());
     file_walker.types(file_types.build()?);
     for path in start_paths.iter().skip(1) {
+        println!("Path {} is file: {}", path.display(), path.is_file());
         // This is necessary because ignore does not check directly added WalkBuilder paths against ignore files
         if path.is_file() && is_file_ignored(path)? {
             continue;

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -461,11 +461,12 @@ pub fn expand_paths(
     // }
     file_walker.add_custom_ignore_filename(PathBuf::from_str(".gritignore")?);
 
-    let grit = OverrideBuilder::new(".").add("!**/.grit/**")?.build()?;
-    file_walker.overrides(grit);
+    let mut grit = OverrideBuilder::new(".");
     for path in start_paths {
-        file_walker.overrides(OverrideBuilder::new(path).build()?);
+        grit.add(&path.to_string_lossy())?;
     }
+    let grit = grit.add("!**/.grit/**")?.build()?;
+    file_walker.overrides(grit);
 
     let final_walker = file_walker
         .standard_filters(true)

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -454,15 +454,18 @@ pub fn expand_paths(
         }
     }
 
-    let mut file_walker = WalkBuilder::new(start_paths[0].clone());
+    let mut file_walker = WalkBuilder::new(".");
     file_walker.types(file_types.build()?);
-    for path in start_paths.iter().skip(1) {
-        file_walker.add(path);
-    }
+    // for path in start_paths.iter().skip(1) {
+    //     file_walker.add(path);
+    // }
     file_walker.add_custom_ignore_filename(PathBuf::from_str(".gritignore")?);
 
     let grit = OverrideBuilder::new(".").add("!**/.grit/**")?.build()?;
     file_walker.overrides(grit);
+    for path in start_paths {
+        file_walker.overrides(OverrideBuilder::new(path).build()?);
+    }
 
     let final_walker = file_walker
         .standard_filters(true)

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -454,18 +454,15 @@ pub fn expand_paths(
         }
     }
 
-    let mut file_walker = WalkBuilder::new(".");
+    let mut file_walker = WalkBuilder::new(start_paths[0].clone());
     file_walker.types(file_types.build()?);
-    // for path in start_paths.iter().skip(1) {
-    //     file_walker.add(path);
-    // }
+    for path in start_paths.iter().skip(1) {
+        file_walker.add(path);
+    }
     file_walker.add_custom_ignore_filename(PathBuf::from_str(".gritignore")?);
 
     let grit = OverrideBuilder::new(".").add("!**/.grit/**")?.build()?;
     file_walker.overrides(grit);
-    for path in start_paths {
-        file_walker.overrides(OverrideBuilder::new(path).build()?);
-    }
 
     let final_walker = file_walker
         .standard_filters(true)

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -464,7 +464,11 @@ pub fn expand_paths(
     let grit = OverrideBuilder::new(".").add("!**/.grit/**")?.build()?;
     file_walker.overrides(grit);
 
-    let final_walker = file_walker.standard_filters(true).parents(true).hidden(false).build();
+    let final_walker = file_walker
+        .standard_filters(true)
+        .parents(true)
+        .hidden(false)
+        .build();
     Ok(final_walker)
 }
 

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -380,6 +380,7 @@ fn find_ignore_files(start_path: &Path, name: &str) -> Vec<PathBuf> {
     let mut current_path = start_path;
     while let Some(parent) = current_path.parent() {
         let gitignore_path = parent.join(name);
+        println!("Checking gitignore path {}, next parent is {:?}", gitignore_path.display(), parent.parent().map(|p| p.display()));
         if gitignore_path.exists() && gitignore_path.is_file() {
             gitignore_files.push(gitignore_path);
         }

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -461,12 +461,11 @@ pub fn expand_paths(
     // }
     file_walker.add_custom_ignore_filename(PathBuf::from_str(".gritignore")?);
 
-    let mut grit = OverrideBuilder::new(".");
-    for path in start_paths {
-        grit.add(&path.to_string_lossy())?;
-    }
-    let grit = grit.add("!**/.grit/**")?.build()?;
+    let grit = OverrideBuilder::new(".").add("!**/.grit/**")?.build()?;
     file_walker.overrides(grit);
+    for path in start_paths {
+        file_walker.overrides(OverrideBuilder::new(path).build()?);
+    }
 
     let final_walker = file_walker
         .standard_filters(true)

--- a/crates/lsp/src/watcher.rs
+++ b/crates/lsp/src/watcher.rs
@@ -12,7 +12,10 @@ pub fn get_watched_files(root_uri: Url) -> Vec<String> {
     let paths = vec![root];
     let languages = PatternLanguage::enumerate();
     let walker = match expand_paths(&paths, Some(&languages)) {
-        Ok(walker) => walker,
+        Ok(Some(walker)) => walker,
+        Ok(None) => {
+            return vec![];
+        }
         Err(_) => {
             return vec![];
         }


### PR DESCRIPTION
for https://github.com/getgrit/rewriter/issues/9042

Unfortunately, there isn't a way to do this out of the box with `ignore`'s interface. There was a crate exposing [closer functionality](https://github.com/nathankleyn/gitignore.rs?tab=readme-ov-file) but it's been archived.