### PR TITLE
chore: introduce `AstNode` trait

### DIFF
--- a/crates/core/src/ast_node.rs
+++ b/crates/core/src/ast_node.rs
@@ -1,0 +1,47 @@
+use tree_sitter::Node;
+
+/// Represents an AST node and offers convenient AST-specific functionality.
+///
+/// This trait should be free from dependencies on TreeSitter.
+pub trait AstNode: Sized {
+    /// Returns the next node, ignoring trivia such as whitespace.
+    fn next_non_trivia_node(&self) -> Option<Self>;
+
+    /// Returns the previous node, ignoring trivia such as whitespace.
+    fn previous_non_trivia_node(&self) -> Option<Self>;
+}
+
+/// A TreeSitter node, including a reference to the source code from which it
+/// was parsed.
+pub(crate) struct NodeWithSource<'a> {
+    pub node: Node<'a>,
+    pub source: &'a str,
+}
+
+impl<'a> NodeWithSource<'a> {
+    pub fn new(node: Node<'a>, source: &'a str) -> Self {
+        Self { node, source }
+    }
+}
+
+impl<'a> AstNode for NodeWithSource<'a> {
+    fn next_non_trivia_node(&self) -> Option<Self> {
+        let mut current_node = self.node.clone();
+        loop {
+            if let Some(sibling) = current_node.next_named_sibling() {
+                return Some(Self::new(sibling, self.source));
+            }
+            current_node = current_node.parent()?;
+        }
+    }
+
+    fn previous_non_trivia_node(&self) -> Option<Self> {
+        let mut current_node = self.node.clone();
+        loop {
+            if let Some(sibling) = current_node.prev_named_sibling() {
+                return Some(Self::new(sibling, self.source));
+            }
+            current_node = current_node.parent()?;
+        }
+    }
+}

--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -1,3 +1,4 @@
+use crate::ast_node::NodeWithSource;
 use crate::inline_snippets::inline_sorted_snippets_with_offset;
 use crate::pattern::state::{get_top_level_effects, FileRegistry};
 use crate::pattern::{Effect, EffectKind};
@@ -324,6 +325,39 @@ pub(crate) fn linearize_binding<'a>(
 }
 
 impl<'a> Binding<'a> {
+    pub(crate) fn from_node(node: NodeWithSource<'a>) -> Self {
+        Self::Node(node.source, node.node)
+    }
+
+    /// Returns the node this binding applies to.
+    ///
+    /// Unlike [`Self::get_node()`], this will return the exact child node if
+    /// the binding applies to a list.
+    pub(crate) fn as_node(&self) -> Option<NodeWithSource<'a>> {
+        match self {
+            Self::Node(src, node) => Some(NodeWithSource::new(node.clone(), src)),
+            Self::List(src, node, field) => node
+                .child_by_field_id(*field)
+                .map(|child| NodeWithSource::new(child, src)),
+            Self::Empty(..) | Self::String(..) | Self::ConstantRef(..) | Binding::FileName(..) => {
+                None
+            }
+        }
+    }
+
+    /// Returns the node from which this binding was created.
+    ///
+    /// This differs from [`Self::as_node()`] in that it returns the node for an
+    /// entire list when the binding applies to a list item.
+    pub(crate) fn get_node(&self) -> Option<NodeWithSource<'a>> {
+        match self {
+            Self::Node(source, node)
+            | Self::List(source, node, _)
+            | Self::Empty(source, node, _) => Some(NodeWithSource::new(node.clone(), source)),
+            Self::String(..) | Binding::FileName(..) | Binding::ConstantRef(_) => None,
+        }
+    }
+
     pub fn singleton(&self) -> Option<(&str, Node)> {
         match self {
             Binding::Node(src, node) => Some((src, node.to_owned())),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::wildcard_enum_match_arm)]
+mod ast_node;
 pub mod binding;
 pub mod compact_api;
 pub mod context;

--- a/crates/core/src/pattern/after.rs
+++ b/crates/core/src/pattern/after.rs
@@ -1,12 +1,11 @@
 use super::{
-    before::Before,
     compiler::CompilationContext,
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::{pattern_to_binding, ResolvedPattern},
     variable::VariableSourceLocations,
     Node, State,
 };
-use crate::{binding::Binding, context::Context, resolve};
+use crate::{ast_node::AstNode, binding::Binding, context::Context, resolve};
 use crate::{binding::Constant, errors::debug};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
@@ -56,18 +55,12 @@ impl After {
         logs: &mut AnalysisLogs,
     ) -> Result<ResolvedPattern<'a>> {
         let binding = pattern_to_binding(&self.after, state, context, logs)?;
-        let (source, node) = match binding {
-            Binding::String(_, _) => bail!("cannot get the node before a string"),
-            Binding::FileName(_) => bail!("cannot get the node before a filename"),
-            Binding::Node(s, n) => (s, n),
-            Binding::List(s, n, _) => (s, n),
-            Binding::Empty(s, n, _) => (s, n),
-            Binding::ConstantRef(_) => bail!("cannot get the node before a constant"),
+        let Some(node) = binding.get_node() else {
+            bail!("cannot get the node after this binding")
         };
-        if let Some(prev) = Before::next_node(node) {
-            Ok(ResolvedPattern::Binding(vector![Binding::Node(
-                source, prev
-            )]))
+
+        if let Some(next) = node.next_non_trivia_node() {
+            Ok(ResolvedPattern::Binding(vector![Binding::from_node(next)]))
         } else {
             debug(
                 logs,
@@ -75,16 +68,6 @@ impl After {
                 "no node after current node, treating as undefined",
             )?;
             Ok(ResolvedPattern::Constant(Constant::Undefined))
-        }
-    }
-
-    pub(crate) fn prev_node(node: Node) -> Option<Node> {
-        let mut current_node = node;
-        loop {
-            if let Some(sibling) = current_node.prev_named_sibling() {
-                return Some(sibling);
-            }
-            current_node = current_node.parent()?;
         }
     }
 }
@@ -114,17 +97,12 @@ impl Matcher for After {
         };
         let mut cur_state = init_state.clone();
         // todo implement for empty and empty list
-        let (src, node) = match binding {
-            Binding::Empty(_, _, _) => return Ok(true),
-            Binding::Node(src, node) => (src, node.to_owned()),
-            Binding::String(_, _) => return Ok(true),
-            Binding::List(src, node, field) => (src, resolve!(node.child_by_field_id(*field))),
-            Binding::ConstantRef(_) => return Ok(true),
-            Binding::FileName(_) => return Ok(true),
+        let Some(node) = binding.as_node() else {
+            return Ok(true);
         };
-        let after_node = resolve!(Self::prev_node(node.clone()));
+        let prev_node = resolve!(node.previous_non_trivia_node());
         if !self.after.execute(
-            &ResolvedPattern::from_node(src, after_node),
+            &ResolvedPattern::from_node(prev_node.source, prev_node.node),
             &mut cur_state,
             context,
             logs,


### PR DESCRIPTION
This introduces an `AstNode` trait, which gets implemented by a `NodeWithSource` struct. The goal is again to reduce dependencies on TreeSitter, so while `NodeWithSource` still uses a TreeSitter node internally, the `AstNode` trait doesn't expose any TreeSitter internals.

Currently there are only 2 methods implemented, which aid with the implementations of the `Before` and `After` patterns. As can be seen, this also reduces the `match binding` expressions. Later, this should hopefully make it possible to place `Binding` itself behind an abstract trait as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an advanced representation for AST (Abstract Syntax Tree) nodes, enhancing the way AST nodes and their source code are managed and navigated.
- **Refactor**
	- Improved the clarity and efficiency of node and binding handling in the core logic, particularly in pattern matching and traversal functionalities.
- **Chores**
	- Reorganized the module structure for better clarity and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->