### PR TITLE
feat: implement includes or/any/and + enforce Cargo convention

### DIFF
--- a/.grit/grit.yaml
+++ b/.grit/grit.yaml
@@ -1,6 +1,15 @@
 version: 0.0.1
 patterns:
   - name: github.com/getgrit/stdlib#*
+  - name: our_cargo_use_long_dependency
+    level: error
+    body: |
+      language toml
+
+      cargo_use_long_dependency() where $filename <: not includes or {
+        "language-submodules",
+        "language-metavariables"
+      }
   - name: no_println_in_lsp
     description: Don't use println!() in LSP code, it breaks the LSP stdio protocol.
     level: error

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -9,12 +9,12 @@ rust.unused_crate_dependencies = "warn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.70"
+anyhow = { version = "1.0.70" }
 reqwest = { version = "0.11", features = ["json", "blocking"] }
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0" }
 serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
+serde_json = { version = "1.0.96" }
 tokio = { version = "1", features = ["full"] }
-log = "0.4.19"
-chrono = "0.4.26"
+log = { version = "0.4.19" }
+chrono = { version = "0.4.26" }
 marzano-util = { path = "../util" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,24 +11,24 @@ rust.unused_crate_dependencies = "warn"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.70"
+anyhow = { version = "1.0.70" }
 clap = { version = "4.1.13", features = ["derive"] }
-indicatif = "0.17.5"
-ignore = "0.4.20"
+indicatif = { version = "0.17.5" }
+ignore = { version = "0.4.20" }
 # Do *NOT* upgrade beyond 1.0.171 until https://github.com/serde-rs/serde/issues/2538 is fixed
 serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
+serde_json = { version = "1.0.96" }
 uuid = { version = "1.1", features = ["v4", "serde"] }
 tokio = { version = "1", features = ["full"] }
 chrono = { version = "0.4.26", features = ["serde"] }
 reqwest = { version = "0.11", features = ["json"] }
-lazy_static = "1.4.0"
-indicatif-log-bridge = "0.2.1"
-colored = "2.0.4"
+lazy_static = { version = "1.4.0" }
+indicatif-log-bridge = { version = "0.2.1" }
+colored = { version = "2.0.4" }
 log = { version = "0.4.19" }
-env_logger = "0.10.0"
-git2 = "0.17.2"
-regex = "1.7.3"
+env_logger = { version = "0.10.0" }
+git2 = { version = "0.17.2" }
+regex = { version = "1.7.3" }
 openssl = { version = "0.10", features = ["vendored"] }
 marzano-core = { path = "../core", features = [
   "non_wasm",
@@ -42,12 +42,12 @@ marzano_messenger = { path = "../marzano_messenger" }
 cli_server = { git = "https://github.com/getgrit/cli_server.git", optional = true }
 ai_builtins = { git = "https://github.com/getgrit/ai_builtins.git", optional = true }
 grit_cache = { path = "../gritcache" }
-tempfile = "3.1"
-similar = "2.2.1"
-dialoguer = "0.10.4"
-console = "0.15.7"
-rayon = "1.8.0"
-dashmap = "5.5.3"
+tempfile = { version = "3.1" }
+similar = { version = "2.2.1" }
+dialoguer = { version = "0.10.4" }
+console = { version = "0.15.7" }
+rayon = { version = "1.8.0" }
+dashmap = { version = "5.5.3" }
 clap-markdown = { git = "https://github.com/getgrit/clap-markdown", optional = true }
 flate2 = { version = "1.0.17", features = [
   "rust_backend",

--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.70"
+anyhow = { version = "1.0.70" }
 marzano-cli = { path = "../cli", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1.40", default-features = false }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,17 +20,17 @@ tracing = { version = "0.1.40", default-features = false, features = [] }
 tracing-opentelemetry = { version = "0.22.0", optional = true, default-features = false, features = [
 ] }
 
-regex = "1.7.3"
-anyhow = "1.0.70"
-itertools = "0.10.5"
-im = "15.1.0"
-serde_json = "1.0.96"
+regex = { version = "1.7.3" }
+anyhow = { version = "1.0.70" }
+itertools = { version = "0.10.5" }
+im = { version = "15.1.0" }
+serde_json = { version = "1.0.96" }
 serde = { version = "1.0.164", features = ["derive"] }
-sha2 = "0.10.8"
-elsa = "1.9.0"
-rayon = "1.8.0"
-log = "0.4.20"
-rand = "0.8.5"
+sha2 = { version = "0.10.8" }
+elsa = { version = "1.9.0" }
+rayon = { version = "1.8.0" }
+log = { version = "0.4.20" }
+rand = { version = "0.8.5" }
 path-absolutize = { version = "3.1.1", optional = false, features = [
   "use_unix_paths_on_wasm",
 ] }

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -97,6 +97,16 @@ impl Matcher for Includes {
                 }
                 Ok(false)
             }
+            Pattern::Any(pattern) => {
+                // Any is subtly different from true in that it will not short-circuit
+                let mut any_matched = false;
+                for p in pattern.patterns.iter() {
+                    if execute(&p, binding, state, context, logs)? {
+                        any_matched = true;
+                    }
+                }
+                Ok(any_matched)
+            }
             Pattern::And(pattern) => {
                 for p in pattern.patterns.iter() {
                     if !execute(p, binding, state, context, logs)? {
@@ -120,7 +130,6 @@ impl Matcher for Includes {
             | Pattern::CallForeignFunction(_)
             | Pattern::Assignment(_)
             | Pattern::Accumulate(_)
-            | Pattern::Any(_)
             | Pattern::Maybe(_)
             | Pattern::Not(_)
             | Pattern::If(_)

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -61,9 +61,13 @@ fn execute<'a>(
     logs: &mut AnalysisLogs,
 ) -> Result<bool> {
     let resolved = ResolvedPattern::from_pattern(pattern, state, context, logs)
-        .context("includes can only be used with patterns that resolve to a string")?;
-    let substring = resolved.text(&state.files)?;
-    let string = binding.text(&state.files)?;
+        .context("includes can only be used with patterns that can be resolved")?;
+    let substring = resolved
+        .text(&state.files)
+        .context("includes can only be used with patterns that can be resolved to a string")?;
+    let string = binding
+        .text(&state.files)
+        .context("includes can only be used with patterns that can be resolved to a string")?;
     if string.contains(&*substring) {
         Ok(true)
     } else {

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -60,7 +60,8 @@ fn execute<'a>(
     context: &'a impl Context,
     logs: &mut AnalysisLogs,
 ) -> Result<bool> {
-    let resolved = ResolvedPattern::from_pattern(pattern, state, context, logs)?;
+    let resolved = ResolvedPattern::from_pattern(pattern, state, context, logs)
+        .context("includes can only be used with patterns that resolve to a string")?;
     let substring = resolved.text(&state.files)?;
     let string = binding.text(&state.files)?;
     if string.contains(&*substring) {

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -6,7 +6,7 @@ use super::{
     Node, State,
 };
 use crate::context::Context;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -60,18 +60,97 @@ fn execute<'a>(
     context: &'a impl Context,
     logs: &mut AnalysisLogs,
 ) -> Result<bool> {
-    let resolved = ResolvedPattern::from_pattern(pattern, state, context, logs)
-        .context("includes can only be used with patterns that can be resolved")?;
-    let substring = resolved
-        .text(&state.files)
-        .context("includes can only be used with patterns that can be resolved to a string")?;
-    let string = binding
-        .text(&state.files)
-        .context("includes can only be used with patterns that can be resolved to a string")?;
-    if string.contains(&*substring) {
-        Ok(true)
-    } else {
-        Ok(false)
+    match &pattern {
+        Pattern::Regex(pattern) => pattern.execute_matching(binding, state, context, logs, false),
+        Pattern::Or(pattern) => {
+            for p in pattern.patterns.iter() {
+                if execute(&p, binding, state, context, logs)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        Pattern::Any(pattern) => {
+            // Any is subtly different from true in that it will not short-circuit
+            let mut any_matched = false;
+            for p in pattern.patterns.iter() {
+                if execute(&p, binding, state, context, logs)? {
+                    any_matched = true;
+                }
+            }
+            Ok(any_matched)
+        }
+        Pattern::And(pattern) => {
+            for p in pattern.patterns.iter() {
+                if !execute(p, binding, state, context, logs)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        Pattern::ASTNode(_)
+        | Pattern::List(_)
+        | Pattern::ListIndex(_)
+        | Pattern::Map(_)
+        | Pattern::Accessor(_)
+        | Pattern::Call(_)
+        | Pattern::File(_)
+        | Pattern::Files(_)
+        | Pattern::Bubble(_)
+        | Pattern::Limit(_)
+        | Pattern::CallBuiltIn(_)
+        | Pattern::CallFunction(_)
+        | Pattern::CallForeignFunction(_)
+        | Pattern::Assignment(_)
+        | Pattern::Accumulate(_)
+        | Pattern::Maybe(_)
+        | Pattern::Not(_)
+        | Pattern::If(_)
+        | Pattern::Undefined
+        | Pattern::Top
+        | Pattern::Bottom
+        | Pattern::Underscore
+        | Pattern::StringConstant(_)
+        | Pattern::AstLeafNode(_)
+        | Pattern::IntConstant(_)
+        | Pattern::FloatConstant(_)
+        | Pattern::BooleanConstant(_)
+        | Pattern::Dynamic(_)
+        | Pattern::CodeSnippet(_)
+        | Pattern::Variable(_)
+        | Pattern::Rewrite(_)
+        | Pattern::Log(_)
+        | Pattern::Range(_)
+        | Pattern::Contains(_)
+        | Pattern::Includes(_)
+        | Pattern::Within(_)
+        | Pattern::After(_)
+        | Pattern::Before(_)
+        | Pattern::Where(_)
+        | Pattern::Some(_)
+        | Pattern::Every(_)
+        | Pattern::Add(_)
+        | Pattern::Subtract(_)
+        | Pattern::Multiply(_)
+        | Pattern::Divide(_)
+        | Pattern::Modulo(_)
+        | Pattern::Dots
+        | Pattern::Sequential(_)
+        | Pattern::Like(_) => {
+            let resolved = ResolvedPattern::from_pattern(pattern, state, context, logs)
+                .context("includes can only be used with patterns that can be resolved")?;
+            let substring = resolved.text(&state.files).context(
+                "includes can only be used with patterns that can be resolved to a string",
+            )?;
+            let string = binding.text(&state.files).context(
+                "includes can only be used with patterns that can be resolved to a string",
+            )?;
+            if string.contains(&*substring) {
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
     }
 }
 
@@ -85,85 +164,6 @@ impl Matcher for Includes {
         context: &'a impl Context,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        match &self.includes {
-            Pattern::Regex(pattern) => {
-                pattern.execute_matching(binding, state, context, logs, false)
-            }
-            Pattern::Or(pattern) => {
-                for p in pattern.patterns.iter() {
-                    if execute(&p, binding, state, context, logs)? {
-                        return Ok(true);
-                    }
-                }
-                Ok(false)
-            }
-            Pattern::Any(pattern) => {
-                // Any is subtly different from true in that it will not short-circuit
-                let mut any_matched = false;
-                for p in pattern.patterns.iter() {
-                    if execute(&p, binding, state, context, logs)? {
-                        any_matched = true;
-                    }
-                }
-                Ok(any_matched)
-            }
-            Pattern::And(pattern) => {
-                for p in pattern.patterns.iter() {
-                    if !execute(p, binding, state, context, logs)? {
-                        return Ok(false);
-                    }
-                }
-                Ok(true)
-            }
-            Pattern::ASTNode(_)
-            | Pattern::List(_)
-            | Pattern::ListIndex(_)
-            | Pattern::Map(_)
-            | Pattern::Accessor(_)
-            | Pattern::Call(_)
-            | Pattern::File(_)
-            | Pattern::Files(_)
-            | Pattern::Bubble(_)
-            | Pattern::Limit(_)
-            | Pattern::CallBuiltIn(_)
-            | Pattern::CallFunction(_)
-            | Pattern::CallForeignFunction(_)
-            | Pattern::Assignment(_)
-            | Pattern::Accumulate(_)
-            | Pattern::Maybe(_)
-            | Pattern::Not(_)
-            | Pattern::If(_)
-            | Pattern::Undefined
-            | Pattern::Top
-            | Pattern::Bottom
-            | Pattern::Underscore
-            | Pattern::StringConstant(_)
-            | Pattern::AstLeafNode(_)
-            | Pattern::IntConstant(_)
-            | Pattern::FloatConstant(_)
-            | Pattern::BooleanConstant(_)
-            | Pattern::Dynamic(_)
-            | Pattern::CodeSnippet(_)
-            | Pattern::Variable(_)
-            | Pattern::Rewrite(_)
-            | Pattern::Log(_)
-            | Pattern::Range(_)
-            | Pattern::Contains(_)
-            | Pattern::Includes(_)
-            | Pattern::Within(_)
-            | Pattern::After(_)
-            | Pattern::Before(_)
-            | Pattern::Where(_)
-            | Pattern::Some(_)
-            | Pattern::Every(_)
-            | Pattern::Add(_)
-            | Pattern::Subtract(_)
-            | Pattern::Multiply(_)
-            | Pattern::Divide(_)
-            | Pattern::Modulo(_)
-            | Pattern::Dots
-            | Pattern::Sequential(_)
-            | Pattern::Like(_) => execute(&self.includes, binding, state, context, logs),
-        }
+        execute(&self.includes, binding, state, context, logs)
     }
 }

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -92,6 +92,14 @@ impl Matcher for Includes {
                 }
                 Ok(false)
             }
+            Pattern::And(pattern) => {
+                for p in pattern.patterns.iter() {
+                    if !execute(p, binding, state, context, logs)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
             Pattern::ASTNode(_)
             | Pattern::List(_)
             | Pattern::ListIndex(_)
@@ -107,9 +115,8 @@ impl Matcher for Includes {
             | Pattern::CallForeignFunction(_)
             | Pattern::Assignment(_)
             | Pattern::Accumulate(_)
-            | Pattern::And(_)
-            | Pattern::Maybe(_)
             | Pattern::Any(_)
+            | Pattern::Maybe(_)
             | Pattern::Not(_)
             | Pattern::If(_)
             | Pattern::Undefined

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -64,17 +64,17 @@ fn execute<'a>(
         Pattern::Regex(pattern) => pattern.execute_matching(binding, state, context, logs, false),
         Pattern::Or(pattern) => {
             for p in pattern.patterns.iter() {
-                if execute(&p, binding, state, context, logs)? {
+                if execute(p, binding, state, context, logs)? {
                     return Ok(true);
                 }
             }
             Ok(false)
         }
         Pattern::Any(pattern) => {
-            // Any is subtly different from true in that it will not short-circuit
+            // Any is subtly different from or in that it will not short-circuit so we *must* execute all patterns
             let mut any_matched = false;
             for p in pattern.patterns.iter() {
-                if execute(&p, binding, state, context, logs)? {
+                if execute(p, binding, state, context, logs)? {
                     any_matched = true;
                 }
             }

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -3125,7 +3125,7 @@ fn includes_and() {
                 |console.log("Hello world!");
                 |console.log("Goodbye world!");
                 |console.log("But not me, handsome.");
-                |console.log("Hello world!");
+                |console.log("Hi, Hello world!");
                 |"#
             .trim_margin()
             .unwrap(),

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -3135,6 +3135,42 @@ fn includes_and() {
 }
 
 #[test]
+fn includes_any() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"
+                |language js
+                |
+                |`console.log($_)` as $haystack where {
+                |   $haystack <: includes any { "Hello", "handsome" }
+                |} => `console.log("Goodbye world!")`
+                |"#
+            .trim_margin()
+            .unwrap(),
+            source: r#"
+                |console.log("Hello world!");
+                |console.log("Hello handsome!");
+                |console.log("But not me, handsome.");
+                |console.log("Hi, Hello world!");
+                |console.log("Just not this....");
+                |"#
+            .trim_margin()
+            .unwrap(),
+            expected: r#"
+                |console.log("Goodbye world!");
+                |console.log("Goodbye world!");
+                |console.log("Goodbye world!");
+                |console.log("Goodbye world!");
+                |console.log("Just not this....");
+                |"#
+            .trim_margin()
+            .unwrap(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
 fn includes_regex() {
     run_test_expected({
         TestArgExpected {

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -3067,6 +3067,40 @@ fn hcl_implicit_regex() {
 }
 
 #[test]
+fn includes_or() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"
+                |language js
+                |
+                |`console.log($_)` as $haystack where {
+                |   $haystack <: includes or { "world", "handsome" }
+                |} => `console.log("Goodbye world!")`
+                |"#
+            .trim_margin()
+            .unwrap(),
+            source: r#"
+                |console.log("Hello world!");
+                |console.log("Hello handsome!");
+                |console.log("But not me, sadly.");
+                |console.log("Hi, Hello world!");
+                |"#
+            .trim_margin()
+            .unwrap(),
+            expected: r#"
+                |console.log("Goodbye world!");
+                |console.log("Goodbye world!");
+                |console.log("But not me, sadly.");
+                |console.log("Goodbye world!");
+                |"#
+            .trim_margin()
+            .unwrap(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
 fn includes_regex() {
     run_test_expected({
         TestArgExpected {
@@ -13385,7 +13419,7 @@ or {
     } else {
         $import_clause => .
     }
-  } 
+  }
 }
 
 remove_unused_imports()"#

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -3101,6 +3101,40 @@ fn includes_or() {
 }
 
 #[test]
+fn includes_and() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"
+                |language js
+                |
+                |`console.log($_)` as $haystack where {
+                |   $haystack <: includes and { "Hello", "handsome" }
+                |} => `console.log("Goodbye world!")`
+                |"#
+            .trim_margin()
+            .unwrap(),
+            source: r#"
+                |console.log("Hello world!");
+                |console.log("Hello handsome!");
+                |console.log("But not me, handsome.");
+                |console.log("Hi, Hello world!");
+                |"#
+            .trim_margin()
+            .unwrap(),
+            expected: r#"
+                |console.log("Hello world!");
+                |console.log("Goodbye world!");
+                |console.log("But not me, handsome.");
+                |console.log("Hello world!");
+                |"#
+            .trim_margin()
+            .unwrap(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
 fn includes_regex() {
     run_test_expected({
         TestArgExpected {

--- a/crates/externals/Cargo.toml
+++ b/crates/externals/Cargo.toml
@@ -9,6 +9,6 @@ rust.unused_crate_dependencies = "warn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.70"
-extism = "^1.0.0-rc7"
-serde_json = "1.0.96"
+anyhow = { version = "1.0.70" }
+extism = { version = "^1.0.0-rc7" }
+serde_json = { version = "1.0.96" }

--- a/crates/gritcache/Cargo.toml
+++ b/crates/gritcache/Cargo.toml
@@ -9,7 +9,7 @@ rust.unused_crate_dependencies = "warn"
 [dependencies]
 marzano-gritmodule = { path = "../gritmodule", features = [
 ], default-features = false }
-anyhow = "1.0.70"
+anyhow = { version = "1.0.70" }
 marzano-util = { path = "../util", features = [], default-features = false }
 
 [dev-dependencies]

--- a/crates/gritmodule/Cargo.toml
+++ b/crates/gritmodule/Cargo.toml
@@ -12,21 +12,21 @@ marzano-language = { path = "../language" }
 marzano-util = { path = "../util", features = ["finder"] }
 tree-sitter = { path = "../../vendor/tree-sitter-facade", package = "tree-sitter-facade-sg" }
 serde = { version = "1.0.164", features = ["derive"] }
-serde_yaml = "0.9.25"
-anyhow = "1.0.70"
-rand = "0.8.5"
+serde_yaml = { version = "0.9.25" }
+anyhow = { version = "1.0.70" }
+rand = { version = "0.8.5" }
 git2 = { version = "0.17.2", default-features = false, features = [
   "vendored-openssl",
 ] }
-lazy_static = "1.4.0"
-regex = "1.7.3"
-markdown = "1.0.0-alpha.11"
+lazy_static = { version = "1.4.0" }
+regex = { version = "1.7.3" }
+markdown = { version = "1.0.0-alpha.11" }
 tokio = { version = "1", features = ["full"] }
-tempfile = "3.7.0"
-log = "0.4.19"
+tempfile = { version = "3.7.0" }
+log = { version = "0.4.19" }
 reqwest = { version = "0.11.22", features = ["blocking", "json"] }
-ignore = "0.4.20"
-homedir = "0.2.1"
+ignore = { version = "0.4.20" }
+homedir = { version = "0.2.1" }
 
 [dev-dependencies]
 insta = { version = "1.30.0", features = ["yaml"] }

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -32,13 +32,13 @@ serde = { version = "1.0.164", features = ["derive"] }
 serde_json = { version = "1.0.91", features = ["preserve_order"] }
 marzano-util = { path = "../util" }
 grit-util = { path = "../grit-util" }
-regex = "1.7.1"
-anyhow = "1.0.70"
-itertools = "0.10.5"
-lazy_static = "1.4.0"
+regex = { version = "1.7.1" }
+anyhow = { version = "1.0.70" }
+itertools = { version = "0.10.5" }
+lazy_static = { version = "1.4.0" }
 ignore = { version = "0.4.21", optional = true }
 web-sys = { version = "0.3.66", features = ["console"], optional = true }
-enum_dispatch = "0.3.12"
+enum_dispatch = { version = "0.3.12" }
 clap = { version = "4.1.13", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 rust.unused_crate_dependencies = "warn"
 
 [dependencies]
-tower-lsp = "0.20.0"
+tower-lsp = { version = "0.20.0" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
+serde_json = { version = "1.0.96" }
 marzano-core = { path = "../core", default-features = false, features = [
   "non_wasm",
 ] }
@@ -19,8 +19,8 @@ grit_cache = { path = "../gritcache", optional = true }
 marzano-language = { path = "../language" }
 ai_builtins = { git = "https://github.com/getgrit/ai_builtins.git", optional = true }
 marzano-util = { path = "../util", features = ["finder"] }
-anyhow = "1.0.70"
-dashmap = "5.5.3"
+anyhow = { version = "1.0.70" }
+dashmap = { version = "5.5.3" }
 uuid = { version = "1.1", features = ["v4", "serde"] }
 tracing = { version = "0.1.40", default-features = false, features = [] }
 tracing-opentelemetry = { version = "0.22.0", optional = true, default-features = false, features = [] }

--- a/crates/marzano_messenger/Cargo.toml
+++ b/crates/marzano_messenger/Cargo.toml
@@ -12,12 +12,12 @@ rust.unused_crate_dependencies = "warn"
 clap = { version = "4.1.13", features = ["derive"] }
 # Do *NOT* upgrade beyond 1.0.171 until https://github.com/serde-rs/serde/issues/2538 is fixed
 serde = { version = "1.0.164", features = ["derive"] }
-anyhow = "1.0.70"
-colored = "2.0.4"
-dialoguer = "0.10.4"
+anyhow = { version = "1.0.70" }
+colored = { version = "2.0.4" }
+dialoguer = { version = "0.10.4" }
 log = { version = "0.4.19" }
-indicatif = "0.17.5"
-serde_json = "1.0.113"
+indicatif = { version = "0.17.5" }
+serde_json = { version = "1.0.113" }
 
 
 marzano-core = { path = "../core", features = [

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -9,9 +9,9 @@ rust.unused_crate_dependencies = "warn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.70"
+anyhow = { version = "1.0.70" }
 marzano-auth = { path = "../auth" }
-assert_cmd = "2.0.12"
-tempfile = "3.1"
-fs_extra = "1.3"
+assert_cmd = { version = "2.0.12" }
+tempfile = { version = "3.1" }
+fs_extra = { version = "1.3" }
 

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -12,20 +12,20 @@ rust.unused_crate_dependencies = "warn"
 tree-sitter = { path = "../../vendor/tree-sitter-facade", package = "tree-sitter-facade-sg" }
 grit-util = { path = "../grit-util" }
 serde = { version = "1.0.164", features = ["derive"] }
-base64 = "0.21.2"
-anyhow = "1.0.70"
+base64 = { version = "0.21.2" }
+anyhow = { version = "1.0.70" }
 log = { version = "0.4.20", optional = true }
 ignore = { version = "0.4.21", optional = true }
 sha2 = { version = "0.10.8" }
-derive_builder = "0.13.1"
+derive_builder = { version = "0.13.1" }
 reqwest = { version = "0.11.22", features = [
   "blocking",
   "json",
 ], optional = true }
 tokio = { version = "1.35.1", optional = true }
-serde_json = "1.0.114"
+serde_json = { version = "1.0.114" }
 futures = { version = "0.3.29", optional = true }
-http = "0.2.11"
+http = { version = "0.2.11" }
 
 [features]
 finder = ["log", "ignore"]

--- a/crates/wasm-bindings/Cargo.toml
+++ b/crates/wasm-bindings/Cargo.toml
@@ -18,11 +18,11 @@ marzano-language = { path = "../language", default-features = false }
 marzano-util = { path = "../util" }
 ai_builtins = { git = "https://github.com/getgrit/ai_builtins.git", optional = true}
 wasm-bindgen = { version = "0.2.89", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.39"
-serde-wasm-bindgen = "0.6"
+wasm-bindgen-futures = { version = "0.4.39" }
+serde-wasm-bindgen = { version = "0.6" }
 web-tree-sitter-sg = { path = "../../vendor/web-tree-sitter" }
 tree-sitter = { path = "../../vendor/tree-sitter-facade", package = "tree-sitter-facade-sg" }
-console_error_panic_hook = "0.1.7"
+console_error_panic_hook = { version = "0.1.7" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 anyhow = "1.0.70"


### PR DESCRIPTION
Adds support for using or/and/any *inside* an `includes` pattern and enforces a Cargo convention of always using the expanded version format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new pattern to check for the usage of certain dependencies in Cargo.toml files, enhancing code quality and consistency.
- **Refactor**
	- Updated dependency declarations across various crates to use version objects, improving clarity and version control.
	- Streamlined pattern matching logic in core functionality, optimizing code structure.
- **Tests**
	- Added new test functions to verify inclusion conditions, ensuring robustness and reliability of pattern matching features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->