### PR TITLE
feat: support `only-in-diff` without file

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,7 +2,7 @@ name: main
 
 on:
   push:
-    branches: [main, optional-path]
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: "^1.22.0"
+          go-version: '^1.22.0'
       - name: test stdlib
         working-directory: ./stdlib
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,7 +2,7 @@ name: main
 
 on:
   push:
-    branches: [main]
+    branches: [main, optional-path]
   pull_request:
     branches: [main]
 
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: '^1.22.0'
+          go-version: "^1.22.0"
       - name: test stdlib
         working-directory: ./stdlib
         run: |

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -226,9 +226,7 @@ pub(crate) async fn run_apply_pattern(
         Some(diff_ranges)
     } else if let Some(None) = &arg.only_in_diff {
         let diff = git_diff(&std::env::current_dir()?)?;
-        println!("Diff is {:?}", diff);
         let diff_ranges = flushable_unwrap!(emitter, parse_modified_ranges(&diff));
-        println!("Diff ranges are {:?}", diff_ranges);
         Some(diff_ranges)
     } else {
         None

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -95,11 +95,11 @@ pub struct ApplyPatternArgs {
     pub visibility: VisibilityLevels,
     #[clap(
         long = "only-in-diff",
-        help = "Only rewrite ranges that are inside the provided unified diff",
+        help = "Only rewrite ranges that are inside the unified diff if a path to the diff is provided, or the results of git diff HEAD if no path is provided.",
         hide = true,
         conflicts_with = "only_in_json"
     )]
-    only_in_diff: Option<PathBuf>,
+    only_in_diff: Option<Option<PathBuf>>,
     #[clap(
         long = "only-in-json",
         help = "Only rewrite ranges that are inside the provided eslint-style JSON file",
@@ -216,7 +216,7 @@ pub(crate) async fn run_apply_pattern(
     let filter_range = if let Some(json_path) = arg.only_in_json.clone() {
         let json_ranges = flushable_unwrap!(emitter, parse_eslint_output(json_path));
         Some(json_ranges)
-    } else if let Some(diff_path) = arg.only_in_diff.clone() {
+    } else if let Some(Some(diff_path)) = arg.only_in_diff.clone() {
         let diff_ranges = flushable_unwrap!(emitter, extract_modified_ranges(&diff_path));
         Some(diff_ranges)
     } else {

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -31,9 +31,14 @@ use std::collections::BTreeMap;
 use tokio::fs;
 
 use crate::{
-    analyze::par_apply_pattern, community::parse_eslint_output, diff::{extract_modified_ranges, git_diff, parse_modified_ranges},
-    error::GoodError, flags::OutputFormat, messenger_variant::create_emitter,
-    result_formatting::get_human_error, updater::Updater,
+    analyze::par_apply_pattern,
+    community::parse_eslint_output,
+    diff::{extract_modified_ranges, git_diff, parse_modified_ranges},
+    error::GoodError,
+    flags::OutputFormat,
+    messenger_variant::create_emitter,
+    result_formatting::get_human_error,
+    updater::Updater,
 };
 
 use marzano_messenger::{

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -226,7 +226,9 @@ pub(crate) async fn run_apply_pattern(
         Some(diff_ranges)
     } else if let Some(None) = &arg.only_in_diff {
         let diff = git_diff(&std::env::current_dir()?)?;
+        println!("Diff is {:?}", diff);
         let diff_ranges = flushable_unwrap!(emitter, parse_modified_ranges(&diff));
+        println!("Diff ranges are {:?}", diff_ranges);
         Some(diff_ranges)
     } else {
         None

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -72,10 +72,10 @@ pub struct CheckArg {
     pub github_actions: bool,
     #[clap(
         long = "only-in-diff",
-        help = "Only check ranges that are inside the provided unified diff",
+        help = "Only check ranges that are inside the unified diff if a path to the diff is provided, or the results of git diff HEAD if no path is provided.",
         hide = true
     )]
-    pub only_in_diff: Option<PathBuf>,
+    pub only_in_diff: Option<Option<PathBuf>>,
 }
 
 pub(crate) async fn run_check(
@@ -124,7 +124,7 @@ pub(crate) async fn run_check(
         std::env::current_dir()?
     };
 
-    let filter_range = if let Some(diff_path) = arg.only_in_diff.clone() {
+    let filter_range = if let Some(Some(diff_path)) = arg.only_in_diff.clone() {
         let diff_ranges = extract_modified_ranges(&diff_path)?;
         Some(diff_ranges)
     } else {

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -33,7 +33,7 @@ use marzano_messenger::emit::{Messager, VisibilityLevels};
 use cli_server::check::CheckMessenger;
 
 use crate::{
-    diff::extract_modified_ranges,
+    diff::{extract_modified_ranges, git_diff, parse_modified_ranges},
     error::GoodError,
     flags::{GlobalFormatFlags, OutputFormat},
     github::{log_check_annotations, write_check_summary},
@@ -124,8 +124,12 @@ pub(crate) async fn run_check(
         std::env::current_dir()?
     };
 
-    let filter_range = if let Some(Some(diff_path)) = arg.only_in_diff.clone() {
-        let diff_ranges = extract_modified_ranges(&diff_path)?;
+    let filter_range = if let Some(Some(diff_path)) = &arg.only_in_diff {
+        let diff_ranges = extract_modified_ranges(diff_path)?;
+        Some(diff_ranges)
+    } else if let Some(None) = &arg.only_in_diff {
+        let diff = git_diff(&std::env::current_dir()?)?;
+        let diff_ranges = parse_modified_ranges(&diff)?;
         Some(diff_ranges)
     } else {
         None

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -46,8 +46,7 @@ pub fn parse_modified_ranges(diff: &str) -> Result<Vec<FileRange>> {
                 end_pos.line = line_num
                     + range_parts
                         .get(1)
-                        .map_or(0, |&x| x.parse::<u32>().unwrap_or(0))
-                        .saturating_sub(1);
+                        .map_or(0, |&x| x.parse::<u32>().unwrap_or(0));
             }
 
             results.push(FileRange {

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -41,13 +41,12 @@ pub fn parse_modified_ranges(diff: &str) -> Result<Vec<FileRange>> {
             }
             let range_part = line.split_whitespace().nth(2).unwrap_or("");
             let range_parts: Vec<&str> = range_part.split(',').collect();
-            println!("Range parts are {:?}", range_parts);
             if let Ok(line_num) = u32::from_str(range_parts[0].trim_start_matches('+')) {
                 start_pos.line = line_num;
                 end_pos.line = line_num
                     + range_parts
                         .get(1)
-                        .map_or(0, |&x| x.parse::<u32>().unwrap_or(0));
+                        .map_or(1, |&x| x.parse::<u32>().unwrap_or(0));
             }
 
             results.push(FileRange {

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -6,6 +6,7 @@ pub fn git_diff(path: &PathBuf) -> Result<String> {
     let output = std::process::Command::new("git")
         .arg("diff")
         .arg("HEAD")
+        .arg("--relative")
         .arg("--unified=0")
         .arg(path)
         .output()?;

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -1,8 +1,6 @@
 use anyhow::Result;
 use marzano_util::position::{FileRange, Position, RangeWithoutByte, UtilRange};
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
-use git2::Repository;
-use marzano_gritmodule::searcher::find_git_dir_from;
 
 pub fn git_diff(path: &PathBuf) -> Result<String> {
     let output = std::process::Command::new("git")

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -41,6 +41,7 @@ pub fn parse_modified_ranges(diff: &str) -> Result<Vec<FileRange>> {
             }
             let range_part = line.split_whitespace().nth(2).unwrap_or("");
             let range_parts: Vec<&str> = range_part.split(',').collect();
+            println!("Range parts are {:?}", range_parts);
             if let Ok(line_num) = u32::from_str(range_parts[0].trim_start_matches('+')) {
                 start_pos.line = line_num;
                 end_pos.line = line_num

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -1,6 +1,23 @@
 use anyhow::Result;
 use marzano_util::position::{FileRange, Position, RangeWithoutByte, UtilRange};
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
+use git2::Repository;
+use marzano_gritmodule::searcher::find_git_dir_from;
+
+pub async fn git_diff(path: &PathBuf) -> Result<String> {
+    let git_dir = find_git_dir_from(dir).await?;
+    let repo = Repository::open(git_dir)?;
+    let head = repo.find_tree(repo.refname_to_id("HEAD")?)?;
+    let diff = repo.diff_tree_to_workdir(head, None)?;
+    // let output = std::process::Command::new("git")
+    //     .arg("diff")
+    //     .arg("--no-prefix")
+    //     .arg("--unified=0")
+    //     .arg(path)
+    //     .output()?;
+    // Ok(String::from_utf8(output.stdout)?)
+
+}
 
 pub fn extract_modified_ranges(diff_path: &PathBuf) -> Result<Vec<FileRange>> {
     let mut file = File::open(diff_path)?;

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -20,7 +20,7 @@ pub fn extract_modified_ranges(diff_path: &PathBuf) -> Result<Vec<FileRange>> {
     parse_modified_ranges(&diff)
 }
 
-fn parse_modified_ranges(diff: &str) -> Result<Vec<FileRange>> {
+pub fn parse_modified_ranges(diff: &str) -> Result<Vec<FileRange>> {
     let mut results = Vec::new();
     let lines = diff.lines();
 

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -4,19 +4,14 @@ use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
 use git2::Repository;
 use marzano_gritmodule::searcher::find_git_dir_from;
 
-pub async fn git_diff(path: &PathBuf) -> Result<String> {
-    let git_dir = find_git_dir_from(dir).await?;
-    let repo = Repository::open(git_dir)?;
-    let head = repo.find_tree(repo.refname_to_id("HEAD")?)?;
-    let diff = repo.diff_tree_to_workdir(head, None)?;
-    // let output = std::process::Command::new("git")
-    //     .arg("diff")
-    //     .arg("--no-prefix")
-    //     .arg("--unified=0")
-    //     .arg(path)
-    //     .output()?;
-    // Ok(String::from_utf8(output.stdout)?)
-
+pub fn git_diff(path: &PathBuf) -> Result<String> {
+    let output = std::process::Command::new("git")
+        .arg("diff")
+        .arg("HEAD")
+        .arg("--unified=0")
+        .arg(path)
+        .output()?;
+    Ok(String::from_utf8(output.stdout)?)
 }
 
 pub fn extract_modified_ranges(diff_path: &PathBuf) -> Result<Vec<FileRange>> {

--- a/crates/cli/src/snapshots/marzano_cli__diff__tests__parse_one_file_diff.snap
+++ b/crates/cli/src/snapshots/marzano_cli__diff__tests__parse_one_file_diff.snap
@@ -9,5 +9,5 @@ expression: parsed
         line: 5
         column: 0
       end:
-        line: 11
+        line: 12
         column: 0

--- a/crates/cli/src/snapshots/marzano_cli__diff__tests__parse_with_created_file.snap
+++ b/crates/cli/src/snapshots/marzano_cli__diff__tests__parse_with_created_file.snap
@@ -9,7 +9,7 @@ expression: parsed
         line: 5
         column: 0
       end:
-        line: 11
+        line: 12
         column: 0
 - filePath: crates/cli_bin/fixtures/es6/export_object.js
   range:
@@ -18,7 +18,7 @@ expression: parsed
         line: 2
         column: 0
       end:
-        line: 10
+        line: 11
         column: 0
 - filePath: crates/cli_bin/fixtures/es6/index.js
   range:
@@ -27,5 +27,5 @@ expression: parsed
         line: 1
         column: 0
       end:
-        line: 12
+        line: 13
         column: 0

--- a/crates/cli/src/snapshots/marzano_cli__diff__tests__parse_with_deleted_file.snap
+++ b/crates/cli/src/snapshots/marzano_cli__diff__tests__parse_with_deleted_file.snap
@@ -9,7 +9,7 @@ expression: parsed
         line: 5
         column: 0
       end:
-        line: 11
+        line: 12
         column: 0
 - filePath: crates/cli_bin/fixtures/es6/export_object.js
   range:
@@ -18,5 +18,5 @@ expression: parsed
         line: 2
         column: 0
       end:
-        line: 10
+        line: 11
         column: 0

--- a/crates/cli/src/snapshots/marzano_cli__diff__tests__parse_with_multiple_files.snap
+++ b/crates/cli/src/snapshots/marzano_cli__diff__tests__parse_with_multiple_files.snap
@@ -9,7 +9,7 @@ expression: parsed
         line: 5
         column: 0
       end:
-        line: 11
+        line: 12
         column: 0
 - filePath: crates/cli_bin/fixtures/es6/export_object.js
   range:
@@ -18,5 +18,5 @@ expression: parsed
         line: 2
         column: 0
       end:
-        line: 10
+        line: 11
         column: 0

--- a/crates/cli_bin/fixtures/only_diff/index.js
+++ b/crates/cli_bin/fixtures/only_diff/index.js
@@ -8,7 +8,9 @@ export async function createTeam() {
   console.log('really cool');
 }
 
-export const addTeamToOrgSubscription = () => console.log('cool');
+export const addTeamToOrgSubscription = () => {
+    console.log('cool');
+}
 
 module.exports = {};
 

--- a/crates/cli_bin/fixtures/only_diff_check/index.js
+++ b/crates/cli_bin/fixtures/only_diff_check/index.js
@@ -12,7 +12,9 @@ export async function createTeam() {
   console.log('very cool');
 }
 
-export const addTeamToOrgSubscription = () => console.log('cool');
+export const addTeamToOrgSubscription = () => {
+  console.log('cool');
+}
 
 module.exports = {};
 


### PR DESCRIPTION
Ran it locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced diff handling with the ability to process unified diff paths or git diff results.
	- Added support for checking ranges within a unified diff.
	- Introduced a new function to retrieve Git diffs for specified paths.
- **Improvements**
	- Improved logic for filtering ranges based on diff inputs.
	- Updated functionality to allow providing a path to the diff or using `git diff HEAD` results.
- **Code Enhancements**
	- Updated an existing function to include additional logging for better insight during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->