### PR TITLE
fix: handle empty lines for languages with semantic whitespace

### DIFF
--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -103,6 +103,17 @@ fn pad_snippet(padding: &str, snippet: &str) -> String {
     result
 }
 
+fn adjust_ranges(substitutions: &mut [(EffectRange, String)], index: usize, delta: isize) {
+    for (EffectRange { range, .. }, _) in substitutions.iter_mut() {
+        if range.start >= index {
+            range.start = (range.start as isize + delta) as usize;
+        }
+        if range.end >= index {
+            range.end = (range.end as isize + delta) as usize;
+        }
+    }
+}
+
 // in multiline snippets, remove padding from every line equal to the padding of the first line,
 // such that the first line is left-aligned.
 pub(crate) fn adjust_padding<'a>(
@@ -136,14 +147,11 @@ pub(crate) fn adjust_padding<'a>(
         for line in lines {
             result.push('\n');
             index += 1;
-            for (EffectRange { range, .. }, _) in substitutions.iter_mut() {
-                if range.start >= index {
-                    range.start = (range.start as isize + delta) as usize;
-                }
-                if range.end >= index {
-                    range.end = (range.end as isize + delta) as usize;
-                }
+            if line.trim().is_empty() {
+                adjust_ranges(substitutions, index, -(line.len() as isize));
+                continue;
             }
+            adjust_ranges(substitutions, index, delta);
             let line = line.strip_prefix(&padding).ok_or_else(|| {
                 anyhow!(
                     "expected line \n{}\n to start with {} spaces, code is either not indented with spaces, or does not consistently indent code blocks",

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -12885,3 +12885,34 @@ fn limit_export_default_match() {
     })
     .unwrap();
 }
+
+#[test]
+fn python_support_empty_line() {
+    run_test_expected(TestArgExpected {
+        pattern: r#"
+            |engine marzano(0.1)
+            |language python
+            |`class $name: $body` => $body
+            |"#
+        .trim_margin()
+        .unwrap(),
+        source: r#"
+            |class MyClass:
+            |    def function(self):
+            |        result = 1 + 1
+            |
+            |        return result
+            |"#
+        .trim_margin()
+        .unwrap(),
+        expected: r#"
+        |def function(self):
+        |    result = 1 + 1
+        |
+        |    return result
+        |"#
+        .trim_margin()
+        .unwrap(),
+    })
+    .unwrap();
+}


### PR DESCRIPTION
fixes: https://github.com/getgrit/gritql/issues/84
lines containing only whitespace will be rewritten as empty lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved modularity and readability of range adjustments in code.
- **Tests**
	- Added tests for Python support with empty lines in code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->