### PR TITLE
fix: graceful error handling for `grit check` in uninitialized contexts

### DIFF
--- a/crates/gritcache/src/new_cache.rs
+++ b/crates/gritcache/src/new_cache.rs
@@ -66,14 +66,10 @@ impl ThreadedCache {
         let file_vector = match std::fs::read(path) {
             Ok(bytes) => bytes,
             Err(e) => {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    return Ok(HashMap::new());
-                } else {
-                    return Err(e).context(format!(
-                        "Failed to read cache file {}",
-                        path.to_string_lossy()
-                    ));
-                }
+                return Err(e).context(format!(
+                    "Failed to read cache file {}",
+                    path.to_string_lossy()
+                ));
             }
         };
 
@@ -182,6 +178,9 @@ mod tests {
         if mismatches_cache_path.exists() {
             std::fs::remove_file(&mismatches_cache_path)?;
         }
+
+        // Assert cache raises err on no file existing + no cache refresh 
+        assert!(ThreadedCache::new(path.clone(), false).await.is_err());
 
         // Create an empty cache
         let (cache, manager) = ThreadedCache::new(path.clone(), true).await?;


### PR DESCRIPTION
(hopefully!) no functional changes. 

calling `grit check` before `grit init` right now panics:
```
❯ marzano check
thread '<unnamed>' panicked at /Users/mattparker/code/gritql/crates/gritcache/src/new_cache.rs:43:65:
called `Result::unwrap()` on an `Err` value: Failed to open cache file

Caused by:
    No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Checking no_println_in_lsp
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/1thread 'main' panicked at /Users/mattparker/code/gritql/crates/cli/src/commands/check.rs:197:58:
called `Result::unwrap()` on an `Err` value: sending on a closed channel
```
    
fix results in:
```
    ❯ marzano check
Error: Failed to read cache file /Users/mattparker/.cargo/.grit/.gritmodules/mismatches_cache

Caused by:
    No such file or directory (os error 2)
```
    
 probably not a super common occurence but it _was_ one of the first things I ran into test driving the CLI, can replicate with the added test in the absence of the fix. Happy to take this PR in a different direction if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified error handling in cache operations to enhance reliability.
	- Improved testing for cache behavior when encountering missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->