### PR TITLE
fix: json empty string only matches empty strings

### DIFF
--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -12815,3 +12815,47 @@ fn css_property_value() {
     })
     .unwrap();
 }
+
+#[test]
+fn json_empty_string_should_not_match_everything() {
+    run_test_no_match(TestArg {
+        pattern: r#"
+            |engine marzano(0.1)
+            |language json
+            |
+            |`"x": ""`
+            |"#
+        .trim_margin()
+        .unwrap(),
+        source: r#"
+            |{
+            |  "x": "foo"
+            |}
+            |"#
+        .trim_margin()
+        .unwrap(),
+    })
+    .unwrap();
+}
+
+#[test]
+fn json_empty_string_should_match_self() {
+    run_test_match(TestArg {
+        pattern: r#"
+            |engine marzano(0.1)
+            |language json
+            |
+            |`"x": ""`
+            |"#
+        .trim_margin()
+        .unwrap(),
+        source: r#"
+            |{
+            |  "x": ""
+            |}
+            |"#
+        .trim_margin()
+        .unwrap(),
+    })
+    .unwrap();
+}

--- a/crates/language/src/json.rs
+++ b/crates/language/src/json.rs
@@ -1,10 +1,11 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage, FieldId};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/json-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
 static LANGUAGE: OnceLock<TSLanguage> = OnceLock::new();
+static MANDATORY_EMPTY_FIELD_SORTS: OnceLock<Vec<(SortId, FieldId)>> = OnceLock::new();
 
 #[cfg(not(feature = "builtin-parser"))]
 fn language() -> TSLanguage {
@@ -22,6 +23,7 @@ pub struct Json {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
     language: &'static TSLanguage,
+    mandatory_empty_field_sorts: &'static Vec<(SortId, FieldId)>,
 }
 
 impl Json {
@@ -29,10 +31,19 @@ impl Json {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let mandatory_empty_field_sorts = MANDATORY_EMPTY_FIELD_SORTS.get_or_init(|| {
+            vec![
+                (
+                    language.id_for_node_kind("string", true),
+                    language.field_id_for_name("content").unwrap(),
+                ),
+            ]
+        });
         Self {
             node_types,
             metavariable_sort,
             language,
+            mandatory_empty_field_sorts,
         }
     }
     pub(crate) fn is_initialized() -> bool {
@@ -43,6 +54,12 @@ impl Json {
 impl Language for Json {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
+    }
+
+    fn mandatory_empty_field(&self, sort_id:SortId, field_id:crate::language::FieldId) -> bool {
+        self.mandatory_empty_field_sorts
+            .iter()
+            .any(|(s, f)| *s == sort_id && *f == field_id)
     }
 
     fn language_name(&self) -> &'static str {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -160,6 +160,10 @@ pub trait Language {
         false
     }
 
+    fn mandatory_empty_field(&self, _sort_id: SortId, _field_id: FieldId) -> bool {
+        false
+    }
+
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)];
 
     // todo maybe iterate over every node and check for is_missing/is_error?


### PR DESCRIPTION
fixes: https://github.com/getgrit/gritql/issues/71
by adding a function to the language trait which lists fields which must be matched regardless of weather or not they are present in the snippet. ordinarily fields that are not present are ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced pattern matching capabilities to include handling of mandatory empty arguments.
	- Introduced new test scenarios for improved JSON parsing and matching accuracy.
	- Added support for identifying mandatory empty fields in JSON structures.

- **Refactor**
	- Modified internal logic for processing pattern arguments and JSON field sorting to enhance functionality.

- **Tests**
	- Implemented new tests to ensure accurate matching behavior for JSON strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->