### PR TITLE
chore: warn instead of forbid unused crate

### DIFF
--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Grit Developers <support@grit.io>"]
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 [lib]
 path = "src/lib.rs"

--- a/crates/cli_bin/src/main.rs
+++ b/crates/cli_bin/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), deny(unused_crate_dependencies))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 use marzano_cli::commands::run_command;
 use marzano_cli::error::GoodError;
 // We always instrument

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 # todo remove all these since we should be interfacing through the language crate.

--- a/crates/externals/Cargo.toml
+++ b/crates/externals/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/gritcache/Cargo.toml
+++ b/crates/gritcache/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 [dependencies]
 marzano-gritmodule = { path = "../gritmodule", features = [

--- a/crates/gritmodule/Cargo.toml
+++ b/crates/gritmodule/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 [dependencies]
 marzano-core = { path = "../core", features = [], default-features = true }

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 [dependencies]
 tree-sitter = { path = "../../vendor/tree-sitter-facade", package = "tree-sitter-facade-sg" }

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 [dependencies]
 tower-lsp = "0.20.0"

--- a/crates/marzano_messenger/Cargo.toml
+++ b/crates/marzano_messenger/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/wasm-bindings/Cargo.toml
+++ b/crates/wasm-bindings/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints]
-rust.unused_crate_dependencies = "forbid"
+rust.unused_crate_dependencies = "warn"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
tests are compiled independently so can result in false positives when enforcing this lint, warn is sufficient to fail CI.