### PR TITLE
fix: use matches instead of equals

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -2,7 +2,7 @@ name: code quality
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
 concurrency:
   group: ${{ github.workflow }}-${{ (github.ref == 'refs/heads/main' && github.sha) || github.ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ name: main
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
 
 jobs:

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,7 +1,7 @@
 name: pr-lint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -36,6 +36,10 @@ impl Constant {
             Constant::Undefined => false,
         }
     }
+
+    pub(crate) fn is_undefined(&self) -> bool {
+        matches!(self, Self::Undefined)
+    }
 }
 
 impl Display for Constant {

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -881,7 +881,7 @@ impl<'a> ResolvedPattern<'a> {
             ResolvedPattern::Binding(b) => b
                 .last()
                 .and_then(Binding::as_constant)
-                .map_or(false, |c| c == &Constant::Undefined),
+                .map_or(false, |c| matches!(c, Constant::Undefined)),
             ResolvedPattern::Constant(Constant::Undefined) => true,
             ResolvedPattern::Constant(_)
             | ResolvedPattern::Snippets(_)

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -881,7 +881,7 @@ impl<'a> ResolvedPattern<'a> {
             ResolvedPattern::Binding(b) => b
                 .last()
                 .and_then(Binding::as_constant)
-                .map_or(false, |c| matches!(c, Constant::Undefined)),
+                .map_or(false, Constant::is_undefined),
             ResolvedPattern::Constant(Constant::Undefined) => true,
             ResolvedPattern::Constant(_)
             | ResolvedPattern::Snippets(_)


### PR DESCRIPTION
fixes the failing tests on main, and changes CI to use on pull_request instead of pull_request_target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to trigger on `pull_request` events for enhanced code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->