### PR TITLE
chore: aggregate common dependencies in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
  "openssl-sys",
  "url",
 ]
@@ -1738,7 +1737,6 @@ checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1753,20 +1751,6 @@ dependencies = [
  "bitflags 2.4.2",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,74 @@ exclude = [
   "vendor/web-tree-sitter",
   "vendor/tree-sitter-facade",
 ]
+
+[workspace.dependencies]
+ai_builtins = { git = "https://github.com/getgrit/ai_builtins.git" }
+anyhow = "1.0.70"
+assert_cmd = "2.0.12"
+base64 = "0.21.2"
+buildkite-test-collector = "0.1.1"
+cc = "1.0"
+chrono = "0.4.26"
+clap = "4.1.13"
+clap-markdown = { git = "https://github.com/getgrit/clap-markdown" }
+cli_server = { git = "https://github.com/getgrit/cli_server.git" }
+colored = "2.0.4"
+console = "0.15.7"
+console_error_panic_hook = "0.1.7"
+dashmap = "5.5.3"
+derive_builder = "0.13.1"
+dialoguer = "0.10.4"
+elsa = "1.9.0"
+embeddings = { git = "https://github.com/getgrit/embeddings.git" }
+enum_dispatch = "0.3.12"
+env_logger = "0.10.0"
+extism = "1.0.0-rc7"
+flate2 = { version = "1.0.17", default-features = false }
+fs_extra = "1.3"
+futures = "0.3.29"
+getrandom = "0.2.11"
+git2 = { version = "0.17.2", default-features = false }
+homedir = "0.2.1"
+http = "0.2.11"
+ignore = "0.4.21"
+im = "15.1.0"
+indicatif = "0.17.5"
+indicatif-log-bridge = "0.2.1"
+insta = "1.30.0"
+itertools = "0.10.5"
+lazy_static = "1.4.0"
+log = "0.4.20"
+markdown = "1.0.0-alpha.11"
+ntest = "0.9.0"
+openssl = "0.10"
+opentelemetry = "0.21.0"
+opentelemetry-otlp = "0.14.0"
+opentelemetry_sdk = "0.21.1"
+path-absolutize = "3.1.1"
+predicates = "3.0.3"
+rand = "0.8.5"
+rayon = "1.8.0"
+regex = "1.7.3"
+reqwest = "0.11.22"
+serde = "1.0.164"
+serde-wasm-bindgen = "0.6"
+serde_json = "1.0.114"
+serde_yaml = "0.9.25"
+sha2 = "0.10.8"
+similar = "2.2.1"
+tempfile = "3.8.1"
+tokio = "1.35.1"
+tower = "0.4.13"
+tower-lsp = "0.20.0"
+tracing = { version = "0.1.40", default-features = false }
+tracing-opentelemetry = { version = "0.22.0", default-features = false }
+tree-sitter = "~0.20.10"
+tree-sitter-traversal = { version = "0.1.2", default-features = false }
+trim-margin = "0.1.0"
+uuid = "1.1"
+walkdir = "2.3.3"
+wasm-bindgen = "0.2.89"
+wasm-bindgen-futures = "0.4.39"
+wasm-bindgen-test = "0.3.39"
+web-sys = "0.3.66"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ rand = "0.8.5"
 rayon = "1.8.0"
 regex = "1.7.3"
 reqwest = "0.11.22"
+# Do *NOT* upgrade beyond 1.0.171 until https://github.com/serde-rs/serde/issues/2538 is fixed
 serde = "1.0.164"
 serde-wasm-bindgen = "0.6"
 serde_json = "1.0.114"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,9 @@ flate2 = { version = "1.0.17", default-features = false }
 fs_extra = "1.3"
 futures = "0.3.29"
 getrandom = "0.2.11"
-git2 = { version = "0.17.2", default-features = false }
+git2 = { version = "0.17.2", default-features = false, features = [
+  "vendored-openssl",
+] }
 homedir = "0.2.1"
 http = "0.2.11"
 ignore = "0.4.21"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -9,12 +9,12 @@ rust.unused_crate_dependencies = "warn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.70"
-reqwest = { version = "0.11", features = ["json", "blocking"] }
-lazy_static = "1.4.0"
-serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
-tokio = { version = "1", features = ["full"] }
-log = "0.4.19"
-chrono = "0.4.26"
+anyhow = { workspace = true }
+reqwest = { workspace = true, features = ["json", "blocking"] }
+lazy_static = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+log = { workspace = true }
+chrono = { workspace = true }
 marzano-util = { path = "../util" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -26,7 +26,9 @@ indicatif-log-bridge = { workspace = true }
 colored = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
-git2 = { workspace = true }
+git2 = { version = "0.17.2", default-features = false, features = [
+  "vendored-openssl",
+] }
 regex = { workspace = true }
 openssl = { version = "0.10", features = ["vendored"] }
 marzano-core = { path = "../core", features = [

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,25 +11,24 @@ rust.unused_crate_dependencies = "warn"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.70"
-clap = { version = "4.1.13", features = ["derive"] }
-indicatif = "0.17.5"
-ignore = "0.4.20"
-# Do *NOT* upgrade beyond 1.0.171 until https://github.com/serde-rs/serde/issues/2538 is fixed
-serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
-uuid = { version = "1.1", features = ["v4", "serde"] }
-tokio = { version = "1", features = ["full"] }
-chrono = { version = "0.4.26", features = ["serde"] }
-reqwest = { version = "0.11", features = ["json"] }
-lazy_static = "1.4.0"
-indicatif-log-bridge = "0.2.1"
-colored = "2.0.4"
-log = { version = "0.4.19" }
-env_logger = "0.10.0"
-git2 = "0.17.2"
-regex = "1.7.3"
-openssl = { version = "0.10", features = ["vendored"] }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+indicatif = { workspace = true }
+ignore = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+uuid = { workspace = true, features = ["v4", "serde"] }
+tokio = { workspace = true, features = ["full"] }
+chrono = { workspace = true, features = ["serde"] }
+reqwest = { workspace = true, features = ["json"] }
+lazy_static = { workspace = true }
+indicatif-log-bridge = { workspace = true }
+colored = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+git2 = { workspace = true }
+regex = { workspace = true }
+openssl = { workspace = true, features = ["vendored"] }
 marzano-core = { path = "../core", features = [
   "non_wasm",
 ], default-features = false }
@@ -39,38 +38,29 @@ marzano-lsp = { path = "../lsp" }
 marzano-util = { path = "../util", features = ["finder"] }
 marzano-auth = { path = "../auth" }
 marzano_messenger = { path = "../marzano_messenger" }
-cli_server = { git = "https://github.com/getgrit/cli_server.git", optional = true }
-ai_builtins = { git = "https://github.com/getgrit/ai_builtins.git", optional = true }
+cli_server = { workspace = true, optional = true }
+ai_builtins = { workspace = true, optional = true }
 grit_cache = { path = "../gritcache" }
-tempfile = "3.1"
-similar = "2.2.1"
-dialoguer = "0.10.4"
-console = "0.15.7"
-futures = "0.3.28"
-rayon = "1.8.0"
-dashmap = "5.5.3"
-clap-markdown = { git = "https://github.com/getgrit/clap-markdown", optional = true }
-flate2 = { version = "1.0.17", features = [
-  "rust_backend",
-], default-features = false }
-
-opentelemetry-otlp = { version = "0.14.0", optional = true, features = [
-  "http-proto",
-  "reqwest-client",
-] }
-opentelemetry = { version = "0.21.0", optional = true }
-opentelemetry_sdk = { version = "0.21.1", optional = true, features = [
-  "rt-tokio",
-] }
-tracing-opentelemetry = { version = "0.22.0", optional = true, default-features = false }
-
-tracing = { version = "0.1.40", default-features = false, features = [] }
+tempfile = { workspace = true }
+similar = { workspace = true }
+dialoguer = { workspace = true }
+console = { workspace = true }
+futures = { workspace = true }
+rayon = { workspace = true }
+dashmap = { workspace = true }
+clap-markdown = { workspace = true, optional = true }
+flate2 = { workspace = true, features = ["rust_backend"] }
+opentelemetry-otlp = { workspace = true, features = ["http-proto", "reqwest-client"], optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"], optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+tracing = { workspace = true, features = [] }
 
 [dev-dependencies]
-trim-margin = "0.1.0"
-buildkite-test-collector = "0.1.1"
-similar = "2.2.1"
-reqwest = { version = "0.11.22", features = ["blocking", "json"] }
+trim-margin = { workspace = true }
+buildkite-test-collector = { workspace = true }
+similar = { workspace = true }
+reqwest = { workspace = true, features = ["blocking", "json"] }
 marzano-test-utils = { path = "../test_utils" }
 
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,7 +28,7 @@ log = { workspace = true }
 env_logger = { workspace = true }
 git2 = { workspace = true }
 regex = { workspace = true }
-openssl = { workspace = true, features = ["vendored"] }
+openssl = { version = "0.10", features = ["vendored"] }
 marzano-core = { path = "../core", features = [
   "non_wasm",
 ], default-features = false }

--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -6,21 +6,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.70"
+anyhow = { workspace = true }
 marzano-cli = { path = "../cli", default-features = false }
-tokio = { version = "1", features = ["full"] }
-tracing = { version = "0.1.40", default-features = false }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1.0.96"
-tempfile = "3.1"
-rayon = "1.8.0"
-insta = { version = "1.30.0", features = ["yaml", "redactions"] }
-predicates = "3.0.3"
-fs_extra = "1.3"
-ntest = "0.9.0"
-regex = "1.7.3"
-assert_cmd = "2.0.12"
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+rayon = { workspace = true }
+insta = { workspace = true, features = ["yaml", "redactions"] }
+predicates = { workspace = true }
+fs_extra = { workspace = true }
+ntest = { workspace = true }
+regex = { workspace = true }
+assert_cmd = { workspace = true }
 marzano-gritmodule = { path = "../gritmodule" }
 
 [features]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,36 +14,31 @@ tree-sitter-gritql = { path = "../../vendor/tree-sitter-gritql", optional = true
 marzano-language = { path = "../language", default-features = false }
 marzano-util = { path = "../util" }
 marzano-externals = { path = "../externals", optional = true }
-embeddings = { git = "https://github.com/getgrit/embeddings.git", optional = true }
-
-tracing = { version = "0.1.40", default-features = false, features = [] }
-tracing-opentelemetry = { version = "0.22.0", optional = true, default-features = false, features = [
-] }
-
-regex = "1.7.3"
-anyhow = "1.0.70"
-tree-sitter-traversal = { version = "0.1.2", default-features = false }
-itertools = "0.10.5"
-im = "15.1.0"
-serde_json = "1.0.96"
-serde = { version = "1.0.164", features = ["derive"] }
-sha2 = "0.10.8"
-elsa = "1.9.0"
-rayon = "1.8.0"
-log = "0.4.20"
-rand = "0.8.5"
-path-absolutize = { version = "3.1.1", optional = false, features = [
-  "use_unix_paths_on_wasm",
-] }
-getrandom = {version = "0.2.11", optional = true }
+embeddings = { workspace = true, optional = true }
+tracing = { workspace = true, features = [] }
+tracing-opentelemetry = { workspace = true, features = [], optional = true }
+regex = { workspace = true }
+anyhow = { workspace = true }
+tree-sitter-traversal = { workspace = true }
+itertools = { workspace = true }
+im = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+sha2 = { workspace = true }
+elsa = { workspace = true }
+rayon = { workspace = true }
+log = { workspace = true }
+rand = { workspace = true }
+path-absolutize = { workspace = true, features = ["use_unix_paths_on_wasm"], optional = false }
+getrandom = { workspace = true, optional = true }
 
 [dev-dependencies]
-similar = "2.2.1"
-lazy_static = "1.4.0"
-insta = { version = "1.30.0", features = ["yaml", "redactions"] }
-trim-margin = "0.1.0"
+similar = { workspace = true }
+lazy_static = { workspace = true }
+insta = { workspace = true, features = ["yaml", "redactions"] }
+trim-margin = { workspace = true }
 marzano-auth = { path = "../auth" }
-walkdir = "2.3.3"
+walkdir = { workspace = true }
 
 [features]
 default = [

--- a/crates/externals/Cargo.toml
+++ b/crates/externals/Cargo.toml
@@ -9,6 +9,6 @@ rust.unused_crate_dependencies = "warn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.70"
-extism = "^1.0.0-rc7"
-serde_json = "1.0.96"
+anyhow = { workspace = true }
+extism = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/gritcache/Cargo.toml
+++ b/crates/gritcache/Cargo.toml
@@ -9,9 +9,9 @@ rust.unused_crate_dependencies = "warn"
 [dependencies]
 marzano-gritmodule = { path = "../gritmodule", features = [
 ], default-features = false }
-anyhow = "1.0.70"
+anyhow = { workspace = true }
 marzano-util = { path = "../util", features = [], default-features = false }
 
 [dev-dependencies]
 marzano-util = { path = "../util", features = ["finder"] }
-tokio = { version = "1.35.1" }
+tokio = { workspace = true }

--- a/crates/gritmodule/Cargo.toml
+++ b/crates/gritmodule/Cargo.toml
@@ -15,7 +15,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
 anyhow = { workspace = true }
 rand = { workspace = true }
-git2 = { workspace = true, features = ["vendored-openssl"] }
+git2 = { version = "0.17.2", default-features = false, features = [
+  "vendored-openssl",
+] }
 lazy_static = { workspace = true }
 regex = { workspace = true }
 markdown = { workspace = true }

--- a/crates/gritmodule/Cargo.toml
+++ b/crates/gritmodule/Cargo.toml
@@ -11,22 +11,20 @@ marzano-core = { path = "../core", features = [], default-features = true }
 marzano-language = { path = "../language" }
 marzano-util = { path = "../util", features = ["finder"] }
 tree-sitter = { path = "../../vendor/tree-sitter-facade", package = "tree-sitter-facade-sg" }
-serde = { version = "1.0.164", features = ["derive"] }
-serde_yaml = "0.9.25"
-anyhow = "1.0.70"
-rand = "0.8.5"
-git2 = { version = "0.17.2", default-features = false, features = [
-  "vendored-openssl",
-] }
-lazy_static = "1.4.0"
-regex = "1.7.3"
-markdown = "1.0.0-alpha.11"
-tokio = { version = "1", features = ["full"] }
-tempfile = "3.7.0"
-log = "0.4.19"
-reqwest = { version = "0.11.22", features = ["blocking", "json"] }
-ignore = "0.4.20"
-homedir = "0.2.1"
+serde = { workspace = true, features = ["derive"] }
+serde_yaml = { workspace = true }
+anyhow = { workspace = true }
+rand = { workspace = true }
+git2 = { workspace = true, features = ["vendored-openssl"] }
+lazy_static = { workspace = true }
+regex = { workspace = true }
+markdown = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tempfile = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true, features = ["blocking", "json"] }
+ignore = { workspace = true }
+homedir = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.30.0", features = ["yaml"] }
+insta = { workspace = true, features = ["yaml"] }

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -27,19 +27,19 @@ tree-sitter-ruby = { path = "../../resources/language-metavariables/tree-sitter-
 tree-sitter-sql = { path = "../../resources/language-metavariables/tree-sitter-sql", optional = true }
 tree-sitter-vue = { path = "../../resources/language-metavariables/tree-sitter-vue", optional = true }
 tree-sitter-toml = { path = "../../resources/language-metavariables/tree-sitter-toml", optional = true }
-serde_json = { version = "1.0.91", features = ["preserve_order"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
 marzano-util = { path = "../util" }
-regex = "1.7.1"
-anyhow = "1.0.70"
-itertools = "0.10.5"
-lazy_static = "1.4.0"
-ignore = { version = "0.4.21", optional = true }
-web-sys = { version = "0.3.66", features = ["console"], optional = true }
-tree-sitter-traversal = { version = "0.1.2", default-features = false }
-enum_dispatch = "0.3.12"
+regex = { workspace = true }
+anyhow = { workspace = true }
+itertools = { workspace = true }
+lazy_static = { workspace = true }
+ignore = { workspace = true, optional = true }
+web-sys = { workspace = true, features = ["console"], optional = true }
+tree-sitter-traversal = { workspace = true }
+enum_dispatch = { workspace = true }
 
 [dev-dependencies]
-trim-margin = "0.1.0"
+trim-margin = { workspace = true }
 
 [features]
 default = ["builtin-parser"]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -7,27 +7,27 @@ edition = "2021"
 rust.unused_crate_dependencies = "warn"
 
 [dependencies]
-tower-lsp = "0.20.0"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
+tower-lsp = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 marzano-core = { path = "../core", default-features = false, features = [
   "non_wasm",
 ] }
 marzano-gritmodule = { path = "../gritmodule" }
 grit_cache = { path = "../gritcache", optional = true }
 marzano-language = { path = "../language" }
-ai_builtins = { git = "https://github.com/getgrit/ai_builtins.git", optional = true }
+ai_builtins = { workspace = true, optional = true }
 marzano-util = { path = "../util", features = ["finder"] }
-anyhow = "1.0.70"
-dashmap = "5.5.3"
-uuid = { version = "1.1", features = ["v4", "serde"] }
-tracing = { version = "0.1.40", default-features = false, features = [] }
-tracing-opentelemetry = { version = "0.22.0", optional = true, default-features = false, features = [] }
+anyhow = { workspace = true }
+dashmap = { workspace = true }
+uuid = { workspace = true, features = ["v4", "serde"] }
+tracing = { workspace = true, features = [] }
+tracing-opentelemetry = { workspace = true, features = [], optional = true }
 
 [dev-dependencies]
-tempfile = "3.8.1"
-tower = "0.4.13"
+tempfile = { workspace = true }
+tower = { workspace = true }
 
 [features]
 default = []

--- a/crates/marzano_messenger/Cargo.toml
+++ b/crates/marzano_messenger/Cargo.toml
@@ -9,15 +9,14 @@ rust.unused_crate_dependencies = "warn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.1.13", features = ["derive"] }
-# Do *NOT* upgrade beyond 1.0.171 until https://github.com/serde-rs/serde/issues/2538 is fixed
-serde = { version = "1.0.164", features = ["derive"] }
-anyhow = "1.0.70"
-colored = "2.0.4"
-dialoguer = "0.10.4"
-log = { version = "0.4.19" }
-indicatif = "0.17.5"
-serde_json = "1.0.113"
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+anyhow = { workspace = true }
+colored = { workspace = true }
+dialoguer = { workspace = true }
+log = { workspace = true }
+indicatif = { workspace = true }
+serde_json = { workspace = true }
 
 
 marzano-core = { path = "../core", features = [

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -9,9 +9,9 @@ rust.unused_crate_dependencies = "warn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.70"
+anyhow = { workspace = true }
 marzano-auth = { path = "../auth" }
-assert_cmd = "2.0.12"
-tempfile = "3.1"
-fs_extra = "1.3"
+assert_cmd = { workspace = true }
+tempfile = { workspace = true }
+fs_extra = { workspace = true }
 

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -10,22 +10,19 @@ rust.unused_crate_dependencies = "warn"
 
 [dependencies]
 tree-sitter = { path = "../../vendor/tree-sitter-facade", package = "tree-sitter-facade-sg" }
-serde = { version = "1.0.164", features = ["derive"] }
-base64 = "0.21.2"
-anyhow = "1.0.70"
-log = { version = "0.4.20", optional = true }
-ignore = { version = "0.4.21", optional = true }
-sha2 = { version = "0.10.8" }
-derive_builder = "0.13.1"
-tree-sitter-traversal = { version = "0.1.2", default-features = false }
-reqwest = { version = "0.11.22", features = [
-  "blocking",
-  "json",
-], optional = true }
-tokio = { version = "1.35.1", optional = true }
-serde_json = "1.0.114"
-futures = { version = "0.3.29", optional = true}
-http = "0.2.11"
+serde = { workspace = true, features = ["derive"] }
+base64 = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true, optional = true }
+ignore = { workspace = true, optional = true }
+sha2 = { workspace = true }
+derive_builder = { workspace = true }
+tree-sitter-traversal = { workspace = true }
+reqwest = { workspace = true, features = ["blocking", "json"], optional = true }
+tokio = { workspace = true, optional = true }
+serde_json = { workspace = true }
+futures = { workspace = true, optional = true }
+http = { workspace = true }
 
 [features]
 finder = ["log", "ignore"]

--- a/crates/wasm-bindings/Cargo.toml
+++ b/crates/wasm-bindings/Cargo.toml
@@ -16,20 +16,20 @@ marzano-core = { path = "../core", features = [
 ], default-features = false }
 marzano-language = { path = "../language", default-features = false }
 marzano-util = { path = "../util" }
-ai_builtins = { git = "https://github.com/getgrit/ai_builtins.git", optional = true}
-wasm-bindgen = { version = "0.2.89", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.39"
-serde-wasm-bindgen = "0.6"
+ai_builtins = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, features = ["serde-serialize"] }
+wasm-bindgen-futures = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
 web-tree-sitter-sg = { path = "../../vendor/web-tree-sitter" }
 tree-sitter = { path = "../../vendor/tree-sitter-facade", package = "tree-sitter-facade-sg" }
-console_error_panic_hook = "0.1.7"
+console_error_panic_hook = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 anyhow = "1.0.70"
 serde_json = "1.0.96"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.39"
+wasm-bindgen-test = { workspace = true }
 
 [features]
 ai_builtins = ["dep:ai_builtins"]


### PR DESCRIPTION
Use https://mainmatter.com/blog/2024/03/18/cargo-autoinherit/ to combine shared dependencies in the root workspace. This should cut down on version mismatches and other toil.