### PR TITLE
revert: "chore: reduce `Binding` variant usages"

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -2,7 +2,7 @@ name: code quality
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
 concurrency:
   group: ${{ github.workflow }}-${{ (github.ref == 'refs/heads/main' && github.sha) || github.ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ name: main
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
 
 jobs:

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,7 +1,7 @@
 name: pr-lint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -80,16 +80,16 @@ pub enum Binding<'a> {
 impl PartialEq for Binding<'_> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Empty(_, _, _), Self::Empty(_, _, _)) => true,
-            (Self::Node(src1, n1), Self::Node(src2, n2)) => {
+            (Binding::Empty(_, _, _), Binding::Empty(_, _, _)) => true,
+            (Binding::Node(src1, n1), Binding::Node(src2, n2)) => {
                 n1.utf8_text(src1.as_bytes()) == n2.utf8_text(src2.as_bytes())
             }
-            (Self::String(src1, r1), Self::String(src2, r2)) => {
+            (Binding::String(src1, r1), Binding::String(src2, r2)) => {
                 src1[r1.start_byte as usize..r1.end_byte as usize]
                     == src2[r2.start_byte as usize..r2.end_byte as usize]
             }
-            (Self::List(_, n1, f1), Self::List(_, n2, f2)) => n1 == n2 && f1 == f2,
-            (Self::ConstantRef(c1), Self::ConstantRef(c2)) => c1 == c2,
+            (Binding::List(_, n1, f1), Binding::List(_, n2, f2)) => n1 == n2 && f1 == f2,
+            (Binding::ConstantRef(c1), Binding::ConstantRef(c2)) => c1 == c2,
             _ => false,
         }
     }
@@ -307,20 +307,8 @@ pub(crate) fn linearize_binding<'a>(
 }
 
 impl<'a> Binding<'a> {
-    pub(crate) fn from_constant(constant: &'a Constant) -> Self {
-        Self::ConstantRef(constant)
-    }
-
     pub(crate) fn from_node(node: NodeWithSource<'a>) -> Self {
         Self::Node(node.source, node.node)
-    }
-
-    pub(crate) fn from_path(path: &'a Path) -> Self {
-        Self::FileName(path)
-    }
-
-    pub(crate) fn from_range(range: Range, source: &'a str) -> Self {
-        Self::String(source, range)
     }
 
     /// Returns the only node bound by this binding.
@@ -351,8 +339,8 @@ impl<'a> Binding<'a> {
 
     pub fn get_sexp(&self) -> Option<String> {
         match self {
-            Self::Node(_, node) => Some(node.to_sexp().to_string()),
-            Self::List(_, parent_node, field_id) => {
+            Binding::Node(_, node) => Some(node.to_sexp().to_string()),
+            Binding::List(_, parent_node, field_id) => {
                 let mut cursor = parent_node.walk();
                 let mut children = parent_node.children_by_field_id(*field_id, &mut cursor);
                 let mut result = String::new();
@@ -365,17 +353,20 @@ impl<'a> Binding<'a> {
                 }
                 Some(result)
             }
-            Self::String(..) | Self::FileName(_) | Self::Empty(..) | Self::ConstantRef(_) => None,
+            Binding::String(..)
+            | Binding::FileName(_)
+            | Binding::Empty(..)
+            | Binding::ConstantRef(_) => None,
         }
     }
 
     // todo implement for empty and empty list
     pub fn position(&self) -> Option<Range> {
         match self {
-            Self::Empty(_, _, _) => None,
-            Self::Node(_, node) => Some(Range::from(node.range())),
-            Self::String(_, range) => Some(range.to_owned()),
-            Self::List(_, parent_node, field_id) => {
+            Binding::Empty(_, _, _) => None,
+            Binding::Node(_, node) => Some(Range::from(node.range())),
+            Binding::String(_, range) => Some(range.to_owned()),
+            Binding::List(_, parent_node, field_id) => {
                 let mut cursor = parent_node.walk();
                 let mut children = parent_node.children_by_field_id(*field_id, &mut cursor);
 
@@ -417,8 +408,8 @@ impl<'a> Binding<'a> {
                     }
                 }
             }
-            Self::FileName(_) => None,
-            Self::ConstantRef(_) => None,
+            Binding::FileName(_) => None,
+            Binding::ConstantRef(_) => None,
         }
     }
 
@@ -432,8 +423,8 @@ impl<'a> Binding<'a> {
         logs: &mut AnalysisLogs,
     ) -> Result<Cow<'a, str>> {
         let res: Result<Cow<'a, str>> = match self {
-            Self::Empty(_, _, _) => Ok(Cow::Borrowed("")),
-            Self::Node(source, node) => {
+            Binding::Empty(_, _, _) => Ok(Cow::Borrowed("")),
+            Binding::Node(source, node) => {
                 let range = CodeRange::from_node(source, node);
                 linearize_binding(
                     language,
@@ -449,11 +440,11 @@ impl<'a> Binding<'a> {
             }
             // can't linearize until we update source to point to the entire file
             // otherwise file file pointers won't match
-            Self::String(s, r) => Ok(Cow::Owned(
+            Binding::String(s, r) => Ok(Cow::Owned(
                 s[r.start_byte as usize..r.end_byte as usize].into(),
             )),
-            Self::FileName(s) => Ok(Cow::Owned(s.to_string_lossy().into())),
-            Self::List(source, _parent_node, _field_id) => {
+            Binding::FileName(s) => Ok(Cow::Owned(s.to_string_lossy().into())),
+            Binding::List(source, _parent_node, _field_id) => {
                 if let Some(pos) = self.position() {
                     let range = CodeRange::new(pos.start_byte, pos.end_byte, source);
                     linearize_binding(
@@ -471,37 +462,37 @@ impl<'a> Binding<'a> {
                     Ok("".into())
                 }
             }
-            Self::ConstantRef(c) => Ok(Cow::Owned(c.to_string())),
+            Binding::ConstantRef(c) => Ok(Cow::Owned(c.to_string())),
         };
         res
     }
 
     pub fn text(&self) -> String {
         match self {
-            Self::Empty(_, _, _) => "".to_string(),
-            Self::Node(source, node) => {
+            Binding::Empty(_, _, _) => "".to_string(),
+            Binding::Node(source, node) => {
                 NodeWithSource::new(node.clone(), source).text().to_string()
             }
-            Self::String(s, r) => s[r.start_byte as usize..r.end_byte as usize].into(),
-            Self::FileName(s) => s.to_string_lossy().into(),
-            Self::List(source, _, _) => {
+            Binding::String(s, r) => s[r.start_byte as usize..r.end_byte as usize].into(),
+            Binding::FileName(s) => s.to_string_lossy().into(),
+            Binding::List(source, _, _) => {
                 if let Some(pos) = self.position() {
                     source[pos.start_byte as usize..pos.end_byte as usize].to_string()
                 } else {
                     "".to_string()
                 }
             }
-            Self::ConstantRef(c) => c.to_string(),
+            Binding::ConstantRef(c) => c.to_string(),
         }
     }
 
     pub fn source(&self) -> Option<&'a str> {
         match self {
-            Self::Empty(source, _, _) => Some(source),
-            Self::Node(source, _) => Some(source),
-            Self::String(source, _) => Some(source),
-            Self::List(source, _, _) => Some(source),
-            Self::FileName(..) | Self::ConstantRef(..) => None,
+            Binding::Empty(source, _, _) => Some(source),
+            Binding::Node(source, _) => Some(source),
+            Binding::String(source, _) => Some(source),
+            Binding::List(source, _, _) => Some(source),
+            Binding::FileName(..) | Binding::ConstantRef(..) => None,
         }
     }
 

--- a/crates/core/src/pattern/after.rs
+++ b/crates/core/src/pattern/after.rs
@@ -5,11 +5,12 @@ use super::{
     variable::VariableSourceLocations,
     Node, State,
 };
+use crate::{binding::Binding, context::Context, resolve};
 use crate::{binding::Constant, errors::debug};
-use crate::{context::Context, resolve};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
 use grit_util::AstNode;
+use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
 
@@ -60,7 +61,7 @@ impl After {
         };
 
         if let Some(next) = node.next_non_trivia_node() {
-            Ok(ResolvedPattern::from_node(next))
+            Ok(ResolvedPattern::Binding(vector![Binding::from_node(next)]))
         } else {
             debug(
                 logs,

--- a/crates/core/src/pattern/before.rs
+++ b/crates/core/src/pattern/before.rs
@@ -5,11 +5,12 @@ use super::{
     variable::VariableSourceLocations,
     Node, State,
 };
+use crate::{binding::Binding, context::Context, resolve};
 use crate::{binding::Constant, errors::debug};
-use crate::{context::Context, resolve};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
 use grit_util::AstNode;
+use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
 
@@ -60,7 +61,7 @@ impl Before {
         };
 
         if let Some(prev) = node.previous_non_trivia_node() {
-            Ok(ResolvedPattern::from_node(prev))
+            Ok(ResolvedPattern::Binding(vector![Binding::from_node(prev)]))
         } else {
             debug(
                 logs,

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -168,9 +168,9 @@ impl ListIndex {
 
                     let len = list_items.clone().count();
                     let index = resolve_opt!(to_unsigned(index, len));
-                    Ok(list_items
+                    return Ok(list_items
                         .nth(index)
-                        .map(|_| PatternOrResolvedMut::_ResolvedBinding))
+                        .map(|_| PatternOrResolvedMut::_ResolvedBinding));
                 }
                 Some(PatternOrResolvedMut::Resolved(ResolvedPattern::List(l))) => {
                     let index = resolve_opt!(to_unsigned(index, l.len()));

--- a/crates/core/src/pattern/or.rs
+++ b/crates/core/src/pattern/or.rs
@@ -74,10 +74,10 @@ impl Matcher for Or {
         if let ResolvedPattern::Binding(binding_vector) = &binding {
             for p in self.patterns.iter() {
                 // filter out pattern which cannot match because of a mismatched node type
-                if let (Some(binding_node), Pattern::ASTNode(node_pattern)) =
-                    (binding_vector.last().and_then(Binding::as_node), p)
+                if let (Binding::Node(_src, binding_node), Pattern::ASTNode(node_pattern)) =
+                    (binding_vector.last().unwrap(), p)
                 {
-                    if node_pattern.sort != binding_node.node.kind_id() {
+                    if node_pattern.sort != binding_node.kind_id() {
                         continue;
                     }
                 }

--- a/crates/core/src/pattern/regex.rs
+++ b/crates/core/src/pattern/regex.rs
@@ -6,9 +6,10 @@ use super::{
     variable::{Variable, VariableSourceLocations},
     State,
 };
-use crate::context::Context;
+use crate::{binding::Binding, context::Context};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
+use im::vector;
 use marzano_language::{language::Language, target_language::TargetLanguage};
 use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
 use marzano_util::position::Range;
@@ -200,7 +201,7 @@ impl RegexPattern {
                             // have a Range<usize> for String bindings?
                             position.end_byte = position.start_byte + range.end as u32;
                             position.start_byte += range.start as u32;
-                            ResolvedPattern::from_range(position, source)
+                            ResolvedPattern::Binding(vector![Binding::String(source, position)])
                         } else {
                             ResolvedPattern::from_string(value.to_string())
                         }

--- a/crates/core/src/text_unparser.rs
+++ b/crates/core/src/text_unparser.rs
@@ -1,4 +1,4 @@
-use crate::binding::linearize_binding;
+use crate::binding::{linearize_binding, Binding};
 use crate::pattern::resolved_pattern::CodeRange;
 use crate::pattern::state::FileRegistry;
 use crate::pattern::Effect;
@@ -46,8 +46,8 @@ pub(crate) fn apply_effects<'a>(
         logs,
     )?;
     for effect in effects.iter() {
-        if let Some(filename) = effect.binding.as_filename() {
-            if std::ptr::eq(filename, the_filename) {
+        if let Binding::FileName(c) = effect.binding {
+            if std::ptr::eq(c, the_filename) {
                 let snippet = effect
                     .pattern
                     .linearized_text(language, &effects, files, &mut memo, false, logs)?;


### PR DESCRIPTION
Reverts getgrit/gritql#132

This PR breaks 4 tests in crates/core:

    test::access_empty_list
    test::access_empty_map
    test::match_on_falsy_accessor
    test::match_on_falsy_list_index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Standardized pattern matching capabilities using the `Binding` enum for improved efficiency.
	- Enhanced code readability and maintenance by updating method calls and import statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->