### PR TITLE
chore: create `grit-util` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "grit-util"
+version = "0.1.0"
+
+[[package]]
 name = "grit_cache"
 version = "0.1.0"
 dependencies = [
@@ -1956,6 +1960,7 @@ dependencies = [
  "elsa",
  "embeddings",
  "getrandom",
+ "grit-util",
  "im",
  "insta",
  "itertools 0.10.5",
@@ -1977,7 +1982,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tree-sitter-facade-sg",
  "tree-sitter-gritql",
- "tree-sitter-traversal",
  "trim-margin",
  "walkdir",
 ]
@@ -2023,6 +2027,7 @@ dependencies = [
  "anyhow",
  "clap",
  "enum_dispatch",
+ "grit-util",
  "ignore",
  "itertools 0.10.5",
  "lazy_static",
@@ -2047,7 +2052,6 @@ dependencies = [
  "tree-sitter-solidity",
  "tree-sitter-sql",
  "tree-sitter-toml",
- "tree-sitter-traversal",
  "tree-sitter-typescript",
  "tree-sitter-vue",
  "tree-sitter-yaml",
@@ -2097,6 +2101,7 @@ dependencies = [
  "base64",
  "derive_builder",
  "futures",
+ "grit-util",
  "http",
  "ignore",
  "log",
@@ -2106,7 +2111,6 @@ dependencies = [
  "sha2",
  "tokio",
  "tree-sitter-facade-sg",
- "tree-sitter-traversal",
 ]
 
 [[package]]
@@ -3939,12 +3943,6 @@ dependencies = [
  "cc",
  "tree-sitter",
 ]
-
-[[package]]
-name = "tree-sitter-traversal"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8a158225e4a4d8505f071340bba9edd109b23f01b70540dccb7c799868f307"
 
 [[package]]
 name = "tree-sitter-typescript"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,11 @@ members = [
   "crates/language",
   "crates/gritmodule",
   "crates/gritcache",
+  "crates/grit-util",
   "crates/auth",
   "crates/externals",
   "crates/wasm-bindings",
-  "crates/marzano_messenger", "crates/cli_bin",
+  "crates/marzano_messenger",
+  "crates/cli_bin",
 ]
-exclude = [
-  "resources",
-  "vendor/web-tree-sitter",
-  "vendor/tree-sitter-facade",
-]
+exclude = ["resources", "vendor/web-tree-sitter", "vendor/tree-sitter-facade"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,14 +15,13 @@ marzano-language = { path = "../language", default-features = false }
 marzano-util = { path = "../util" }
 marzano-externals = { path = "../externals", optional = true }
 embeddings = { git = "https://github.com/getgrit/embeddings.git", optional = true }
-
+grit-util = { path = "../grit-util" }
 tracing = { version = "0.1.40", default-features = false, features = [] }
 tracing-opentelemetry = { version = "0.22.0", optional = true, default-features = false, features = [
 ] }
 
 regex = "1.7.3"
 anyhow = "1.0.70"
-tree-sitter-traversal = { version = "0.1.2", default-features = false }
 itertools = "0.10.5"
 im = "15.1.0"
 serde_json = "1.0.96"
@@ -35,7 +34,7 @@ rand = "0.8.5"
 path-absolutize = { version = "3.1.1", optional = false, features = [
   "use_unix_paths_on_wasm",
 ] }
-getrandom = {version = "0.2.11", optional = true }
+getrandom = { version = "0.2.11", optional = true }
 
 [dev-dependencies]
 similar = "2.2.1"
@@ -65,8 +64,18 @@ grit_alpha = ["external_functions", "embeddings"]
 # Shared network requests - common to all approaches
 network_requests_common = ["marzano-util/network_requests_common"]
 network_requests = ["network_requests_common", "marzano-util/network_requests"]
-network_requests_external = ["network_requests_common", "marzano-util/network_requests_external"]
-wasm_core = [ "dep:getrandom", "getrandom/js", "network_requests_external", "external_functions_common", "external_functions_ffi", "marzano-util/external_functions_ffi"]
+network_requests_external = [
+  "network_requests_common",
+  "marzano-util/network_requests_external",
+]
+wasm_core = [
+  "dep:getrandom",
+  "getrandom/js",
+  "network_requests_external",
+  "external_functions_common",
+  "external_functions_ffi",
+  "marzano-util/external_functions_ffi",
+]
 grit_tracing = ["dep:tracing-opentelemetry"]
 language-parsers = ["marzano-language/builtin-parser"]
 grit-parser = ["tree-sitter-gritql"]

--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -1,19 +1,18 @@
-use crate::ast_node::NodeWithSource;
 use crate::inline_snippets::inline_sorted_snippets_with_offset;
+use crate::pattern::resolved_pattern::CodeRange;
 use crate::pattern::state::{get_top_level_effects, FileRegistry};
 use crate::pattern::{Effect, EffectKind};
 use anyhow::{anyhow, Result};
 use marzano_language::language::{FieldId, Language};
 use marzano_language::target_language::TargetLanguage;
 use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
+use marzano_util::node_with_source::NodeWithSource;
 use marzano_util::position::{Position, Range};
 use marzano_util::tree_sitter_util::children_by_field_id_count;
 use std::ops::Range as StdRange;
 use std::path::Path;
 use std::{borrow::Cow, collections::HashMap, fmt::Display};
 use tree_sitter::Node;
-
-use crate::pattern::resolved_pattern::CodeRange;
 
 // the inner references hold the mutable state
 #[derive(Debug, Clone)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::wildcard_enum_match_arm)]
-mod ast_node;
 pub mod binding;
 pub mod compact_api;
 pub mod context;

--- a/crates/core/src/orphan.rs
+++ b/crates/core/src/orphan.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
+use grit_util::{traverse, Order};
 use itertools::Itertools;
 use marzano_language::{language::Language, target_language::TargetLanguage};
+use marzano_util::cursor_wrapper::CursorWrapper;
 use marzano_util::position::Range;
 use tree_sitter::{Parser, Range as TSRange, Tree};
-use tree_sitter_traversal::{traverse, Order};
-
-use marzano_util::cursor_wrapper::CursorWrapper;
 
 fn merge_treesitter_ranges(ranges: Vec<TSRange>) -> Vec<Range> {
     if ranges.is_empty() {
@@ -54,8 +53,8 @@ pub(crate) fn remove_orphaned_ranges(
 pub fn get_orphaned_ranges(tree: &Tree, src: &str, lang: &TargetLanguage) -> Vec<TSRange> {
     let mut orphan_ranges = vec![];
     let cursor = tree.walk();
-    for n in traverse(CursorWrapper::from(cursor), Order::Pre) {
-        lang.check_orphaned(n, src, &mut orphan_ranges);
+    for n in traverse(CursorWrapper::new(cursor, src), Order::Pre) {
+        lang.check_orphaned(n.node, src, &mut orphan_ranges);
     }
     orphan_ranges
 }

--- a/crates/core/src/pattern/after.rs
+++ b/crates/core/src/pattern/after.rs
@@ -5,10 +5,11 @@ use super::{
     variable::VariableSourceLocations,
     Node, State,
 };
-use crate::{ast_node::AstNode, binding::Binding, context::Context, resolve};
+use crate::{binding::Binding, context::Context, resolve};
 use crate::{binding::Constant, errors::debug};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
+use grit_util::AstNode;
 use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;

--- a/crates/core/src/pattern/before.rs
+++ b/crates/core/src/pattern/before.rs
@@ -5,10 +5,11 @@ use super::{
     variable::VariableSourceLocations,
     Node, State,
 };
-use crate::{ast_node::AstNode, binding::Binding, context::Context, resolve};
+use crate::{binding::Binding, context::Context, resolve};
 use crate::{binding::Constant, errors::debug};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
+use grit_util::AstNode;
 use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -55,7 +56,7 @@ impl Before {
         logs: &mut AnalysisLogs,
     ) -> Result<ResolvedPattern<'a>> {
         let binding = pattern_to_binding(&self.before, state, context, logs)?;
-        let Some(node) = binding.get_node() else {
+        let Some(node) = binding.as_node() else {
             bail!("cannot get the node before this binding")
         };
 

--- a/crates/grit-util/Cargo.toml
+++ b/crates/grit-util/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "grit-util"
+version = "0.1.0"
+edition = "2021"
+
+[lints]
+rust.unused_crate_dependencies = "warn"

--- a/crates/grit-util/src/ast_node.rs
+++ b/crates/grit-util/src/ast_node.rs
@@ -1,0 +1,10 @@
+/// Represents an AST node and offers convenient AST-specific functionality.
+///
+/// This trait should be free from dependencies on TreeSitter.
+pub trait AstNode: Sized {
+    /// Returns the next node, ignoring trivia such as whitespace.
+    fn next_non_trivia_node(&self) -> Option<Self>;
+
+    /// Returns the previous node, ignoring trivia such as whitespace.
+    fn previous_non_trivia_node(&self) -> Option<Self>;
+}

--- a/crates/grit-util/src/ast_node_traversal.rs
+++ b/crates/grit-util/src/ast_node_traversal.rs
@@ -1,0 +1,331 @@
+// Based on: https://github.com/skmendez/tree-sitter-traversal/blob/main/src/lib.rs
+// License: MIT License
+//
+// Copyright (c) 2021 Sebastian Mendez
+
+//!
+//! Iterators to traverse trees with a [`Cursor`] trait to allow for traversing
+//! arbitrary n-ary trees.
+//!
+
+use crate::ast_node::AstNode;
+use core::iter::FusedIterator;
+
+/// Trait which represents a stateful cursor in a n-ary tree.
+/// The cursor can be moved between nodes in the tree by the given methods,
+/// and the node which the cursor is currently pointing at can be read as well.
+pub trait AstCursor {
+    /// The type of the nodes which the cursor points at; the cursor is always pointing
+    /// at exactly one of this type.
+    type Node: AstNode;
+
+    /// Move this cursor to the first child of its current node.
+    ///
+    /// This returns `true` if the cursor successfully moved, and returns `false`
+    /// if there were no children.
+    fn goto_first_child(&mut self) -> bool;
+
+    /// Move this cursor to the parent of its current node.
+    ///
+    /// This returns `true` if the cursor successfully moved, and returns `false`
+    /// if there was no parent node (the cursor was already on the root node).
+    fn goto_parent(&mut self) -> bool;
+
+    /// Move this cursor to the next sibling of its current node.
+    ///
+    /// This returns `true` if the cursor successfully moved, and returns `false`
+    /// if there was no next sibling node.
+    fn goto_next_sibling(&mut self) -> bool;
+
+    /// Get the node which the cursor is currently pointing at.
+    fn node(&self) -> Self::Node;
+}
+
+impl<'a, T> AstCursor for &'a mut T
+where
+    T: AstCursor,
+{
+    type Node = T::Node;
+
+    fn goto_first_child(&mut self) -> bool {
+        T::goto_first_child(self)
+    }
+
+    fn goto_parent(&mut self) -> bool {
+        T::goto_parent(self)
+    }
+
+    fn goto_next_sibling(&mut self) -> bool {
+        T::goto_next_sibling(self)
+    }
+
+    fn node(&self) -> Self::Node {
+        T::node(self)
+    }
+}
+
+/// Order to iterate through a n-ary tree; for n-ary trees only
+/// Pre-order and Post-order make sense.
+#[derive(Eq, PartialEq, Hash, Debug, Copy, Clone)]
+pub enum Order {
+    Pre,
+    Post,
+}
+
+/// Iterative traversal of the tree; serves as a reference for both
+/// PreorderTraversal and PostorderTraversal, as they both will call the exact same
+/// cursor methods in the exact same order as this function for a given tree; the order
+/// is also the same as traverse_recursive.
+#[allow(dead_code)]
+fn traverse_iterative<C: AstCursor, F>(mut c: C, order: Order, mut cb: F)
+where
+    F: FnMut(C::Node),
+{
+    loop {
+        // This is the first time we've encountered the node, so we'll call if preorder
+        if order == Order::Pre {
+            cb(c.node());
+        }
+
+        // Keep travelling down the tree as far as we can
+        if c.goto_first_child() {
+            continue;
+        }
+
+        let node = c.node();
+
+        // If we can't travel any further down, try going to next sibling and repeating
+        if c.goto_next_sibling() {
+            // If we succeed in going to the previous nodes sibling,
+            // we won't be encountering that node again, so we'll call if postorder
+            if order == Order::Post {
+                cb(node);
+            }
+            continue;
+        }
+
+        // Otherwise, we must travel back up; we'll loop until we reach the root or can
+        // go to the next sibling of a node again.
+        loop {
+            // Since we're retracing back up the tree, this is the last time we'll encounter
+            // this node, so we'll call if postorder
+            if order == Order::Post {
+                cb(c.node());
+            }
+            if !c.goto_parent() {
+                // We have arrived back at the root, so we are done.
+                return;
+            }
+
+            let node = c.node();
+
+            if c.goto_next_sibling() {
+                // If we succeed in going to the previous node's sibling,
+                // we will go back to travelling down that sibling's tree, and we also
+                // won't be encountering the previous node again, so we'll call if postorder
+                if order == Order::Post {
+                    cb(node);
+                }
+                break;
+            }
+        }
+    }
+}
+
+/// Idiomatic recursive traversal of the tree; this version is easier to understand
+/// conceptually, but the recursion is actually unnecessary and can cause stack overflow.
+#[allow(dead_code)]
+fn traverse_recursive<C: AstCursor, F>(mut c: C, order: Order, mut cb: F)
+where
+    F: FnMut(C::Node),
+{
+    traverse_helper(&mut c, order, &mut cb);
+}
+
+fn traverse_helper<C: AstCursor, F>(c: &mut C, order: Order, cb: &mut F)
+where
+    F: FnMut(C::Node),
+{
+    // If preorder, call the callback when we first touch the node
+    if order == Order::Pre {
+        cb(c.node());
+    }
+    if c.goto_first_child() {
+        // If there is a child, recursively call on
+        // that child and all its siblings
+        loop {
+            traverse_helper(c, order, cb);
+            if !c.goto_next_sibling() {
+                break;
+            }
+        }
+        // Make sure to reset back to the original node;
+        // this must always return true, as we only get here if we go to a child
+        // of the original node.
+        assert!(c.goto_parent());
+    }
+    // If preorder, call the callback after the recursive calls on child nodes
+    if order == Order::Post {
+        cb(c.node());
+    }
+}
+
+struct PreorderTraverse<C> {
+    cursor: Option<C>,
+}
+
+impl<C> PreorderTraverse<C> {
+    pub fn new(c: C) -> Self {
+        PreorderTraverse { cursor: Some(c) }
+    }
+}
+
+impl<C> Iterator for PreorderTraverse<C>
+where
+    C: AstCursor,
+{
+    type Item = C::Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let c = match self.cursor.as_mut() {
+            None => {
+                return None;
+            }
+            Some(c) => c,
+        };
+
+        // We will always return the node we were on at the start;
+        // the node we traverse to will either be returned on the next iteration,
+        // or will be back to the root node, at which point we'll clear out
+        // the reference to the cursor
+        let node = c.node();
+
+        // First, try to go to a child or a sibling; if either succeed, this will be the
+        // first time we touch that node, so it'll be the next starting node
+        if c.goto_first_child() || c.goto_next_sibling() {
+            return Some(node);
+        }
+
+        loop {
+            // If we can't go to the parent, then that means we've reached the root, and our
+            // iterator will be done in the next iteration
+            if !c.goto_parent() {
+                self.cursor = None;
+                break;
+            }
+
+            // If we get to a sibling, then this will be the first time we touch that node,
+            // so it'll be the next starting node
+            if c.goto_next_sibling() {
+                break;
+            }
+        }
+
+        Some(node)
+    }
+}
+
+struct PostorderTraverse<C> {
+    cursor: Option<C>,
+    retracing: bool,
+}
+
+impl<C> PostorderTraverse<C> {
+    pub fn new(c: C) -> Self {
+        PostorderTraverse {
+            cursor: Some(c),
+            retracing: false,
+        }
+    }
+}
+
+impl<C> Iterator for PostorderTraverse<C>
+where
+    C: AstCursor,
+{
+    type Item = C::Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let c = match self.cursor.as_mut() {
+            None => {
+                return None;
+            }
+            Some(c) => c,
+        };
+
+        // For the postorder traversal, we will only return a node when we are travelling back up
+        // the tree structure. Therefore, we go all the way to the leaves of the tree immediately,
+        // and only when we are retracing do we return elements
+        if !self.retracing {
+            while c.goto_first_child() {}
+        }
+
+        // Much like in preorder traversal, we want to return the node we were previously at.
+        // We know this will be the last time we touch this node, as we will either be going
+        // to its next sibling or retracing back up the tree
+        let node = c.node();
+        if c.goto_next_sibling() {
+            // If we successfully go to a sibling of this node, we want to go back down
+            // the tree on the next iteration
+            self.retracing = false;
+        } else {
+            // If we weren't already retracing, we are now; travel upwards until we can
+            // go to the next sibling or reach the root again
+            self.retracing = true;
+            if !c.goto_parent() {
+                // We've reached the root again, and our iteration is done
+                self.cursor = None;
+            }
+        }
+
+        Some(node)
+    }
+}
+
+// Used for visibility purposes, in case this struct becomes public
+struct Traverse<C> {
+    inner: TraverseInner<C>,
+}
+
+enum TraverseInner<C> {
+    Post(PostorderTraverse<C>),
+    Pre(PreorderTraverse<C>),
+}
+
+impl<C> Traverse<C> {
+    pub fn new(c: C, order: Order) -> Self {
+        let inner = match order {
+            Order::Pre => TraverseInner::Pre(PreorderTraverse::new(c)),
+            Order::Post => TraverseInner::Post(PostorderTraverse::new(c)),
+        };
+        Self { inner }
+    }
+}
+
+/// Traverse an n-ary tree using `cursor`, returning the nodes of the tree through an iterator
+/// in an order according to `order`.
+///
+/// `cursor` must be at the root of the tree
+/// (i.e. `cursor.goto_parent()` must return false)
+pub fn traverse<C: AstCursor>(mut cursor: C, order: Order) -> impl FusedIterator<Item = C::Node> {
+    assert!(!cursor.goto_parent());
+    Traverse::new(cursor, order)
+}
+
+impl<C> Iterator for Traverse<C>
+where
+    C: AstCursor,
+{
+    type Item = C::Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner {
+            TraverseInner::Post(ref mut i) => i.next(),
+            TraverseInner::Pre(ref mut i) => i.next(),
+        }
+    }
+}
+
+// We know that PreorderTraverse and PostorderTraverse are fused due to their implementation,
+// so we can add this bound for free.
+impl<C> FusedIterator for Traverse<C> where C: AstCursor {}

--- a/crates/grit-util/src/lib.rs
+++ b/crates/grit-util/src/lib.rs
@@ -1,0 +1,5 @@
+mod ast_node;
+mod ast_node_traversal;
+
+pub use ast_node::AstNode;
+pub use ast_node_traversal::{traverse, AstCursor, Order};

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -30,13 +30,13 @@ tree-sitter-toml = { path = "../../resources/language-metavariables/tree-sitter-
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = { version = "1.0.91", features = ["preserve_order"] }
 marzano-util = { path = "../util" }
+grit-util = { path = "../grit-util" }
 regex = "1.7.1"
 anyhow = "1.0.70"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 ignore = { version = "0.4.21", optional = true }
 web-sys = { version = "0.3.66", features = ["console"], optional = true }
-tree-sitter-traversal = { version = "0.1.2", default-features = false }
 enum_dispatch = "0.3.12"
 clap = { version = "4.1.13", features = ["derive"] }
 

--- a/crates/language/src/xscript_util.rs
+++ b/crates/language/src/xscript_util.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
+use grit_util::{traverse, Order};
 use marzano_util::{cursor_wrapper::CursorWrapper, tree_sitter_util::children_by_field_name_count};
 use tree_sitter::{Node, Parser, Range, Tree};
-use tree_sitter_traversal::{traverse, Order};
 
 use crate::{
     language::{default_parse_file, Language, SortId, TSLanguage},
@@ -89,8 +89,8 @@ fn get_vue_ranges(file: &str) -> Result<Vec<Range>> {
     let tree = parser.parse(file, None)?.ok_or(anyhow!("missing tree"))?;
     let cursor = tree.walk();
     let mut ranges = Vec::new();
-    for n in traverse(CursorWrapper::from(cursor), Order::Pre) {
-        append_code_range(&n, text, &mut ranges)
+    for n in traverse(CursorWrapper::new(cursor, file), Order::Pre) {
+        append_code_range(&n.node, text, &mut ranges)
     }
     Ok(ranges)
 }

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -10,6 +10,7 @@ rust.unused_crate_dependencies = "warn"
 
 [dependencies]
 tree-sitter = { path = "../../vendor/tree-sitter-facade", package = "tree-sitter-facade-sg" }
+grit-util = { path = "../grit-util" }
 serde = { version = "1.0.164", features = ["derive"] }
 base64 = "0.21.2"
 anyhow = "1.0.70"
@@ -17,21 +18,26 @@ log = { version = "0.4.20", optional = true }
 ignore = { version = "0.4.21", optional = true }
 sha2 = { version = "0.10.8" }
 derive_builder = "0.13.1"
-tree-sitter-traversal = { version = "0.1.2", default-features = false }
 reqwest = { version = "0.11.22", features = [
   "blocking",
   "json",
 ], optional = true }
 tokio = { version = "1.35.1", optional = true }
 serde_json = "1.0.114"
-futures = { version = "0.3.29", optional = true}
+futures = { version = "0.3.29", optional = true }
 http = "0.2.11"
 
 [features]
 finder = ["log", "ignore"]
 
 network_requests_common = []
-network_requests = ["dep:futures", "reqwest", "tokio", "tokio/rt", "network_requests_common"]
+network_requests = [
+  "dep:futures",
+  "reqwest",
+  "tokio",
+  "tokio/rt",
+  "network_requests_common",
+]
 network_requests_external = ["network_requests_common"]
 
 external_functions_ffi = []

--- a/crates/util/src/cursor_wrapper.rs
+++ b/crates/util/src/cursor_wrapper.rs
@@ -1,30 +1,34 @@
-use tree_sitter::{Node, TreeCursor};
-use tree_sitter_traversal::Cursor;
+use crate::node_with_source::NodeWithSource;
+use grit_util::AstCursor;
+use tree_sitter::TreeCursor;
 
-pub struct CursorWrapper<'a>(TreeCursor<'a>);
+pub struct CursorWrapper<'a> {
+    cursor: TreeCursor<'a>,
+    source: &'a str,
+}
 
-impl<'a> Cursor for CursorWrapper<'a> {
-    type Node = Node<'a>;
-
-    fn goto_first_child(&mut self) -> bool {
-        self.0.goto_first_child()
-    }
-
-    fn goto_parent(&mut self) -> bool {
-        self.0.goto_parent()
-    }
-
-    fn goto_next_sibling(&mut self) -> bool {
-        self.0.goto_next_sibling()
-    }
-
-    fn node(&self) -> Self::Node {
-        self.0.node()
+impl<'a> CursorWrapper<'a> {
+    pub fn new(cursor: TreeCursor<'a>, source: &'a str) -> Self {
+        Self { cursor, source }
     }
 }
 
-impl<'a> From<TreeCursor<'a>> for CursorWrapper<'a> {
-    fn from(value: TreeCursor<'a>) -> Self {
-        Self(value)
+impl<'a> AstCursor for CursorWrapper<'a> {
+    type Node = NodeWithSource<'a>;
+
+    fn goto_first_child(&mut self) -> bool {
+        self.cursor.goto_first_child()
+    }
+
+    fn goto_parent(&mut self) -> bool {
+        self.cursor.goto_parent()
+    }
+
+    fn goto_next_sibling(&mut self) -> bool {
+        self.cursor.goto_next_sibling()
+    }
+
+    fn node(&self) -> Self::Node {
+        NodeWithSource::new(self.cursor.node(), self.source)
     }
 }

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -5,9 +5,10 @@ pub mod cursor_wrapper;
 #[cfg(feature = "finder")]
 pub mod finder;
 pub mod hasher;
+pub mod node_with_source;
 pub mod position;
 pub mod print_node;
 pub mod rich_path;
+pub mod runtime;
 pub mod tree_sitter_util;
 pub mod url;
-pub mod runtime;

--- a/crates/util/src/node_with_source.rs
+++ b/crates/util/src/node_with_source.rs
@@ -1,19 +1,9 @@
+use grit_util::AstNode;
 use tree_sitter::Node;
-
-/// Represents an AST node and offers convenient AST-specific functionality.
-///
-/// This trait should be free from dependencies on TreeSitter.
-pub trait AstNode: Sized {
-    /// Returns the next node, ignoring trivia such as whitespace.
-    fn next_non_trivia_node(&self) -> Option<Self>;
-
-    /// Returns the previous node, ignoring trivia such as whitespace.
-    fn previous_non_trivia_node(&self) -> Option<Self>;
-}
 
 /// A TreeSitter node, including a reference to the source code from which it
 /// was parsed.
-pub(crate) struct NodeWithSource<'a> {
+pub struct NodeWithSource<'a> {
     pub node: Node<'a>,
     pub source: &'a str,
 }


### PR DESCRIPTION
This introduces a new crate with the traversal algorithm from `tree-sitter-traversal`. The source of the crate has been integrated so that even the optional TreeSitter dependency could be removed, and the `AstCursor` trait could be tied to our new `AstNode` trait, which has also been put in the same crate.

See previous discussion: https://github.com/getgrit/gritql/pull/85#discussion_r1541353476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `AstNode` and `AstCursor` traits for abstract syntax tree (AST) node representation and traversal.
	- Added new modules for handling AST nodes and their traversal, enhancing the library's functionality.
- **Refactor**
	- Updated various modules to use `grit_util` for node traversal, replacing previous implementations.
	- Reorganized imports and adjusted module paths and dependencies across multiple files.
	- Modified function calls and parameters to align with new `grit_util` traversal logic.
- **Chores**
	- Removed the `ast_node` module from public exports, streamlining the library's interface.
	- Added `node_with_source` and `runtime` modules to the public API, expanding the available utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->