### PR TITLE
feat: allow includes regex

### DIFF
--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -5,7 +5,7 @@ use super::{
     variable::VariableSourceLocations,
     Context, Node, State,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -62,13 +62,72 @@ impl Matcher for Includes {
         context: &Context<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let resolved = ResolvedPattern::from_pattern(&self.includes, state, context, logs)?;
-        let substring = resolved.text(&state.files)?;
-        let string = binding.text(&state.files)?;
-        if string.contains(&*substring) {
-            Ok(true)
-        } else {
-            Ok(false)
+        match &self.includes {
+            Pattern::Regex(_) => {
+                Ok(true)
+                // bail!("regex patterns are not allowed in includes")
+            }
+            Pattern::ASTNode(_)
+            | Pattern::List(_)
+            | Pattern::ListIndex(_)
+            | Pattern::Map(_)
+            | Pattern::Accessor(_)
+            | Pattern::Call(_)
+            | Pattern::File(_)
+            | Pattern::Files(_)
+            | Pattern::Bubble(_)
+            | Pattern::Limit(_)
+            | Pattern::CallBuiltIn(_)
+            | Pattern::CallFunction(_)
+            | Pattern::CallForeignFunction(_)
+            | Pattern::Assignment(_)
+            | Pattern::Accumulate(_)
+            | Pattern::And(_)
+            | Pattern::Or(_)
+            | Pattern::Maybe(_)
+            | Pattern::Any(_)
+            | Pattern::Not(_)
+            | Pattern::If(_)
+            | Pattern::Undefined
+            | Pattern::Top
+            | Pattern::Bottom
+            | Pattern::Underscore
+            | Pattern::StringConstant(_)
+            | Pattern::AstLeafNode(_)
+            | Pattern::IntConstant(_)
+            | Pattern::FloatConstant(_)
+            | Pattern::BooleanConstant(_)
+            | Pattern::Dynamic(_)
+            | Pattern::CodeSnippet(_)
+            | Pattern::Variable(_)
+            | Pattern::Rewrite(_)
+            | Pattern::Log(_)
+            | Pattern::Range(_)
+            | Pattern::Contains(_)
+            | Pattern::Includes(_)
+            | Pattern::Within(_)
+            | Pattern::After(_)
+            | Pattern::Before(_)
+            | Pattern::Where(_)
+            | Pattern::Some(_)
+            | Pattern::Every(_)
+            | Pattern::Add(_)
+            | Pattern::Subtract(_)
+            | Pattern::Multiply(_)
+            | Pattern::Divide(_)
+            | Pattern::Modulo(_)
+            | Pattern::Dots
+            | Pattern::Sequential(_)
+            | Pattern::Like(_) => {
+                let resolved = ResolvedPattern::from_pattern(&self.includes, state, context, logs)?;
+                let substring = resolved.text(&state.files)?;
+                let string = binding.text(&state.files)?;
+                if string.contains(&*substring) {
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
         }
     }
 }

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -63,9 +63,8 @@ impl Matcher for Includes {
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
         match &self.includes {
-            Pattern::Regex(_) => {
-                Ok(true)
-                // bail!("regex patterns are not allowed in includes")
+            Pattern::Regex(pattern) => {
+                pattern.execute_matching(binding, state, context, logs, false)
             }
             Pattern::ASTNode(_)
             | Pattern::List(_)

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -5,7 +5,7 @@ use super::{
     variable::VariableSourceLocations,
     Context, Node, State,
 };
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -43,7 +43,7 @@ use marzano_language::{language::Language, language::SnippetNode};
 use marzano_util::analysis_logs::AnalysisLogs;
 use marzano_util::cursor_wrapper::CursorWrapper;
 use marzano_util::position::{char_index_to_byte_index, Position, Range};
-use regex::{Match, Regex};
+use regex::Match;
 use std::collections::{BTreeMap, HashMap};
 use std::str;
 use std::vec;
@@ -409,7 +409,7 @@ fn implicit_metavariable_regex(
             &text[last as usize..range.end_byte as usize],
         ));
     }
-    let regex = format!("{}", regex_string);
+    let regex = regex_string.to_string();
     let regex = RegexLike::Regex(regex);
     Ok(Some(RegexPattern::new(regex, variables)))
 }

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -409,8 +409,8 @@ fn implicit_metavariable_regex(
             &text[last as usize..range.end_byte as usize],
         ));
     }
-    let regex = format!("^{}$", regex_string);
-    let regex = RegexLike::Regex(Regex::new(regex.as_str())?);
+    let regex = format!("{}", regex_string);
+    let regex = RegexLike::Regex(regex);
     Ok(Some(RegexPattern::new(regex, variables)))
 }
 

--- a/crates/core/src/pattern/regex.rs
+++ b/crates/core/src/pattern/regex.rs
@@ -135,29 +135,21 @@ impl RegexPattern {
             regex, variables,
         ))))
     }
-}
 
-impl Name for RegexPattern {
-    fn name(&self) -> &'static str {
-        "REGEX"
-    }
-}
-
-impl Matcher for RegexPattern {
-    // wrong, but whatever for now
-    fn execute<'a>(
+    fn execute_matching<'a>(
         &'a self,
         binding: &ResolvedPattern<'a>,
         state: &mut State<'a>,
         context: &Context<'a>,
         logs: &mut AnalysisLogs,
+        entire_string: bool,
     ) -> Result<bool> {
         let text = binding.text(&state.files)?;
         let resolved_regex = match self.regex {
             RegexLike::Regex(ref regex) => regex.clone(),
             RegexLike::Pattern(ref pattern) => {
                 let resolved = ResolvedPattern::from_pattern(pattern, state, context, logs)?;
-                let text = format!("^{}$", resolved.text(&state.files)?);
+                let text = format!("{}", resolved.text(&state.files)?);
                 Regex::new(&text)?
             }
         };
@@ -228,5 +220,23 @@ impl Matcher for RegexPattern {
         }
 
         Ok(true)
+    }
+}
+
+impl Name for RegexPattern {
+    fn name(&self) -> &'static str {
+        "REGEX"
+    }
+}
+
+impl Matcher for RegexPattern {
+    fn execute<'a>(
+        &'a self,
+        binding: &ResolvedPattern<'a>,
+        state: &mut State<'a>,
+        context: &Context<'a>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<bool> {
+        self.execute_matching(binding, state, context, logs, true)
     }
 }

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -2945,6 +2945,40 @@ fn includes_regex() {
 }
 
 #[test]
+fn includes_regex_with_capture() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"
+                |language js
+                |
+                |`console.log($_)` as $haystack where {
+                |   $haystack <: includes r"Hello (\w+)"($name)
+                |} => `console.log("Goodbye $name!")`
+                |"#
+            .trim_margin()
+            .unwrap(),
+            source: r#"
+                |console.log("Hello world!");
+                |console.log("Hello handsome!");
+                |console.log("But not me, sadly.");
+                |console.log("Hi, Hello world!");
+                |"#
+            .trim_margin()
+            .unwrap(),
+            expected: r#"
+                |console.log("Goodbye world!");
+                |console.log("Goodbye handsome!");
+                |console.log("But not me, sadly.");
+                |console.log("Goodbye world!");
+                |"#
+            .trim_margin()
+            .unwrap(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
 fn parses_simple_pattern() {
     let pattern = r#"
         |engine marzano(0.1)

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -2911,6 +2911,40 @@ fn hcl_implicit_regex() {
 }
 
 #[test]
+fn includes_regex() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"
+                |language js
+                |
+                |`console.log($_)` as $haystack where {
+                |   $haystack <: includes r"Hello"
+                |} => `console.log("Goodbye world!")`
+                |"#
+            .trim_margin()
+            .unwrap(),
+            source: r#"
+                |console.log("Hello world!");
+                |console.log("Hello handsome!");
+                |console.log("But not me, sadly.");
+                |console.log("Hi, Hello world!");
+                |"#
+            .trim_margin()
+            .unwrap(),
+            expected: r#"
+                |console.log("Goodbye world!");
+                |console.log("Goodbye world!");
+                |console.log("But not me, sadly.");
+                |console.log("Goodbye world!");
+                |"#
+            .trim_margin()
+            .unwrap(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
 fn parses_simple_pattern() {
     let pattern = r#"
         |engine marzano(0.1)
@@ -2927,7 +2961,7 @@ fn parses_simple_pattern() {
 fn warning_rewrite_in_not() {
     let pattern = r#"
         |`async ($args) => { $body }` where {
-        |    $body <: not contains `try` => ` try { 
+        |    $body <: not contains `try` => ` try {
         |        $body
         |    } catch { }`
         |}"#
@@ -10743,7 +10777,7 @@ fn rewrite_to_accessor_mut() {
                 |language js
                 |
                 |`const $x = $foo` where {
-                |   $cities = {}, 
+                |   $cities = {},
                 |   $kiel = `kiel`,
                 |   $cities.germany = $kiel,
                 |   $cities.italy = `"venice"`,


### PR DESCRIPTION
Previously, a pattern like `includes r"something"` would cause an error.

Since `includes` and `regex` both focus on textual matching, it makes sense for `includes r"foo"` to work. In this case, the `includes` converts the regex so it doesn't have to match the entire node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved pattern matching capabilities, including direct execution for regex patterns and enhanced handling for other types.
- **Tests**
	- Expanded test suite with new functions for regex inclusion and updated existing tests for better coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->