### PR TITLE
chore: use `NodeWithContainer` in `ResolvedPattern::from_node()` + more `Binding::list_items()` usage

### DIFF
--- a/crates/core/src/pattern/after.rs
+++ b/crates/core/src/pattern/after.rs
@@ -103,7 +103,7 @@ impl Matcher for After {
         };
         let prev_node = resolve!(node.previous_non_trivia_node());
         if !self.after.execute(
-            &ResolvedPattern::from_node(prev_node.source, prev_node.node),
+            &ResolvedPattern::from_node(prev_node),
             &mut cur_state,
             context,
             logs,

--- a/crates/core/src/pattern/ast_node.rs
+++ b/crates/core/src/pattern/ast_node.rs
@@ -203,7 +203,7 @@ impl Matcher for ASTNode {
                 )
             } else if let Some(child) = node.child_by_field_id(*field_id) {
                 pattern.execute(
-                    &ResolvedPattern::from_node(source, child),
+                    &ResolvedPattern::from_node(NodeWithSource::new(child, source)),
                     &mut cur_state,
                     context,
                     logs,

--- a/crates/core/src/pattern/before.rs
+++ b/crates/core/src/pattern/before.rs
@@ -103,7 +103,7 @@ impl Matcher for Before {
         };
         let next_node = resolve!(node.next_non_trivia_node());
         if !self.before.execute(
-            &ResolvedPattern::from_node(next_node.source, next_node.node),
+            &ResolvedPattern::from_node(next_node),
             &mut cur_state,
             context,
             logs,

--- a/crates/core/src/pattern/contains.rs
+++ b/crates/core/src/pattern/contains.rs
@@ -11,7 +11,7 @@ use super::{
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use im::vector;
-use marzano_util::analysis_logs::AnalysisLogs;
+use marzano_util::{analysis_logs::AnalysisLogs, node_with_source::NodeWithSource};
 
 use std::collections::BTreeMap;
 
@@ -86,7 +86,7 @@ fn execute_until<'a>(
     let mut still_computing = true;
     while still_computing {
         let node = cursor.node();
-        let node_lhs = ResolvedPattern::from_node(src, node);
+        let node_lhs = ResolvedPattern::from_node(NodeWithSource::new(node, src));
 
         let state = cur_state.clone();
         if the_contained.execute(&node_lhs, &mut cur_state, context, logs)? {
@@ -137,50 +137,43 @@ impl Matcher for Contains {
         match resolved_pattern {
             ResolvedPattern::Binding(bindings) => {
                 let binding = resolve!(bindings.last());
-                let mut did_match = false;
-                let mut cur_state = init_state.clone();
-                let mut cursor; // needed for scope in case of list.
-                match binding {
-                    Binding::Empty(_, _, _) => Ok(false),
-                    Binding::String(_, _) => Ok(false),
-                    Binding::Node(src, node) => execute_until(
+                if let Some(node) = binding.as_node() {
+                    execute_until(
                         init_state,
-                        node,
-                        src,
+                        &node.node,
+                        node.source,
                         context,
                         logs,
                         &self.contains,
                         &self.until,
-                    ),
-                    Binding::List(src, node, field_id) => {
-                        cursor = node.walk();
-                        let children = node.children_by_field_id(*field_id, &mut cursor);
-
-                        for child in children {
-                            let state = cur_state.clone();
-                            if self.execute(
-                                &ResolvedPattern::from_node(src, child),
-                                &mut cur_state,
-                                context,
-                                logs,
-                            )? {
-                                did_match = true;
-                            } else {
-                                cur_state = state;
-                            }
+                    )
+                } else if let Some(list_items) = binding.list_items() {
+                    let mut did_match = false;
+                    let mut cur_state = init_state.clone();
+                    for item in list_items {
+                        let state = cur_state.clone();
+                        if self.execute(
+                            &ResolvedPattern::from_node(item),
+                            &mut cur_state,
+                            context,
+                            logs,
+                        )? {
+                            did_match = true;
+                        } else {
+                            cur_state = state;
                         }
-
-                        if did_match {
-                            *init_state = cur_state;
-                        }
-                        Ok(did_match)
                     }
-                    Binding::FileName(_) => Ok(false),
+
+                    if did_match {
+                        *init_state = cur_state;
+                    }
+                    Ok(did_match)
+                } else if let Some(_c) = binding.as_constant() {
                     // this seems like an infinite loop, todo return false?
-                    Binding::ConstantRef(_c) => {
-                        self.contains
-                            .execute(resolved_pattern, init_state, context, logs)
-                    }
+                    self.contains
+                        .execute(resolved_pattern, init_state, context, logs)
+                } else {
+                    Ok(false)
                 }
             }
             ResolvedPattern::List(elements) => {

--- a/crates/core/src/pattern/every.rs
+++ b/crates/core/src/pattern/every.rs
@@ -73,7 +73,7 @@ impl Matcher for Every {
 
                 for item in list_items {
                     if !self.pattern.execute(
-                        &ResolvedPattern::from_node(item.source, item.node),
+                        &ResolvedPattern::from_node(item),
                         init_state,
                         context,
                         logs,

--- a/crates/core/src/pattern/list.rs
+++ b/crates/core/src/pattern/list.rs
@@ -126,7 +126,8 @@ impl Matcher for List {
                 };
 
                 let children: Vec<Cow<ResolvedPattern>> = list_items
-                    .map(|node| Cow::Owned(ResolvedPattern::from_node(node.source, node.node)))
+                    .map(ResolvedPattern::from_node)
+                    .map(Cow::Owned)
                     .collect();
 
                 execute_assoc(&self.patterns, &children, state, context, logs)

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -17,7 +17,9 @@ use crate::{
 use anyhow::{anyhow, bail, Result};
 use im::{vector, Vector};
 use marzano_language::{language::FieldId, target_language::TargetLanguage};
-use marzano_util::{analysis_logs::AnalysisLogs, position::Range};
+use marzano_util::{
+    analysis_logs::AnalysisLogs, node_with_source::NodeWithSource, position::Range,
+};
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
@@ -478,8 +480,8 @@ impl<'a> ResolvedPattern<'a> {
         Self::Binding(vector![Binding::ConstantRef(constant)])
     }
 
-    pub(crate) fn from_node(src: &'a str, node: Node<'a>) -> Self {
-        Self::Binding(vector![Binding::Node(src, node)])
+    pub(crate) fn from_node(node: NodeWithSource<'a>) -> Self {
+        Self::Binding(vector![Binding::Node(node.source, node.node)])
     }
 
     pub(crate) fn from_list(src: &'a str, node: Node<'a>, field_id: FieldId) -> Self {

--- a/crates/core/src/pattern/some.rs
+++ b/crates/core/src/pattern/some.rs
@@ -74,7 +74,7 @@ impl Matcher for Some {
                 for item in list_items {
                     let state = cur_state.clone();
                     if self.pattern.execute(
-                        &ResolvedPattern::from_node(item.source, item.node),
+                        &ResolvedPattern::from_node(item),
                         &mut cur_state,
                         context,
                         logs,

--- a/crates/core/src/pattern/within.rs
+++ b/crates/core/src/pattern/within.rs
@@ -9,7 +9,7 @@ use crate::{context::Context, resolve};
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use marzano_language::parent_traverse::{ParentTraverse, TreeSitterParentCursor};
-use marzano_util::analysis_logs::AnalysisLogs;
+use marzano_util::{analysis_logs::AnalysisLogs, node_with_source::NodeWithSource};
 use std::collections::BTreeMap;
 use tree_sitter::Node;
 
@@ -88,7 +88,7 @@ impl Matcher for Within {
         for n in ParentTraverse::new(TreeSitterParentCursor::new(node.node)) {
             let state = cur_state.clone();
             if self.pattern.execute(
-                &ResolvedPattern::from_node(node.source, n),
+                &ResolvedPattern::from_node(NodeWithSource::new(n, node.source)),
                 &mut cur_state,
                 context,
                 logs,


### PR DESCRIPTION
With this PR I converted a few more places to use `Binding::list_items()`.

It also became easier to use `NodeWithContainer` in `ResolvedPattern::from_node()`, which is a small step towards making sure `ResolvedPattern` also doesn't depend on `Node` directly anymore. In a later follow-up `NodeWithContainer` will probably be swapped for `impl AstNode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified argument passing in various pattern matching implementations, enhancing code clarity and reducing complexity.
	- Improved efficiency in handling list items and bindings within built-in functions and matchers.
	- Streamlined the usage of `ResolvedPattern::from_node` across multiple modules for more consistent and simplified code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->