### PR TITLE
perf: optimize `is_binding_suppressed()`

### DIFF
--- a/crates/core/src/pattern/state.rs
+++ b/crates/core/src/pattern/state.rs
@@ -246,9 +246,7 @@ impl<'a> State<'a> {
                     if let ResolvedPattern::Binding(bindings) = value {
                         for binding in bindings.iter() {
                             bindings_count += 1;
-                            if is_binding_suppressed(binding, lang, current_name)
-                                .unwrap_or_default()
-                            {
+                            if is_binding_suppressed(binding, lang, current_name) {
                                 suppressed_count += 1;
                                 continue;
                             }

--- a/crates/core/src/suppress.rs
+++ b/crates/core/src/suppress.rs
@@ -1,3 +1,4 @@
+use itertools::{EitherOrBoth, Itertools};
 use marzano_language::{
     language::Language,
     parent_traverse::{ParentTraverse, TreeSitterParentCursor},
@@ -5,21 +6,17 @@ use marzano_language::{
 use tree_sitter::{Node, Range};
 
 use crate::binding::Binding;
-use crate::resolve;
-use anyhow::Result;
 
 pub(crate) fn is_binding_suppressed(
     binding: &Binding,
     lang: &impl Language,
     current_name: Option<&str>,
-) -> Result<bool> {
+) -> bool {
     let (src, node) = match binding {
-        Binding::Node(src, node) => (src, node),
-        Binding::String(_, _) => return Ok(false),
-        Binding::List(src, node, _) => (src, node),
-        Binding::Empty(src, node, _) => (src, node),
-        Binding::FileName(_) => return Ok(false),
-        Binding::ConstantRef(_) => return Ok(false),
+        Binding::Node(src, node) | Binding::List(src, node, _) | Binding::Empty(src, node, _) => {
+            (src, node)
+        }
+        Binding::String(_, _) | Binding::FileName(_) | Binding::ConstantRef(_) => return false,
     };
     let target_range = node.range();
     for n in
@@ -34,13 +31,13 @@ pub(crate) fn is_binding_suppressed(
             if !(lang.is_comment(c.kind_id()) || lang.is_comment_wrapper(&c)) {
                 continue;
             }
-            if is_suppress_comment(&c, src, &target_range, current_name, lang)? {
-                return Ok(true);
+            if is_suppress_comment(&c, src, &target_range, current_name, lang) {
+                return true;
             }
         }
     }
 
-    Ok(false)
+    false
 }
 
 fn is_suppress_comment(
@@ -49,28 +46,30 @@ fn is_suppress_comment(
     target_range: &Range,
     current_name: Option<&str>,
     lang: &impl Language,
-) -> Result<bool> {
+) -> bool {
     let child_range = comment_node.range();
-    let text = comment_node.utf8_text(src.as_bytes())?;
+    let Ok(text) = comment_node.utf8_text(src.as_bytes()) else {
+        return false;
+    };
     let inline_suppress = child_range.end_point().row() >= target_range.start_point().row()
         && child_range.end_point().row() <= target_range.end_point().row();
     if !inline_suppress {
-        let pre_suppress = comment_applies_to_range(comment_node, target_range, lang, src)?
-            && comment_occupies_entire_line(text.as_ref(), &comment_node.range(), src)?;
+        let pre_suppress = comment_applies_to_range(comment_node, target_range, lang, src)
+            && comment_occupies_entire_line(text.as_ref(), &comment_node.range(), src);
         if !pre_suppress {
-            return Ok(false);
+            return false;
         }
     }
     if !text.contains("grit-ignore") {
-        return Ok(false);
+        return false;
     }
     let comment_text = text.trim();
-    let ignore_spec = match comment_text.split("grit-ignore").collect::<Vec<_>>().get(1) {
-        Some(s) => match s.split(':').next() {
+    let ignore_spec = match comment_text.split_once("grit-ignore") {
+        Some((_, s)) => match s.split(':').next() {
             Some(s) => s.trim(),
-            None => return Ok(true),
+            None => return true,
         },
-        None => return Ok(true),
+        None => return true,
     };
     if ignore_spec.is_empty()
         || ignore_spec
@@ -78,13 +77,15 @@ fn is_suppress_comment(
             .next()
             .is_some_and(|c| !c.is_alphanumeric() && c != '_')
     {
-        return Ok(true);
+        return true;
     }
     let Some(current_name) = current_name else {
-        return Ok(false);
+        return false;
     };
-    let ignored_rules = ignore_spec.split(',').map(|s| s.trim()).collect::<Vec<_>>();
-    Ok(ignored_rules.contains(&current_name))
+    ignore_spec
+        .split(',')
+        .map(str::trim)
+        .contains(&current_name)
 }
 
 fn comment_applies_to_range(
@@ -92,28 +93,31 @@ fn comment_applies_to_range(
     range: &Range,
     lang: &impl Language,
     src: &str,
-) -> Result<bool> {
-    let mut applicable = resolve!(comment_node.next_named_sibling());
+) -> bool {
+    let Some(mut applicable) = comment_node.next_named_sibling() else {
+        return false;
+    };
     while let Some(next) = applicable.next_named_sibling() {
         if !lang.is_comment(applicable.kind_id())
             && !lang.is_comment_wrapper(&applicable)
             // Some languages have significant whitespace; continue until we find a non-whitespace non-comment node
-            && !applicable.utf8_text(src.as_bytes())?.trim().is_empty()
+            && !applicable.utf8_text(src.as_bytes()).map_or(true, |text| text.trim().is_empty())
         {
             break;
         }
         applicable = next;
     }
     let applicable_range = applicable.range();
-    Ok(applicable_range.start_point().row() == range.start_point().row())
+    applicable_range.start_point().row() == range.start_point().row()
 }
 
-fn comment_occupies_entire_line(text: &str, range: &Range, src: &str) -> Result<bool> {
-    let code = src
-        .lines()
+fn comment_occupies_entire_line(text: &str, range: &Range, src: &str) -> bool {
+    src.lines()
         .skip(range.start_point().row() as usize)
         .take((range.end_point().row() - range.start_point().row() + 1) as usize)
-        .collect::<Vec<_>>()
-        .join("\n");
-    Ok(code.trim() == text.trim())
+        .zip_longest(text.split("\n"))
+        .all(|zipped| match zipped {
+            EitherOrBoth::Both(src_line, text_line) => src_line.trim() == text_line.trim(),
+            _ => false,
+        })
 }


### PR DESCRIPTION
Got a little side-tracked... this one is for fun :)

This optimizes `is_binding_suppressed()` to eliminate unnecessary allocations. Also made the function infallible for simplicity's sake: One out of 2 call sites already ignored potential errors anyway, and it looks safe to ignore in general.

Will have a little conflict with https://github.com/getgrit/gritql/pull/104, but decided to still put in a separate PR so you can judge separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified logic for checking binding suppression across different components for improved performance and readability.
	- Streamlined the approach for filtering effects based on binding suppression, enhancing code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->