### PR TITLE
chore: move `node_text()` to `AstNode::text()`

### DIFF
--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -3,6 +3,7 @@ use crate::pattern::resolved_pattern::CodeRange;
 use crate::pattern::state::{get_top_level_effects, FileRegistry};
 use crate::pattern::{Effect, EffectKind};
 use anyhow::{anyhow, Result};
+use grit_util::AstNode;
 use marzano_language::language::{FieldId, Language};
 use marzano_language::target_language::TargetLanguage;
 use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
@@ -461,7 +462,9 @@ impl<'a> Binding<'a> {
     pub fn text(&self) -> String {
         match self {
             Binding::Empty(_, _, _) => "".to_string(),
-            Binding::Node(source, node) => node_text(source, node).to_string(),
+            Binding::Node(source, node) => {
+                NodeWithSource::new(node.clone(), source).text().to_string()
+            }
             Binding::String(s, r) => s[r.start_byte as usize..r.end_byte as usize].into(),
             Binding::FileName(s) => s.to_string_lossy().into(),
             Binding::List(source, _, _) => {
@@ -471,13 +474,7 @@ impl<'a> Binding<'a> {
                     "".to_string()
                 }
             }
-            Binding::ConstantRef(c) => match c {
-                Constant::Boolean(b) => b.to_string(),
-                Constant::String(s) => s.to_string(),
-                Constant::Integer(i) => i.to_string(),
-                Constant::Float(d) => d.to_string(),
-                Constant::Undefined => String::new(),
-            },
+            Binding::ConstantRef(c) => c.to_string(),
         }
     }
 
@@ -614,9 +611,4 @@ impl<'a> Binding<'a> {
 
         Ok(())
     }
-}
-
-pub(crate) fn node_text<'a>(source: &'a str, node: &Node) -> &'a str {
-    let range = Range::from(node.range());
-    &source[range.start_byte as usize..range.end_byte as usize]
 }

--- a/crates/grit-util/src/ast_node.rs
+++ b/crates/grit-util/src/ast_node.rs
@@ -7,4 +7,7 @@ pub trait AstNode: Sized {
 
     /// Returns the previous node, ignoring trivia such as whitespace.
     fn previous_non_trivia_node(&self) -> Option<Self>;
+
+    /// Returns the text representation of the node.
+    fn text(&self) -> &str;
 }

--- a/crates/util/src/node_with_source.rs
+++ b/crates/util/src/node_with_source.rs
@@ -1,3 +1,4 @@
+use crate::position::Range;
 use grit_util::AstNode;
 use tree_sitter::Node;
 
@@ -33,5 +34,10 @@ impl<'a> AstNode for NodeWithSource<'a> {
             }
             current_node = current_node.parent()?;
         }
+    }
+
+    fn text(&self) -> &str {
+        let range = Range::from(self.node.range());
+        &self.source[range.start_byte as usize..range.end_byte as usize]
     }
 }


### PR DESCRIPTION
Turns `node_text()` into a trait method for `AstNode`.

Also found another case that could be simplified with `Binding::singleton()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified handling and text extraction logic for bindings in the core functionality.
- **New Features**
	- Enhanced pattern matching capabilities for string constants.
- **Enhancements**
	- Introduced new methods for improved text representation of nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->