### PR TITLE
refactor: use `NodeWithSource` in `Binding` variants

### DIFF
--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -578,7 +578,7 @@ impl<'a> Binding<'a> {
     ) -> Result<()> {
         match self {
             Self::Empty(node, field) | Self::List(node, field) => {
-                let range: Range = node.range().into();
+                let range = node.range();
                 let log = AnalysisLogBuilder::default()
                         .level(441_u16)
                         .source(node.source)

--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -332,7 +332,7 @@ impl<'a> Binding<'a> {
         match self {
             Self::Node(node) => Some(node.clone()),
             Self::List(parent_node, field_id) => {
-                let mut children = parent_node.children_by_field_id(*field_id);
+                let mut children = parent_node.named_children_by_field_id(*field_id);
                 children.next().filter(|_| children.next().is_none())
             }
             Self::String(..) | Self::FileName(..) | Self::Empty(..) | Self::ConstantRef(..) => None,
@@ -528,11 +528,9 @@ impl<'a> Binding<'a> {
     /// Returns `None` if the binding is not bound to a list.
     pub(crate) fn list_items(&self) -> Option<impl Iterator<Item = NodeWithSource<'a>> + Clone> {
         match self {
-            Self::List(parent_node, field_id) => Some(
-                parent_node
-                    .children_by_field_id(*field_id)
-                    .filter(|item| item.node.is_named()),
-            ),
+            Self::List(parent_node, field_id) => {
+                Some(parent_node.named_children_by_field_id(*field_id))
+            }
             Self::Empty(..)
             | Self::Node(..)
             | Self::String(..)
@@ -557,10 +555,7 @@ impl<'a> Binding<'a> {
         match self {
             Self::Empty(..) => false,
             Self::List(node, field_id) => {
-                let child_count = node
-                    .children_by_field_id(*field_id)
-                    .filter(|child| child.node.is_named())
-                    .count();
+                let child_count = node.named_children_by_field_id(*field_id).count();
                 child_count > 0
             }
             Self::Node(..) => true,

--- a/crates/core/src/equivalence.rs
+++ b/crates/core/src/equivalence.rs
@@ -1,6 +1,7 @@
 use crate::binding::Binding;
-use marzano_util::tree_sitter_util::children_by_field_id_count;
-use tree_sitter::Node;
+use grit_util::AstNode;
+use itertools::{EitherOrBoth, Itertools};
+use marzano_util::node_with_source::NodeWithSource;
 
 impl<'a> Binding<'a> {
     /// Checks whether two bindings are equivalent.
@@ -9,13 +10,13 @@ impl<'a> Binding<'a> {
     pub fn is_equivalent_to(&self, other: &'a Binding) -> bool {
         // covers Node, and List with one element
         if let (Some(s1), Some(s2)) = (self.singleton(), other.singleton()) {
-            return are_equivalent(s1.source, &s1.node, s2.source, &s2.node);
+            return are_equivalent(&s1, &s2);
         }
 
         match self {
             // should never occur covered by singleton
-            Self::Node(source1, node1) => match other {
-                Self::Node(source2, node2) => are_equivalent(source1, node1, source2, node2),
+            Self::Node(node1) => match other {
+                Self::Node(node2) => are_equivalent(node1, node2),
                 Self::String(str, range) => {
                     str[range.start_byte as usize..range.end_byte as usize] == self.text()
                 }
@@ -23,17 +24,14 @@ impl<'a> Binding<'a> {
                     false
                 }
             },
-            Self::List(source1, parent_node1, field1) => match other {
-                Self::List(source2, parent_node2, field2) => {
-                    let mut cursor1 = parent_node1.walk();
-                    let mut cursor2 = parent_node2.walk();
-                    children_by_field_id_count(parent_node1, *field1)
-                        == children_by_field_id_count(parent_node2, *field2)
-                        && parent_node1
-                            .children_by_field_id(*field1, &mut cursor1)
-                            .zip(parent_node2.children_by_field_id(*field2, &mut cursor2))
-                            .all(|(node1, node2)| are_equivalent(source1, &node1, source2, &node2))
-                }
+            Self::List(parent_node1, field1) => match other {
+                Self::List(parent_node2, field2) => parent_node1
+                    .children_by_field_id(*field1)
+                    .zip_longest(parent_node2.children_by_field_id(*field2))
+                    .all(|zipped| match zipped {
+                        EitherOrBoth::Both(node1, node2) => are_equivalent(&node1, &node2),
+                        _ => false,
+                    }),
                 Self::String(..)
                 | Self::FileName(_)
                 | Self::Node(..)
@@ -41,9 +39,9 @@ impl<'a> Binding<'a> {
                 | Self::ConstantRef(_) => false,
             },
             // I suspect matching kind is too strict
-            Self::Empty(_, node1, field1) => match other {
-                Self::Empty(_, node2, field2) => {
-                    node1.kind_id() == node2.kind_id() && field1 == field2
+            Self::Empty(node1, field1) => match other {
+                Self::Empty(node2, field2) => {
+                    node1.node.kind_id() == node2.node.kind_id() && field1 == field2
                 }
                 Self::String(..)
                 | Self::FileName(_)
@@ -73,13 +71,11 @@ impl<'a> Binding<'a> {
 /// Potential improvements:
 /// 1. Use cursors that are passed as arguments -- not clear if this would be faster.
 /// 2. Precompute hashes on all nodes, which define the equivalence relation. The check then becomes O(1).
-pub fn are_equivalent(source1: &str, node1: &Node, source2: &str, node2: &Node) -> bool {
+pub fn are_equivalent(node1: &NodeWithSource, node2: &NodeWithSource) -> bool {
     // If the source is identical, we consider the nodes equivalent.
     // This covers most cases of constant nodes.
     // We may want a more precise check here eventually, but this is a good start.
-    if source1[node1.start_byte() as usize..node1.end_byte() as usize]
-        == source2[node2.start_byte() as usize..node2.end_byte() as usize]
-    {
+    if node1.text() == node2.text() {
         return true;
     }
 
@@ -90,35 +86,31 @@ pub fn are_equivalent(source1: &str, node1: &Node, source2: &str, node2: &Node) 
     // currently fixed by moving this check to after string matching, but
     // still not enough consider that a given snippet could be any one
     // of several nested nodes.
-    if node1.kind_id() != node2.kind_id() {
+    if node1.node.kind_id() != node2.node.kind_id() {
         return false;
     }
 
     // If the node kinds are the same, then we need to check the named fields.
-    let mut cursor1 = node1.walk();
-    let mut cursor2 = node2.walk();
-    let named_fields1 = node1.named_children(&mut cursor1);
-    let named_fields2 = node2.named_children(&mut cursor2);
+    let named_fields1 = node1.named_children();
+    let named_fields2 = node2.named_children();
 
-    // If the number of named fields is different, then the nodes are not equivalent.
-    // This also covers the case of mistached optional and "multiple" fields.
-    if named_fields1.len() != named_fields2.len() {
-        return false;
-    }
-
-    // This is effectively a leaf node. If two leaf nodes have different sources (see above),
-    // then they are not equivalent.
+    // If there are no children, this is effectively a leaf node. If two leaf
+    // nodes have different sources (see above), then they are not equivalent.
     // If they do not have the same sources, we consider them different.
-    if named_fields1.len() == 0 {
-        return false;
-    }
+    let mut is_empty = true;
 
-    // And now recursing on the named fields.
-    for (child1, child2) in named_fields1.zip(named_fields2) {
-        if !are_equivalent(source1, &child1, source2, &child2) {
-            return false;
-        }
-    }
+    // Recurse through the named fields to find the first mismatch.
+    // Differences in length are caught by the use of `EitherOrBoth`.
+    // This also covers the case of mistached optional and "multiple" fields.
+    let are_equivalent = named_fields1
+        .zip_longest(named_fields2)
+        .all(|zipped| match zipped {
+            EitherOrBoth::Both(child1, child2) => {
+                is_empty = false;
+                are_equivalent(&child1, &child2)
+            }
+            _ => false,
+        });
 
-    true
+    are_equivalent && !is_empty
 }

--- a/crates/core/src/equivalence.rs
+++ b/crates/core/src/equivalence.rs
@@ -30,7 +30,7 @@ impl<'a> Binding<'a> {
                     .zip_longest(parent_node2.children_by_field_id(*field2))
                     .all(|zipped| match zipped {
                         EitherOrBoth::Both(node1, node2) => are_equivalent(&node1, &node2),
-                        _ => false,
+                        EitherOrBoth::Left(_) | EitherOrBoth::Right(_) => false,
                     }),
                 Self::String(..)
                 | Self::FileName(_)
@@ -109,7 +109,7 @@ pub fn are_equivalent(node1: &NodeWithSource, node2: &NodeWithSource) -> bool {
                 is_empty = false;
                 are_equivalent(&child1, &child2)
             }
-            _ => false,
+            EitherOrBoth::Left(_) | EitherOrBoth::Right(_) => false,
         });
 
     are_equivalent && !is_empty

--- a/crates/core/src/equivalence.rs
+++ b/crates/core/src/equivalence.rs
@@ -26,8 +26,8 @@ impl<'a> Binding<'a> {
             },
             Self::List(parent_node1, field1) => match other {
                 Self::List(parent_node2, field2) => parent_node1
-                    .children_by_field_id(*field1)
-                    .zip_longest(parent_node2.children_by_field_id(*field2))
+                    .named_children_by_field_id(*field1)
+                    .zip_longest(parent_node2.named_children_by_field_id(*field2))
                     .all(|zipped| match zipped {
                         EitherOrBoth::Both(node1, node2) => are_equivalent(&node1, &node2),
                         EitherOrBoth::Left(_) | EitherOrBoth::Right(_) => false,

--- a/crates/core/src/pattern/after.rs
+++ b/crates/core/src/pattern/after.rs
@@ -59,7 +59,7 @@ impl After {
             bail!("cannot get the node after this binding")
         };
 
-        if let Some(next) = node.next_named_sibling() {
+        if let Some(next) = node.next_named_node() {
             Ok(ResolvedPattern::from_node(next))
         } else {
             debug(
@@ -100,7 +100,7 @@ impl Matcher for After {
         let Some(node) = binding.as_node() else {
             return Ok(true);
         };
-        let prev_node = resolve!(node.previous_named_sibling());
+        let prev_node = resolve!(node.previous_named_node());
         if !self.after.execute(
             &ResolvedPattern::from_node(prev_node),
             &mut cur_state,

--- a/crates/core/src/pattern/before.rs
+++ b/crates/core/src/pattern/before.rs
@@ -59,7 +59,7 @@ impl Before {
             bail!("cannot get the node before this binding")
         };
 
-        if let Some(prev) = node.previous_named_sibling() {
+        if let Some(prev) = node.previous_named_node() {
             Ok(ResolvedPattern::from_node(prev))
         } else {
             debug(
@@ -100,7 +100,7 @@ impl Matcher for Before {
         let Some(node) = binding.as_node() else {
             return Ok(true);
         };
-        let next_node = resolve!(node.next_named_sibling());
+        let next_node = resolve!(node.next_named_node());
         if !self.before.execute(
             &ResolvedPattern::from_node(next_node),
             &mut cur_state,

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -425,11 +425,11 @@ impl<'a> ResolvedPattern<'a> {
     }
 
     pub(crate) fn from_list(src: &'a str, node: Node<'a>, field_id: FieldId) -> Self {
-        Self::from_binding(Binding::List(src, node, field_id))
+        Self::from_binding(Binding::List(NodeWithSource::new(node, src), field_id))
     }
 
     pub(crate) fn empty_field(src: &'a str, node: Node<'a>, field_id: FieldId) -> Self {
-        Self::from_binding(Binding::Empty(src, node, field_id))
+        Self::from_binding(Binding::Empty(NodeWithSource::new(node, src), field_id))
     }
 
     pub(crate) fn from_path(path: &'a Path) -> Self {

--- a/crates/core/src/suppress.rs
+++ b/crates/core/src/suppress.rs
@@ -8,9 +8,7 @@ use tree_sitter::Range;
 impl<'a> Binding<'a> {
     pub(crate) fn is_suppressed(&self, lang: &impl Language, current_name: Option<&str>) -> bool {
         let node = match self {
-            Self::Node(src, node) | Self::List(src, node, _) | Self::Empty(src, node, _) => {
-                NodeWithSource::new(node.clone(), src)
-            }
+            Self::Node(node) | Self::List(node, _) | Self::Empty(node, _) => node.clone(),
             Self::String(_, _) | Self::FileName(_) | Self::ConstantRef(_) => return false,
         };
         let target_range = node.node.range();

--- a/crates/core/src/suppress.rs
+++ b/crates/core/src/suppress.rs
@@ -77,10 +77,10 @@ fn comment_applies_to_range(
     range: &Range,
     lang: &impl Language,
 ) -> bool {
-    let Some(mut applicable) = comment_node.next_named_sibling() else {
+    let Some(mut applicable) = comment_node.next_named_node() else {
         return false;
     };
-    while let Some(next) = applicable.next_named_sibling() {
+    while let Some(next) = applicable.next_named_node() {
         if !lang.is_comment(applicable.node.kind_id())
             && !lang.is_comment_wrapper(&applicable.node)
             // Some languages have significant whitespace; continue until we find a non-whitespace non-comment node

--- a/crates/grit-util/src/ast_node.rs
+++ b/crates/grit-util/src/ast_node.rs
@@ -14,17 +14,18 @@ pub trait AstNode: Sized {
     /// Returns `None` if this is the root node.
     fn parent(&self) -> Option<Self>;
 
+    /// Returns the next node in the tree, ignoring trivia such as whitespace.
+    fn next_named_node(&self) -> Option<Self>;
+
+    /// Returns the previous node in the tree, ignoring trivia such as
+    /// whitespace.
+    fn previous_named_node(&self) -> Option<Self>;
+
     /// Returns the next adjacent node.
     fn next_sibling(&self) -> Option<Self>;
 
     /// Returns the previous adjacent node.
     fn previous_sibling(&self) -> Option<Self>;
-
-    /// Returns the next adjacent node, ignoring trivia such as whitespace.
-    fn next_named_sibling(&self) -> Option<Self>;
-
-    /// Returns the previous adjacent node, ignoring trivia such as whitespace.
-    fn previous_named_sibling(&self) -> Option<Self>;
 
     /// Returns the text representation of the node.
     fn text(&self) -> &str;

--- a/crates/grit-util/src/ast_node.rs
+++ b/crates/grit-util/src/ast_node.rs
@@ -9,10 +9,21 @@ pub trait AstNode: Sized {
     /// Returns an iterator over the node's children.
     fn children(&self) -> impl Iterator<Item = Self>;
 
-    /// Returns the next node, ignoring trivia such as whitespace.
+    /// Returns the node's parent.
+    ///
+    /// Returns `None` if this is the root node.
+    fn parent(&self) -> Option<Self>;
+
+    /// Returns the next adjacent node.
+    fn next_sibling(&self) -> Option<Self>;
+
+    /// Returns the previous adjacent node.
+    fn previous_sibling(&self) -> Option<Self>;
+
+    /// Returns the next adjacent node, ignoring trivia such as whitespace.
     fn next_named_sibling(&self) -> Option<Self>;
 
-    /// Returns the previous node, ignoring trivia such as whitespace.
+    /// Returns the previous adjacent node, ignoring trivia such as whitespace.
     fn previous_named_sibling(&self) -> Option<Self>;
 
     /// Returns the text representation of the node.

--- a/crates/util/src/cursor_wrapper.rs
+++ b/crates/util/src/cursor_wrapper.rs
@@ -2,6 +2,7 @@ use crate::node_with_source::NodeWithSource;
 use grit_util::AstCursor;
 use tree_sitter::TreeCursor;
 
+#[derive(Clone)]
 pub struct CursorWrapper<'a> {
     cursor: TreeCursor<'a>,
     source: &'a str,
@@ -10,6 +11,10 @@ pub struct CursorWrapper<'a> {
 impl<'a> CursorWrapper<'a> {
     pub fn new(cursor: TreeCursor<'a>, source: &'a str) -> Self {
         Self { cursor, source }
+    }
+
+    pub(crate) fn field_id(&self) -> Option<u16> {
+        self.cursor.field_id()
     }
 }
 

--- a/crates/util/src/node_with_source.rs
+++ b/crates/util/src/node_with_source.rs
@@ -23,6 +23,10 @@ impl<'a> NodeWithSource<'a> {
         ChildrenByFieldIterator::new(self, field_id)
     }
 
+    pub fn named_children_by_field_id(&self, field_id: u16) -> impl Iterator<Item = Self> + Clone {
+        ChildrenByFieldIterator::new(self, field_id).filter(|child| child.node.is_named())
+    }
+
     pub fn named_children(&self) -> impl Iterator<Item = Self> {
         ChildrenIterator::new(self).filter(|child| child.node.is_named())
     }

--- a/crates/util/src/node_with_source.rs
+++ b/crates/util/src/node_with_source.rs
@@ -60,27 +60,7 @@ impl<'a> AstNode for NodeWithSource<'a> {
             .map(|parent| Self::new(parent, self.source))
     }
 
-    fn next_sibling(&self) -> Option<Self> {
-        let mut current_node = self.node.clone();
-        loop {
-            if let Some(sibling) = current_node.next_sibling() {
-                return Some(Self::new(sibling, self.source));
-            }
-            current_node = current_node.parent()?;
-        }
-    }
-
-    fn previous_sibling(&self) -> Option<Self> {
-        let mut current_node = self.node.clone();
-        loop {
-            if let Some(sibling) = current_node.prev_sibling() {
-                return Some(Self::new(sibling, self.source));
-            }
-            current_node = current_node.parent()?;
-        }
-    }
-
-    fn next_named_sibling(&self) -> Option<Self> {
+    fn next_named_node(&self) -> Option<Self> {
         let mut current_node = self.node.clone();
         loop {
             if let Some(sibling) = current_node.next_named_sibling() {
@@ -90,7 +70,7 @@ impl<'a> AstNode for NodeWithSource<'a> {
         }
     }
 
-    fn previous_named_sibling(&self) -> Option<Self> {
+    fn previous_named_node(&self) -> Option<Self> {
         let mut current_node = self.node.clone();
         loop {
             if let Some(sibling) = current_node.prev_named_sibling() {
@@ -98,6 +78,18 @@ impl<'a> AstNode for NodeWithSource<'a> {
             }
             current_node = current_node.parent()?;
         }
+    }
+
+    fn next_sibling(&self) -> Option<Self> {
+        self.node
+            .next_sibling()
+            .map(|sibling| Self::new(sibling, self.source))
+    }
+
+    fn previous_sibling(&self) -> Option<Self> {
+        self.node
+            .prev_sibling()
+            .map(|sibling| Self::new(sibling, self.source))
     }
 
     fn text(&self) -> &str {

--- a/crates/util/src/node_with_source.rs
+++ b/crates/util/src/node_with_source.rs
@@ -1,10 +1,14 @@
+use std::ptr;
+
+use crate::position::Range;
+
 use super::cursor_wrapper::CursorWrapper;
 use grit_util::{AstCursor, AstNode};
 use tree_sitter::Node;
 
 /// A TreeSitter node, including a reference to the source code from which it
 /// was parsed.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct NodeWithSource<'a> {
     pub node: Node<'a>,
     pub source: &'a str,
@@ -13,6 +17,27 @@ pub struct NodeWithSource<'a> {
 impl<'a> NodeWithSource<'a> {
     pub fn new(node: Node<'a>, source: &'a str) -> Self {
         Self { node, source }
+    }
+
+    pub fn children_by_field_id(&self, field_id: u16) -> impl Iterator<Item = Self> + Clone {
+        ChildrenByFieldIterator::new(self, field_id)
+    }
+
+    pub fn named_children(&self) -> impl Iterator<Item = Self> {
+        ChildrenIterator::new(self).filter(|child| child.node.is_named())
+    }
+
+    pub fn range(&self) -> Range {
+        Range::from(self.node.range())
+    }
+}
+
+impl<'a> PartialEq for NodeWithSource<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        // We can compare source by pointer instead of comparing the entire
+        // source strings. This implies that two nodes cannot be equal if they
+        // point to different (even cloned) source references.
+        self.node == other.node && ptr::eq(self.source.as_ptr(), other.source.as_ptr())
     }
 }
 
@@ -23,6 +48,32 @@ impl<'a> AstNode for NodeWithSource<'a> {
 
     fn children(&self) -> impl Iterator<Item = Self> {
         ChildrenIterator::new(self)
+    }
+
+    fn parent(&self) -> Option<Self> {
+        self.node
+            .parent()
+            .map(|parent| Self::new(parent, self.source))
+    }
+
+    fn next_sibling(&self) -> Option<Self> {
+        let mut current_node = self.node.clone();
+        loop {
+            if let Some(sibling) = current_node.next_sibling() {
+                return Some(Self::new(sibling, self.source));
+            }
+            current_node = current_node.parent()?;
+        }
+    }
+
+    fn previous_sibling(&self) -> Option<Self> {
+        let mut current_node = self.node.clone();
+        loop {
+            if let Some(sibling) = current_node.prev_sibling() {
+                return Some(Self::new(sibling, self.source));
+            }
+            current_node = current_node.parent()?;
+        }
     }
 
     fn next_named_sibling(&self) -> Option<Self> {
@@ -69,10 +120,7 @@ impl<'a> Iterator for AncestorIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let node = self.node.as_ref().cloned()?;
-        self.node = node
-            .node
-            .parent()
-            .map(|parent| NodeWithSource::new(parent, node.source));
+        self.node = node.parent();
         Some(node)
     }
 }
@@ -95,6 +143,41 @@ impl<'a> Iterator for ChildrenIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let c = self.cursor.as_mut()?;
+        let node = c.node();
+        if !c.goto_next_sibling() {
+            self.cursor = None;
+        }
+        Some(node)
+    }
+}
+
+#[derive(Clone)]
+pub struct ChildrenByFieldIterator<'a> {
+    cursor: Option<CursorWrapper<'a>>,
+    field_id: u16,
+}
+
+impl<'a> ChildrenByFieldIterator<'a> {
+    fn new(node: &NodeWithSource<'a>, field_id: u16) -> Self {
+        let mut cursor = CursorWrapper::new(node.node.walk(), node.source);
+        Self {
+            cursor: cursor.goto_first_child().then_some(cursor),
+            field_id,
+        }
+    }
+}
+
+impl<'a> Iterator for ChildrenByFieldIterator<'a> {
+    type Item = NodeWithSource<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let c = self.cursor.as_mut()?;
+        while c.field_id() != Some(self.field_id) {
+            if !c.goto_next_sibling() {
+                self.cursor = None;
+                return None;
+            }
+        }
         let node = c.node();
         if !c.goto_next_sibling() {
             self.cursor = None;


### PR DESCRIPTION
At this point, I bit the bullet and changed the variants of `Binding` that stored separate `node` and `src` values to hold a single `NodeWithSource` instead. The PR is slightly bigger because I had to add a few more traversal methods to cover cases that weren't covered yet (I should have done those in reverse order).

The nice thing is that you can see this PR completely strips the `use tree_sitter::Node;` imports from several of the files it touches. Progress! :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Enhanced node and source handling for improved functionality and clarity.
    - Optimized equivalence checking logic and simplified pattern matching for increased efficiency.
- **New Features**
    - Expanded AST node navigation capabilities with new methods for efficient structure traversal.
- **Style**
    - Implemented `Debug` trait and refined comparisons for better debugging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->