### PR TITLE
chore: add `Binding::parent_node()`

### DIFF
--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -515,6 +515,18 @@ impl<'a> Binding<'a> {
         }
     }
 
+    /// Returns the parent node of this binding.
+    ///
+    /// Returns `None` if the binding has no relation to a node.
+    pub(crate) fn parent_node(&self) -> Option<NodeWithSource<'a>> {
+        match self {
+            Self::Node(src, node) => node.parent().map(|parent| NodeWithSource::new(parent, src)),
+            Self::List(src, node, _) => Some(NodeWithSource::new(node.clone(), src)),
+            Self::Empty(src, node, _) => Some(NodeWithSource::new(node.clone(), src)),
+            Self::String(..) | Self::FileName(..) | Self::ConstantRef(..) => None,
+        }
+    }
+
     pub fn is_truthy(&self) -> bool {
         match self {
             Self::Empty(..) => false,

--- a/crates/core/src/pattern/within.rs
+++ b/crates/core/src/pattern/within.rs
@@ -5,7 +5,7 @@ use super::{
     variable::VariableSourceLocations,
     State,
 };
-use crate::{binding::Binding, context::Context, resolve};
+use crate::{context::Context, resolve};
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use marzano_language::parent_traverse::{ParentTraverse, TreeSitterParentCursor};
@@ -82,25 +82,13 @@ impl Matcher for Within {
             return Ok(did_match);
         };
 
-        let (src, node) = match binding {
-            Binding::Node(src, node) => (
-                src,
-                if let Some(node) = node.parent() {
-                    node
-                } else {
-                    return Ok(did_match);
-                },
-            ),
-            Binding::String(_, _) => return Ok(did_match),
-            Binding::List(src, node, _) => (src, node.to_owned()),
-            Binding::Empty(src, node, _) => (src, node.to_owned()),
-            Binding::FileName(_) => return Ok(did_match),
-            Binding::ConstantRef(_) => return Ok(did_match),
+        let Some(node) = binding.parent_node() else {
+            return Ok(did_match);
         };
-        for n in ParentTraverse::new(TreeSitterParentCursor::new(node)) {
+        for n in ParentTraverse::new(TreeSitterParentCursor::new(node.node)) {
             let state = cur_state.clone();
             if self.pattern.execute(
-                &ResolvedPattern::from_node(src, n),
+                &ResolvedPattern::from_node(node.source, n),
                 &mut cur_state,
                 context,
                 logs,


### PR DESCRIPTION
Used inside `Within`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to access the parent node of a binding, enhancing navigation and pattern execution capabilities.
- **Refactor**
	- Improved the handling of bindings within patterns for more accurate node traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->