### PR TITLE
chore: remove unused cli deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,13 +1957,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "tracing-subscriber",
- "tree-sitter-facade-sg",
- "tree-sitter-gritql",
- "tree-sitter-javascript",
  "trim-margin",
  "uuid",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,12 +782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debug_print"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f215f9b7224f49fb73256115331f677d868b34d18b65dbe4db392e6021eea90"
-
-[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,7 +1904,6 @@ version = "0.1.1"
 dependencies = [
  "ai_builtins",
  "anyhow",
- "assert_cmd",
  "buildkite-test-collector",
  "chrono",
  "clap",
@@ -1919,18 +1912,15 @@ dependencies = [
  "colored",
  "console",
  "dashmap",
- "debug_print",
  "dialoguer",
  "env_logger",
  "flate2",
- "fs_extra",
  "futures",
  "git2",
  "grit_cache",
  "ignore",
  "indicatif",
  "indicatif-log-bridge",
- "insta",
  "lazy_static",
  "log",
  "marzano-auth",
@@ -1941,12 +1931,10 @@ dependencies = [
  "marzano-test-utils",
  "marzano-util",
  "marzano_messenger",
- "ntest",
  "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "predicates",
  "rayon",
  "regex",
  "reqwest",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -67,14 +67,8 @@ tracing-opentelemetry = { version = "0.22.0", optional = true, default-features 
 tracing = { version = "0.1.40", default-features = false, features = [] }
 
 [dev-dependencies]
-insta = { version = "1.30.0", features = ["yaml", "redactions"] }
 trim-margin = "0.1.0"
 buildkite-test-collector = "0.1.1"
-assert_cmd = "2.0.12"
-predicates = "3.0.3"
-fs_extra = "1.3"
-ntest = "0.9.0"
-debug_print = "1.0.0"
 similar = "2.2.1"
 reqwest = { version = "0.11.22", features = ["blocking", "json"] }
 marzano-test-utils = { path = "../test_utils" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,8 +13,6 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.70"
 clap = { version = "4.1.13", features = ["derive"] }
-tree-sitter = { path = "../../vendor/tree-sitter-facade", package = "tree-sitter-facade-sg" }
-walkdir = "2.3.3"
 indicatif = "0.17.5"
 ignore = "0.4.20"
 # Do *NOT* upgrade beyond 1.0.171 until https://github.com/serde-rs/serde/issues/2538 is fixed
@@ -32,8 +30,6 @@ env_logger = "0.10.0"
 git2 = "0.17.2"
 regex = "1.7.3"
 openssl = { version = "0.10", features = ["vendored"] }
-tree-sitter-gritql = { path = "../../vendor/tree-sitter-gritql" }
-tree-sitter-javascript = { path = "../../resources/language-metavariables/tree-sitter-javascript" }
 marzano-core = { path = "../core", features = [
   "non_wasm",
 ], default-features = false }
@@ -68,7 +64,6 @@ opentelemetry_sdk = { version = "0.21.1", optional = true, features = [
 ] }
 tracing-opentelemetry = { version = "0.22.0", optional = true, default-features = false }
 
-tracing-subscriber = { version = "0.3.18" }
 tracing = { version = "0.1.40", default-features = false, features = [] }
 
 [dev-dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.1"
 edition = "2021"
 authors = ["Grit Developers <support@grit.io>"]
 
+[lints]
+rust.unused_crate_dependencies = "forbid"
+
 [lib]
 path = "src/lib.rs"
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -16,3 +16,8 @@ mod utils;
 mod ux;
 #[cfg(feature = "workflows_v2")]
 mod workflows;
+
+// git2 uses openssl, but breaks windows, so we need 
+// to import openssl and specify the vendored feature in order
+// to prevet git2 from breaking on windows
+use openssl as _;

--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -3,9 +3,6 @@ name = "marzano"
 version = "0.1.0"
 edition = "2021"
 
-[lints]
-rust.unused_crate_dependencies = "forbid"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -3,6 +3,9 @@ name = "marzano"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+rust.unused_crate_dependencies = "forbid"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/cli_bin/src/main.rs
+++ b/crates/cli_bin/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(unused_crate_dependencies))]
 use marzano_cli::commands::run_command;
 use marzano_cli::error::GoodError;
 // We always instrument


### PR DESCRIPTION
adds a lint to clil and cli_bin crate to enforce no unused dependencies in cargo.toml