### PR TITLE
fix: Revert "chore: switch to faster runners"

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   clippy_check:
-    runs-on: namespace-profile-grit-oss
+    runs-on: "nscloud-ubuntu-22.04-amd64-4x16"
     steps:
       - name: clone code
         uses: actions/checkout@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [namespace-profile-grit-oss]
+        os: [nscloud-ubuntu-22.04-amd64-8x32]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: "read"
@@ -76,7 +76,8 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
-    runs-on: namespace-profile-grit-oss
+    runs-on:
+      - ubuntu-latest
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   main:
     name: validate PR title
-    runs-on: namespace-profile-grit-oss
+    runs-on: "nscloud-ubuntu-22.04-amd64-4x16"
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:


### PR DESCRIPTION
Reverts getgrit/gritql#79

Tests somehow broke on main: https://github.com/getgrit/gritql/actions/runs/8445635117/job/23133307086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the infrastructure for code quality checks, main workflow, and PR linting to enhance performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->