### PR TITLE
chore: refactor `normalize_insert()`

### DIFF
--- a/crates/core/src/pattern/accumulate.rs
+++ b/crates/core/src/pattern/accumulate.rs
@@ -16,7 +16,6 @@ use super::{
 };
 use super::{Effect, EffectKind};
 use crate::context::Context;
-use crate::smart_insert::normalize_insert;
 use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
@@ -203,7 +202,7 @@ impl Matcher for Accumulate {
                 .iter()
                 .map(|b| {
                     let is_first = !state.effects.iter().any(|e| e.binding == *b);
-                    normalize_insert(b, &mut replacement, is_first, context.language())?;
+                    replacement.normalize_insert(b, is_first, context.language())?;
                     Ok(Effect {
                         binding: b.clone(),
                         pattern: replacement.clone(),


### PR DESCRIPTION
Similar to https://github.com/getgrit/gritql/pull/86, in order to reduce `match`es on `Binding`, I've refactored `normalize_insert()`. The function itself has become a method on `ResolvedPattern`, while most of its body is refactored into the `get_insertion_padding()` method on `Binding`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the insertion normalization process for better flexibility and clarity.
	- Improved the logic for insertion padding calculation to be more adaptable to different contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->