### PR TITLE
chore: consolidate `as_node()`

### DIFF
--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -289,35 +289,6 @@ impl<'a> Binding<'a> {
         Self::Node(node.source, node.node)
     }
 
-    /// Returns the node this binding applies to.
-    ///
-    /// Unlike [`Self::get_node()`], this will return the exact child node if
-    /// the binding applies to a list.
-    pub(crate) fn as_node(&self) -> Option<NodeWithSource<'a>> {
-        match self {
-            Self::Node(src, node) => Some(NodeWithSource::new(node.clone(), src)),
-            Self::List(src, node, field) => node
-                .child_by_field_id(*field)
-                .map(|child| NodeWithSource::new(child, src)),
-            Self::Empty(..) | Self::String(..) | Self::ConstantRef(..) | Binding::FileName(..) => {
-                None
-            }
-        }
-    }
-
-    /// Returns the node from which this binding was created.
-    ///
-    /// This differs from [`Self::as_node()`] in that it returns the node for an
-    /// entire list when the binding applies to a list item.
-    pub(crate) fn get_node(&self) -> Option<NodeWithSource<'a>> {
-        match self {
-            Self::Node(source, node)
-            | Self::List(source, node, _)
-            | Self::Empty(source, node, _) => Some(NodeWithSource::new(node.clone(), source)),
-            Self::String(..) | Binding::FileName(..) | Binding::ConstantRef(_) => None,
-        }
-    }
-
     pub fn singleton(&self) -> Option<(&str, Node)> {
         match self {
             Binding::Node(src, node) => Some((src, node.to_owned())),
@@ -504,14 +475,21 @@ impl<'a> Binding<'a> {
         }
     }
 
+    /// Returns the path of this binding, if and only if it is a filename binding.
     pub fn as_filename(&self) -> Option<&Path> {
-        match self {
-            Binding::FileName(path) => Some(path),
-            Binding::Empty(..)
-            | Binding::Node(..)
-            | Binding::String(..)
-            | Binding::List(..)
-            | Binding::ConstantRef(..) => None,
+        if let Self::FileName(path) = self {
+            Some(path)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the node of this binding, if and only if it is a node binding.
+    pub(crate) fn as_node(&self) -> Option<NodeWithSource<'a>> {
+        if let Self::Node(source, node) = self {
+            Some(NodeWithSource::new(node.clone(), source))
+        } else {
+            None
         }
     }
 

--- a/crates/core/src/pattern/after.rs
+++ b/crates/core/src/pattern/after.rs
@@ -55,7 +55,7 @@ impl After {
         logs: &mut AnalysisLogs,
     ) -> Result<ResolvedPattern<'a>> {
         let binding = pattern_to_binding(&self.after, state, context, logs)?;
-        let Some(node) = binding.get_node() else {
+        let Some(node) = binding.as_node() else {
             bail!("cannot get the node after this binding")
         };
 

--- a/crates/core/src/pattern/before.rs
+++ b/crates/core/src/pattern/before.rs
@@ -55,7 +55,7 @@ impl Before {
         logs: &mut AnalysisLogs,
     ) -> Result<ResolvedPattern<'a>> {
         let binding = pattern_to_binding(&self.before, state, context, logs)?;
-        let Some(node) = binding.get_node() else {
+        let Some(node) = binding.as_node() else {
             bail!("cannot get the node before this binding")
         };
 

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -989,7 +989,7 @@ impl<'a> ResolvedPattern<'a> {
         let Some(ResolvedSnippet::Text(text)) = snippets.front() else {
             return Ok(());
         };
-        if let Some(padding) = binding.get_insertion_padding(&text, is_first, language) {
+        if let Some(padding) = binding.get_insertion_padding(text, is_first, language) {
             if padding.chars().next() != binding.text().chars().last() {
                 snippets.push_front(ResolvedSnippet::Text(padding.into()));
             }


### PR DESCRIPTION
See discussion at: https://github.com/getgrit/gritql/pull/85#discussion_r1541373392

I've followed @ilevyor 's suggestion to return `None` for the empty and list variants, although I ended up calling it `as_node()` for consistency with the `as_filename()` method we also have now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling and retrieval of file paths and nodes within the core binding structure.
	- Enhanced logic for inserting text padding in patterns, ensuring more accurate formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->