### PR TITLE
chore: implement `Binding::list_items()`

### DIFF
--- a/crates/core/src/pattern/some.rs
+++ b/crates/core/src/pattern/some.rs
@@ -1,8 +1,3 @@
-use anyhow::{anyhow, Result};
-use im::vector;
-
-use crate::{binding::Binding, context::Context, resolve};
-
 use super::{
     compiler::CompilationContext,
     patterns::{Matcher, Name, Pattern},
@@ -10,6 +5,9 @@ use super::{
     variable::VariableSourceLocations,
     State,
 };
+use crate::{context::Context, resolve};
+use anyhow::{anyhow, Result};
+use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
 use tree_sitter::Node;
@@ -67,37 +65,27 @@ impl Matcher for Some {
         match binding {
             ResolvedPattern::Binding(bindings) => {
                 let binding = resolve!(bindings.last());
+                let Some(list_items) = binding.list_items() else {
+                    return Ok(false);
+                };
+
                 let mut did_match = false;
-                let pattern = &self.pattern;
-                match binding {
-                    Binding::Empty(_, _, _) => Ok(false),
-                    Binding::Node(_, _node) => Ok(false),
-                    Binding::String(_, _) => Ok(false),
-                    Binding::List(src, node, field_id) => {
-                        let mut cur_state = init_state.clone();
-                        let mut cursor = node.walk();
-                        let children = node
-                            .children_by_field_id(*field_id, &mut cursor)
-                            .filter(|c| c.is_named());
-                        for child in children {
-                            let state = cur_state.clone();
-                            if pattern.execute(
-                                &ResolvedPattern::from_node(src, child),
-                                &mut cur_state,
-                                context,
-                                logs,
-                            )? {
-                                did_match = true;
-                            } else {
-                                cur_state = state;
-                            }
-                        }
-                        *init_state = cur_state;
-                        Ok(did_match)
+                let mut cur_state = init_state.clone();
+                for item in list_items {
+                    let state = cur_state.clone();
+                    if self.pattern.execute(
+                        &ResolvedPattern::from_node(item.source, item.node),
+                        &mut cur_state,
+                        context,
+                        logs,
+                    )? {
+                        did_match = true;
+                    } else {
+                        cur_state = state;
                     }
-                    Binding::ConstantRef(_) => Ok(false),
-                    Binding::FileName(_) => Ok(false),
                 }
+                *init_state = cur_state;
+                Ok(did_match)
             }
             ResolvedPattern::List(elements) => {
                 let pattern = &self.pattern;


### PR DESCRIPTION
Implemented `Binding::list_items()` and used it in `Every`, `List` and `Some`.

Also ran into one more case that could be covered by `Binding::singleton()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to iterate over items in a list through the `list_items` method for enhanced list handling.
- **Refactor**
	- Improved pattern matching logic for better clarity and efficiency, particularly in handling list items.
	- Optimized the handling of bindings and list items across various matchers to ensure accurate pattern execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->