### PR TITLE
chore: moved equivalence testing to `Binding`

### DIFF
--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -302,7 +302,7 @@ impl<'a> Binding<'a> {
         Self::Node(node.source, node.node)
     }
 
-    pub fn singleton(&self) -> Option<(&str, Node)> {
+    pub(crate) fn singleton(&self) -> Option<(&str, Node)> {
         match self {
             Binding::Node(src, node) => Some((src, node.to_owned())),
             Binding::List(src, parent_node, field_id) => {
@@ -485,6 +485,15 @@ impl<'a> Binding<'a> {
             Binding::String(source, _) => Some(source),
             Binding::List(source, _, _) => Some(source),
             Binding::FileName(..) | Binding::ConstantRef(..) => None,
+        }
+    }
+
+    /// Returns the constant this binding binds to, if and only if it is a constant binding.
+    pub fn as_constant(&self) -> Option<&Constant> {
+        if let Self::ConstantRef(constant) = self {
+            Some(constant)
+        } else {
+            None
         }
     }
 

--- a/crates/core/src/equivalence.rs
+++ b/crates/core/src/equivalence.rs
@@ -1,85 +1,78 @@
-use tree_sitter::Node;
-
 use crate::binding::Binding;
 use marzano_util::tree_sitter_util::children_by_field_id_count;
+use tree_sitter::Node;
 
-pub fn are_bindings_equivalent(binding1: &Binding, binding2: &Binding) -> bool {
-    // covers Node, and List with one element
-    if let Some(binding1) = binding1.singleton() {
-        if let Some(binding2) = binding2.singleton() {
-            return are_equivalent(binding1.0, &binding1.1, binding2.0, &binding2.1);
+impl<'a> Binding<'a> {
+    /// Checks whether two bindings are equivalent.
+    ///
+    /// Bindings are considered equivalent if they refer to the same thing.
+    pub fn is_equivalent_to(&self, other: &'a Binding) -> bool {
+        // covers Node, and List with one element
+        if let (Some(s1), Some(s2)) = (self.singleton(), other.singleton()) {
+            return are_equivalent(s1.0, &s1.1, s2.0, &s2.1);
         }
-    }
-    match binding1 {
-        // should never occur covered by singleton
-        Binding::Node(source1, node1) => match binding2 {
-            Binding::Node(source2, node2) => are_equivalent(source1, node1, source2, node2),
-            Binding::String(str, range) => {
-                str[range.start_byte as usize..range.end_byte as usize] == binding1.text()
+
+        match self {
+            // should never occur covered by singleton
+            Self::Node(source1, node1) => match other {
+                Self::Node(source2, node2) => are_equivalent(source1, node1, source2, node2),
+                Self::String(str, range) => {
+                    str[range.start_byte as usize..range.end_byte as usize] == self.text()
+                }
+                Self::FileName(_) | Self::List(..) | Self::Empty(..) | Self::ConstantRef(_) => {
+                    false
+                }
+            },
+            Self::List(source1, parent_node1, field1) => match other {
+                Self::List(source2, parent_node2, field2) => {
+                    let mut cursor1 = parent_node1.walk();
+                    let mut cursor2 = parent_node2.walk();
+                    children_by_field_id_count(parent_node1, *field1)
+                        == children_by_field_id_count(parent_node2, *field2)
+                        && parent_node1
+                            .children_by_field_id(*field1, &mut cursor1)
+                            .zip(parent_node2.children_by_field_id(*field2, &mut cursor2))
+                            .all(|(node1, node2)| are_equivalent(source1, &node1, source2, &node2))
+                }
+                Self::String(..)
+                | Self::FileName(_)
+                | Self::Node(..)
+                | Self::Empty(..)
+                | Self::ConstantRef(_) => false,
+            },
+            // I suspect matching kind is too strict
+            Self::Empty(_, node1, field1) => match other {
+                Self::Empty(_, node2, field2) => {
+                    node1.kind_id() == node2.kind_id() && field1 == field2
+                }
+                Self::String(..)
+                | Self::FileName(_)
+                | Self::Node(..)
+                | Self::List(..)
+                | Self::ConstantRef(_) => false,
+            },
+            Self::ConstantRef(c1) => other.as_constant().map_or(false, |c2| *c1 == c2),
+            Self::String(s1, range) => {
+                s1[range.start_byte as usize..range.end_byte as usize] == other.text()
             }
-            Binding::FileName(_)
-            | Binding::List(..)
-            | Binding::Empty(..)
-            | Binding::ConstantRef(_) => false,
-        },
-        Binding::List(source1, parent_node1, field1) => match binding2 {
-            Binding::List(source2, parent_node2, field2) => {
-                let mut cursor1 = parent_node1.walk();
-                let mut cursor2 = parent_node2.walk();
-                children_by_field_id_count(parent_node1, *field1)
-                    == children_by_field_id_count(parent_node2, *field2)
-                    && parent_node1
-                        .children_by_field_id(*field1, &mut cursor1)
-                        .zip(parent_node2.children_by_field_id(*field2, &mut cursor2))
-                        .all(|(node1, node2)| are_equivalent(source1, &node1, source2, &node2))
-            }
-            Binding::String(..)
-            | Binding::FileName(_)
-            | Binding::Node(..)
-            | Binding::Empty(..)
-            | Binding::ConstantRef(_) => false,
-        },
-        // I suspect matching kind is too strict
-        Binding::Empty(_, node1, field1) => match binding2 {
-            Binding::Empty(_, node2, field2) => {
-                node1.kind_id() == node2.kind_id() && field1 == field2
-            }
-            Binding::String(..)
-            | Binding::FileName(_)
-            | Binding::Node(..)
-            | Binding::List(..)
-            | Binding::ConstantRef(_) => false,
-        },
-        Binding::ConstantRef(c1) => match binding2 {
-            Binding::ConstantRef(c2) => c1 == c2,
-            Binding::String(..)
-            | Binding::FileName(_)
-            | Binding::Node(..)
-            | Binding::List(..)
-            | Binding::Empty(..) => false,
-        },
-        Binding::String(s1, range) => {
-            s1[range.start_byte as usize..range.end_byte as usize] == binding2.text()
+            Self::FileName(s1) => other.as_filename().map_or(false, |s2| *s1 == s2),
         }
-        Binding::FileName(s1) => binding2.as_filename().map_or(false, |s2| *s1 == s2),
     }
 }
 
-/**
- * Checks whether two nodes are equivalent.
- *
- * We define two nodes to be equivalent if they have the same sort (kind) and
- * equivalent named fields.
- *
- * TODO: Improve performance. Equivalence checks happen often so we want them to
- * be fast. The current implementation requires a traversal of the tree on all
- * named fields, which can be slow for large nodes. It also creates a cursor
- * at each traversal step.
- *
- * Potential improvements:
- * 1. Use cursors that are passed as arguments -- not clear if this would be faster.
- * 2. Precompute hashes on all nodes, which define the equivalence relation. The check then becomes O(1).
- */
+/// Checks whether two nodes are equivalent.
+///
+/// We define two nodes to be equivalent if they have the same sort (kind) and
+/// equivalent named fields.
+///
+/// TODO: Improve performance. Equivalence checks happen often so we want them to
+/// be fast. The current implementation requires a traversal of the tree on all
+/// named fields, which can be slow for large nodes. It also creates a cursor
+/// at each traversal step.
+///
+/// Potential improvements:
+/// 1. Use cursors that are passed as arguments -- not clear if this would be faster.
+/// 2. Precompute hashes on all nodes, which define the equivalence relation. The check then becomes O(1).
 pub fn are_equivalent(source1: &str, node1: &Node, source2: &str, node2: &Node) -> bool {
     // If the source is identical, we consider the nodes equivalent.
     // This covers most cases of constant nodes.

--- a/crates/core/src/pattern/accessor.rs
+++ b/crates/core/src/pattern/accessor.rs
@@ -1,7 +1,3 @@
-use std::{borrow::Cow, collections::BTreeMap};
-
-use crate::{binding::Constant, context::Context, equivalence::are_bindings_equivalent};
-
 use super::{
     compiler::CompilationContext,
     container::{Container, PatternOrResolved, PatternOrResolvedMut},
@@ -11,8 +7,10 @@ use super::{
     state::State,
     variable::{Variable, VariableSourceLocations},
 };
+use crate::{binding::Constant, context::Context};
 use anyhow::{anyhow, bail, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
+use std::{borrow::Cow, collections::BTreeMap};
 use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
@@ -200,7 +198,7 @@ pub(crate) fn execute_resolved_with_binding<'a>(
     if let ResolvedPattern::Binding(r) = r {
         if let ResolvedPattern::Binding(b) = binding {
             if let (Some(r), Some(b)) = (r.last(), b.last()) {
-                return Ok(are_bindings_equivalent(r, b));
+                return Ok(r.is_equivalent_to(b));
             } else {
                 bail!("Resolved pattern missing binding")
             }

--- a/crates/core/src/pattern/variable.rs
+++ b/crates/core/src/pattern/variable.rs
@@ -5,7 +5,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{binding::Binding, context::Context, equivalence::are_bindings_equivalent};
+use crate::{binding::Binding, context::Context};
 use anyhow::{bail, Result};
 use core::fmt::Debug;
 use im::vector;
@@ -137,7 +137,7 @@ impl Variable {
                             if let (Some(var_binding), Some(binding)) =
                                 (bindings.last(), cur_bindings.last())
                             {
-                                if !are_bindings_equivalent(var_binding, binding) {
+                                if !var_binding.is_equivalent_to(binding) {
                                     return Ok(Some(false));
                                 }
                                 let value_history = &mut variable_content.value_history;


### PR DESCRIPTION
Moved `are_bindings_equivalent()` to `Binding::is_equivalent_to()`.

Also created a little `Binding::as_constant()` helper in alignment with `as_filename()` and `as_node()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the internal logic for binding equivalence checks, enhancing clarity and maintainability.
	- Updated method calls related to binding equivalence to use a more encapsulated approach.
- **Chores**
	- Cleaned up import statements in the pattern accessor logic for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->