### PR TITLE
chore: forbid unused crates in core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "buildkite-test-collector",
- "bytes",
  "chrono",
  "clap",
  "clap-markdown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,8 +1260,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1951,6 +1953,7 @@ dependencies = [
  "anyhow",
  "elsa",
  "embeddings",
+ "getrandom",
  "im",
  "insta",
  "itertools 0.10.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,21 +243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,32 +798,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro 0.12.0",
-]
-
-[[package]]
-name = "derive_builder"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f59169f400d8087f238c5c0c7db6a28af18681717f3b623227d92f397e938c7"
 dependencies = [
- "derive_builder_macro 0.13.1",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "derive_builder_macro",
 ]
 
 [[package]]
@@ -855,21 +819,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core 0.12.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "870368c3fb35b8031abb378861d4460f573b92238ec2152c927a21f77e3e0127"
 dependencies = [
- "derive_builder_core 0.13.1",
+ "derive_builder_core",
  "syn 1.0.109",
 ]
 
@@ -1096,16 +1050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
-name = "fancy-regex"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,10 +1260,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1948,6 +1890,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "buildkite-test-collector",
+ "bytes",
  "chrono",
  "clap",
  "clap-markdown",
@@ -2007,13 +1950,8 @@ name = "marzano-core"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "debug_print",
- "derive_builder 0.12.0",
  "elsa",
  "embeddings",
- "futures",
- "getrandom",
- "http",
  "im",
  "insta",
  "itertools 0.10.5",
@@ -2027,13 +1965,10 @@ dependencies = [
  "rand",
  "rayon",
  "regex",
- "reqwest",
  "serde",
  "serde_json",
  "sha2",
  "similar",
- "tiktoken-rs",
- "tokio",
  "tracing",
  "tracing-opentelemetry",
  "tree-sitter-facade-sg",
@@ -2041,7 +1976,6 @@ dependencies = [
  "tree-sitter-traversal",
  "trim-margin",
  "walkdir",
- "web-sys",
 ]
 
 [[package]]
@@ -2164,7 +2098,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
- "derive_builder 0.13.1",
+ "derive_builder",
  "futures",
  "http",
  "ignore",
@@ -3543,21 +3477,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tiktoken-rs"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40894b788eb28bbb7e36bdc8b7b1b1488b9c93fa3730f315ab965330c94c0842"
-dependencies = [
- "anyhow",
- "base64",
- "bstr",
- "fancy-regex",
- "lazy_static",
- "parking_lot",
- "rustc-hash",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -56,7 +56,6 @@ console = "0.15.7"
 futures = "0.3.28"
 rayon = "1.8.0"
 dashmap = "5.5.3"
-bytes = "1.5.0"
 clap-markdown = { git = "https://github.com/getgrit/clap-markdown", optional = true }
 flate2 = { version = "1.0.17", features = [
   "rust_backend",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -56,6 +56,7 @@ console = "0.15.7"
 futures = "0.3.28"
 rayon = "1.8.0"
 dashmap = "5.5.3"
+bytes = "1.5.0"
 clap-markdown = { git = "https://github.com/getgrit/clap-markdown", optional = true }
 flate2 = { version = "1.0.17", features = [
   "rust_backend",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -35,7 +35,6 @@ rand = "0.8.5"
 path-absolutize = { version = "3.1.1", optional = false, features = [
   "use_unix_paths_on_wasm",
 ] }
-# getrandom = "0.2.11"
 getrandom = {version = "0.2.11", optional = true }
 
 [dev-dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -3,6 +3,9 @@ name = "marzano-core"
 version = "0.2.0"
 edition = "2021"
 
+[lints]
+rust.unused_crate_dependencies = "forbid"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 # todo remove all these since we should be interfacing through the language crate.
 [dependencies]
@@ -20,34 +23,22 @@ tracing-opentelemetry = { version = "0.22.0", optional = true, default-features 
 regex = "1.7.3"
 anyhow = "1.0.70"
 tree-sitter-traversal = { version = "0.1.2", default-features = false }
-lazy_static = "1.4.0"
 itertools = "0.10.5"
 im = "15.1.0"
 serde_json = "1.0.96"
 serde = { version = "1.0.164", features = ["derive"] }
-debug_print = "1.0.0"
-derive_builder = { version = "0.12.0", features = ["clippy"] }
-similar = "2.2.1"
 sha2 = "0.10.8"
 elsa = "1.9.0"
-reqwest = { version = "0.11.22", features = [
-  "blocking",
-  "json",
-], optional = true }
-futures = "0.3.29"
 rayon = "1.8.0"
 log = "0.4.20"
-tiktoken-rs = "0.5.7"
 rand = "0.8.5"
 path-absolutize = { version = "3.1.1", optional = false, features = [
   "use_unix_paths_on_wasm",
 ] }
-getrandom = "0.2.11"
-http = "0.2.11"
-tokio = { version = "1.35.1", optional = true }
-web-sys = { version = "0.3.66", features = ["console"], optional = true }
 
 [dev-dependencies]
+similar = "2.2.1"
+lazy_static = "1.4.0"
 insta = { version = "1.30.0", features = ["yaml", "redactions"] }
 trim-margin = "0.1.0"
 marzano-auth = { path = "../auth" }
@@ -72,9 +63,9 @@ test_all = ["embeddings", "external_functions"]
 grit_alpha = ["external_functions", "embeddings"]
 # Shared network requests - common to all approaches
 network_requests_common = ["marzano-util/network_requests_common"]
-network_requests = ["reqwest", "tokio", "tokio/rt", "network_requests_common", "marzano-util/network_requests"]
+network_requests = ["network_requests_common", "marzano-util/network_requests"]
 network_requests_external = ["network_requests_common", "marzano-util/network_requests_external"]
-wasm_core = ["getrandom/js", "web-sys", "network_requests_external", "external_functions_common", "external_functions_ffi", "marzano-util/external_functions_ffi"]
+wasm_core = ["network_requests_external", "external_functions_common", "external_functions_ffi", "marzano-util/external_functions_ffi"]
 grit_tracing = ["dep:tracing-opentelemetry"]
 language-parsers = ["marzano-language/builtin-parser"]
 grit-parser = ["tree-sitter-gritql"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -35,6 +35,8 @@ rand = "0.8.5"
 path-absolutize = { version = "3.1.1", optional = false, features = [
   "use_unix_paths_on_wasm",
 ] }
+# getrandom = "0.2.11"
+getrandom = {version = "0.2.11", optional = true }
 
 [dev-dependencies]
 similar = "2.2.1"
@@ -65,7 +67,7 @@ grit_alpha = ["external_functions", "embeddings"]
 network_requests_common = ["marzano-util/network_requests_common"]
 network_requests = ["network_requests_common", "marzano-util/network_requests"]
 network_requests_external = ["network_requests_common", "marzano-util/network_requests_external"]
-wasm_core = ["network_requests_external", "external_functions_common", "external_functions_ffi", "marzano-util/external_functions_ffi"]
+wasm_core = [ "dep:getrandom", "getrandom/js", "network_requests_external", "external_functions_common", "external_functions_ffi", "marzano-util/external_functions_ffi"]
 grit_tracing = ["dep:tracing-opentelemetry"]
 language-parsers = ["marzano-language/builtin-parser"]
 grit-parser = ["tree-sitter-gritql"]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,3 +19,10 @@ pub mod tree_sitter_serde;
 
 #[cfg(test)]
 mod test;
+
+// getrandom is a deeply nested dependency used by many things eg. uuid
+// to get wasm working we needed to enable a feature for this crate, so
+// while we don't have a direct usage of it, we had to add it as a dependency
+// and here we import it to avoid an unused dependency warning
+#[cfg(target_arch = "wasm32")]
+use getrandom as _;


### PR DESCRIPTION
Removes unused crates in Marzano core, and adds a lint that forbids them