### PR TITLE
fix: wasm feature doesn't break build

### DIFF
--- a/crates/core/src/pattern/function_definition.rs
+++ b/crates/core/src/pattern/function_definition.rs
@@ -240,7 +240,10 @@ impl FunctionDefinition for ForeignFunctionDefinition {
         let resolved_str: Vec<&str> = cow_resolved.iter().map(Cow::as_ref).collect();
 
         // START Simple externalized version
-        #[cfg(feature = "external_functions_ffi")]
+        #[cfg(all(
+            feature = "external_functions_ffi",
+            target_arch = "wasm32"
+        ))]
         let result = (context.runtime.exec_external)(&self.code, param_names, &resolved_str)?;
 
         // END Simple externalized version

--- a/crates/util/src/runtime.rs
+++ b/crates/util/src/runtime.rs
@@ -30,7 +30,8 @@ pub struct ExecutionContext {
 #[cfg(all(
     feature = "network_requests_external",
     feature = "external_functions_ffi",
-    not(feature = "network_requests")
+    not(feature = "network_requests"),
+    target_arch = "wasm32"
 ))]
 #[derive(Clone, Debug)]
 pub struct ExecutionContext {
@@ -83,7 +84,8 @@ impl ExecutionContext {
     #[cfg(all(
         feature = "network_requests_external",
         feature = "external_functions_ffi",
-        not(feature = "network_requests")
+        not(feature = "network_requests"),
+        target_arch = "wasm32"
     ))]
     pub fn new(
         fetch: fn(url: &str, headers: &HeaderMap, json: &serde_json::Value) -> Result<String>,


### PR DESCRIPTION
hides some wasm specific features behind arch wasm32, so they don't break the build due to conflicting feature flags