### PR TITLE
refactor: simplify list bindings

### DIFF
--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -531,7 +531,7 @@ impl<'a> Binding<'a> {
     /// Returns an iterator over the items in a list.
     ///
     /// Returns `None` if the binding is not bound to a list.
-    pub(crate) fn list_items(&self) -> Option<impl Iterator<Item = NodeWithSource<'a>>> {
+    pub(crate) fn list_items(&self) -> Option<impl Iterator<Item = NodeWithSource<'a>> + Clone> {
         match self {
             Self::List(src, node, field_id) => {
                 let field_id = *field_id;

--- a/crates/core/src/pattern/contains.rs
+++ b/crates/core/src/pattern/contains.rs
@@ -1,12 +1,11 @@
-use crate::{binding::Binding, context::Context, resolve};
-
 use super::{
     compiler::CompilationContext,
     patterns::{Matcher, Name, Pattern},
-    resolved_pattern::{LazyBuiltIn, ListBinding, Lists, ResolvedPattern, ResolvedSnippet},
+    resolved_pattern::{LazyBuiltIn, ResolvedPattern, ResolvedSnippet},
     variable::VariableSourceLocations,
     Node, State,
 };
+use crate::{context::Context, resolve};
 
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
@@ -270,18 +269,7 @@ impl Matcher for Contains {
                             ResolvedPattern::Binding(vector![b.to_owned()])
                         }
                         ResolvedSnippet::LazyFn(l) => match &**l {
-                            LazyBuiltIn::Join(j) => match &j.list {
-                                Lists::Binding(ListBinding {
-                                    src,
-                                    parent_node,
-                                    field,
-                                }) => ResolvedPattern::Binding(vector![Binding::List(
-                                    src,
-                                    parent_node.to_owned(),
-                                    *field
-                                )]),
-                                Lists::Resolved(l) => ResolvedPattern::List(l.to_owned()),
-                            },
+                            LazyBuiltIn::Join(j) => ResolvedPattern::List(j.list.clone()),
                         },
                     };
                     if self.execute(&resolved, &mut cur_state, context, logs)? {

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -12,8 +12,7 @@ use crate::binding::{Binding, Constant};
 use crate::context::Context;
 use crate::resolve_opt;
 use anyhow::{anyhow, bail, Result};
-use im::vector;
-use marzano_util::{analysis_logs::AnalysisLogs, tree_sitter_util::named_children_by_field_id};
+use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
 use tree_sitter::Node;
 
@@ -129,21 +128,16 @@ impl ListIndex {
                     Ok(l.get(index).map(PatternOrResolved::Pattern))
                 }
                 Some(PatternOrResolved::Resolved(ResolvedPattern::Binding(b))) => {
-                    let binding = b
+                    let mut list_items = b
                         .last()
+                        .and_then(Binding::list_items)
                         .ok_or_else(|| anyhow!("left side of a listIndex must be a list"))?;
-                    if let Binding::List(src, node, field) = binding {
-                        let mut cursor = node.walk();
-                        let len = named_children_by_field_id(node, &mut cursor, *field).count();
-                        let mut list = named_children_by_field_id(node, &mut cursor, *field);
-                        let index = resolve_opt!(to_unsigned(index, len));
-                        return Ok(list.nth(index).map(|n| {
-                            PatternOrResolved::ResolvedBinding(ResolvedPattern::Binding(vector![
-                                Binding::Node(src, n)
-                            ]))
-                        }));
-                    }
-                    bail!("left side of a listIndex must be a list")
+
+                    let len = list_items.clone().count();
+                    let index = resolve_opt!(to_unsigned(index, len));
+                    return Ok(list_items.nth(index).map(|n| {
+                        PatternOrResolved::ResolvedBinding(ResolvedPattern::from_node(n))
+                    }));
                 }
                 Some(PatternOrResolved::Resolved(ResolvedPattern::List(l))) => {
                     let index = resolve_opt!(to_unsigned(index, l.len()));
@@ -167,19 +161,16 @@ impl ListIndex {
                     Ok(l.get(index).map(PatternOrResolvedMut::Pattern))
                 }
                 Some(PatternOrResolvedMut::Resolved(ResolvedPattern::Binding(b))) => {
-                    let binding = b
+                    let mut list_items = b
                         .last()
+                        .and_then(Binding::list_items)
                         .ok_or_else(|| anyhow!("left side of a listIndex must be a list"))?;
-                    if let Binding::List(_src, node, field) = binding {
-                        let mut cursor = node.walk();
-                        let len = named_children_by_field_id(node, &mut cursor, *field).count();
-                        let mut list = named_children_by_field_id(node, &mut cursor, *field);
-                        let index = resolve_opt!(to_unsigned(index, len));
-                        return Ok(list
-                            .nth(index)
-                            .map(|_n| PatternOrResolvedMut::_ResolvedBinding));
-                    }
-                    bail!("left side of a listIndex must be a list")
+
+                    let len = list_items.clone().count();
+                    let index = resolve_opt!(to_unsigned(index, len));
+                    return Ok(list_items
+                        .nth(index)
+                        .map(|_| PatternOrResolvedMut::_ResolvedBinding));
                 }
                 Some(PatternOrResolvedMut::Resolved(ResolvedPattern::List(l))) => {
                     let index = resolve_opt!(to_unsigned(index, l.len()));


### PR DESCRIPTION
This PR simplifies list bindings by getting of the `Lists` enum and the `ListBinding` struct, both in `resolved_pattern.rs`.

This involves a compromise: Instead of lazily retrieving the list items, this eagerly retrieves them when creating the `JoinFn`. The tests seem fine with this, but let me know if this has other repercussions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `Binding` struct to enhance the return type of `list_items` function.
	- Simplified pattern matching and refactored import statements in built-in functions for better efficiency.
	- Enhanced the handling of `Contains` functionality to streamline the code.
	- Improved the logic for accessing and resolving list items in the `ListIndex` implementation.
	- Revamped the handling of lists in the `JoinFn` struct for improved performance and simplicity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->