### PR TITLE
fix: match against undefined

### DIFF
--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -36,6 +36,10 @@ impl Constant {
             Constant::Undefined => false,
         }
     }
+
+    pub(crate) fn is_undefined(&self) -> bool {
+        matches!(self, Self::Undefined)
+    }
 }
 
 impl Display for Constant {

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -881,7 +881,7 @@ impl<'a> ResolvedPattern<'a> {
             ResolvedPattern::Binding(b) => b
                 .last()
                 .and_then(Binding::as_constant)
-                .map_or(false, |c| c == &Constant::Undefined),
+                .map_or(false, Constant::is_undefined),
             ResolvedPattern::Constant(Constant::Undefined) => true,
             ResolvedPattern::Constant(_)
             | ResolvedPattern::Snippets(_)


### PR DESCRIPTION
Seems the `PartialEq` implementation doesn't consider `Undefined` to be equal to `Undefined`. I assume this was intentional, so I solved it using a matching helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to check if a constant is undefined, enhancing the way constants are evaluated.

- **Refactor**
	- Improved the comparison logic for undefined constants to make it more reliable and readable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->