### PR TITLE
fix: run code quality on both push, and pull requests

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,5 +1,9 @@
 name: code quality
-on: "push"
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 concurrency:
   group: ${{ github.workflow }}-${{ (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
code quality was not running on pull requests from third party contributors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the code quality workflow to trigger only for actions on the `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->