### PR TITLE
chore: rename `GRIT_OPENAI_API_KEY` environment variable

### DIFF
--- a/crates/core/src/pattern/compiler.rs
+++ b/crates/core/src/pattern/compiler.rs
@@ -816,15 +816,23 @@ mod tests {
 
     use super::*;
 
-
     #[test]
     fn test_typescript_flavor() {
         let libs = BTreeMap::new();
         let pattern = r#"
             language js (typescript)
             `foo`
-        "#.to_owned();
-        let pattern = src_to_problem_libs(pattern, &libs, PatternLanguage::JavaScript.try_into().unwrap(), None, None, None).unwrap();
+        "#
+        .to_owned();
+        let pattern = src_to_problem_libs(
+            pattern,
+            &libs,
+            PatternLanguage::JavaScript.try_into().unwrap(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         let language = pattern.problem.language.language_name();
         assert_eq!(language, "TypeScript");
     }

--- a/crates/core/src/pattern/container.rs
+++ b/crates/core/src/pattern/container.rs
@@ -31,7 +31,7 @@ pub(crate) enum PatternOrResolved<'a, 'b> {
 pub(crate) enum PatternOrResolvedMut<'a, 'b> {
     Pattern(&'a Pattern),
     Resolved(&'b mut ResolvedPattern<'a>),
-    _ResolvedBinding(ResolvedPattern<'a>),
+    _ResolvedBinding,
 }
 
 // A Container represents anything which "contains" a reference to a Pattern

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -179,11 +179,9 @@ impl ListIndex {
                         let len = named_children_by_field_id(node, &mut cursor, *field).count();
                         let mut list = named_children_by_field_id(node, &mut cursor, *field);
                         let index = resolve_opt!(to_unsigned(index, len));
-                        return Ok(list.nth(index).map(|n| {
-                            PatternOrResolvedMut::_ResolvedBinding(ResolvedPattern::Binding(
-                                vector![Binding::Node(src, n)],
-                            ))
-                        }));
+                        return Ok(list
+                            .nth(index)
+                            .map(|n| PatternOrResolvedMut::_ResolvedBinding));
                     }
                     bail!("left side of a listIndex must be a list")
                 }

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -174,7 +174,7 @@ impl ListIndex {
                     let binding = b
                         .last()
                         .ok_or_else(|| anyhow!("left side of a listIndex must be a list"))?;
-                    if let Binding::List(src, node, field) = binding {
+                    if let Binding::List(_src, node, field) = binding {
                         let mut cursor = node.walk();
                         let len = named_children_by_field_id(node, &mut cursor, *field).count();
                         let mut list = named_children_by_field_id(node, &mut cursor, *field);

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -181,7 +181,7 @@ impl ListIndex {
                         let index = resolve_opt!(to_unsigned(index, len));
                         return Ok(list
                             .nth(index)
-                            .map(|n| PatternOrResolvedMut::_ResolvedBinding));
+                            .map(|_n| PatternOrResolvedMut::_ResolvedBinding));
                     }
                     bail!("left side of a listIndex must be a list")
                 }

--- a/crates/gritmodule/src/formatting.rs
+++ b/crates/gritmodule/src/formatting.rs
@@ -28,6 +28,7 @@ pub async fn format_rich_files(
         let mut f = OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&new_file_path)
             .await
             .with_context(|| {

--- a/crates/lsp/src/language.rs
+++ b/crates/lsp/src/language.rs
@@ -53,9 +53,7 @@ pub fn target_language_to_language_id(target_language: TargetLanguage) -> &'stat
 
 #[allow(dead_code)]
 pub fn extension_to_language_id(extension: &str) -> Option<String> {
-    let Some(language) = TargetLanguage::from_extension(extension) else {
-        return None;
-    };
+    let language = TargetLanguage::from_extension(extension)?;
     Some(target_language_to_language_id(language).to_string())
 }
 

--- a/crates/lsp/src/manager.rs
+++ b/crates/lsp/src/manager.rs
@@ -252,9 +252,7 @@ impl GritServerManager {
     }
 
     pub fn get_root_path(&self) -> Option<PathBuf> {
-        let Some(root_uri) = self.get_root_uri() else {
-            return None;
-        };
+        let root_uri = self.get_root_uri()?;
         match uri_to_file_path(root_uri.as_ref()) {
             Ok(path) => Some(path),
             Err(_) => None,

--- a/crates/util/src/runtime.rs
+++ b/crates/util/src/runtime.rs
@@ -56,11 +56,11 @@ impl ExecutionContext {
             Some(api) => Ok(api.clone()),
             None => {
                 // Try to build it from the legacy env vars
-                let openai_api_key = match env::var("OPENAI_API_KEY") {
+                let openai_api_key = match env::var("GRIT_OPENAI_API_KEY") {
                     Ok(val) => val,
                     Err(_) => {
                         return Err(anyhow::anyhow!(
-                            "Authentication is required. Please run grit auth login or provide the OPENAI_API_KEY environment variable."
+                            "Authentication is required. Please run grit auth login or provide the GRIT_OPENAI_API_KEY environment variable."
                         ))
                     }
                 };


### PR DESCRIPTION
fixes #https://github.com/getgrit/rewriter/issues/9312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the environment variable for authentication to enhance security and clarity.
- **Refactor**
	- Adjusted the formatting of the `pattern` variable assignment in the `test_typescript_flavor()` test for improved readability and consistency.
- **Refactor**
	- Simplified the `PatternOrResolvedMut` enum in the `_ResolvedBinding` variant by removing the `ResolvedPattern` type.
- **Refactor**
	- Simplified the mapping of a list index to a resolved binding in the `ListIndex` implementation by adjusting the closure usage within the `map` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->