### PR TITLE
ci: only clone one level of submodules

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: clone code
         uses: actions/checkout@v3
         with:
-          submodules: recursive
+          submodules: true
       - name: Install Protoc
         run: sudo apt-get install -y protobuf-compiler
       - run: rustup component add clippy


### PR DESCRIPTION
This repo only needs one level and shouldn't attempt to recurse further.