### PR TITLE
feat: test match only with filenames

### DIFF
--- a/crates/cli_bin/fixtures/match_filename/.grit/grit.yaml
+++ b/crates/cli_bin/fixtures/match_filename/.grit/grit.yaml
@@ -1,0 +1,23 @@
+version: 0.0.1
+patterns:
+  - name: rewrite_filename
+    body: |
+      engine marzano(0.1)
+      language markdown
+
+      file($name, $body) where {
+        $name <: `index.js`
+      }
+    samples:
+      - input: |
+          // @filename: index.js
+
+          console.log('hello')
+        output: |
+          // @filename: index.js
+
+          console.log('hello')
+      - input: |
+          // @filename: main.js
+
+          // This should be unmatched

--- a/crates/cli_bin/tests/patterns_test.rs
+++ b/crates/cli_bin/tests/patterns_test.rs
@@ -247,3 +247,19 @@ fn tests_patterns_with_foreign_function_call_from_dot_grit_lib() -> Result<()> {
     assert!(output.status.success());
     Ok(())
 }
+
+#[test]
+fn checks_non_matching_yaml_sample() -> Result<()> {
+    let (_temp_dir, dir) = get_fixture("yaml_unmatched", false)?;
+
+    let mut test = get_test_cmd()?;
+    test.arg("patterns")
+        .arg("test")
+        .current_dir(dir);
+
+    let output = test.output()?;
+
+    assert!(output.status.success());
+
+    Ok(())
+}

--- a/crates/cli_bin/tests/patterns_test.rs
+++ b/crates/cli_bin/tests/patterns_test.rs
@@ -263,3 +263,20 @@ fn checks_non_matching_yaml_sample() -> Result<()> {
 
     Ok(())
 }
+
+
+#[test]
+fn tests_match_only_with_file_name() -> Result<()> {
+    let (_temp_dir, dir) = get_fixture("match_filename", false)?;
+
+    let mut test = get_test_cmd()?;
+    test.arg("patterns")
+        .arg("test")
+        .current_dir(dir);
+
+    let output = test.output()?;
+
+    assert!(output.status.success());
+
+    Ok(())
+}

--- a/crates/cli_bin/tests/plumbing.rs
+++ b/crates/cli_bin/tests/plumbing.rs
@@ -255,19 +255,3 @@ fn lists_imported_patterns() -> Result<()> {
 
     Ok(())
 }
-
-#[test]
-fn checks_non_matching_yaml_sample() -> Result<()> {
-    let (_temp_dir, dir) = get_fixture("yaml_unmatched", false)?;
-
-    let mut test = get_test_cmd()?;
-    test.arg("patterns")
-        .arg("test")
-        .current_dir(dir);
-
-    let output = test.output()?;
-
-    assert!(output.status.success());
-
-    Ok(())
-}

--- a/crates/gritmodule/src/testing.rs
+++ b/crates/gritmodule/src/testing.rs
@@ -224,7 +224,7 @@ pub fn test_pattern_sample(
             }
             MatchResult::Match(r) => {
                 if sample.input.contains("// @filename:")
-                    && !sample.output.is_some_and(|o| o == sample.input)
+                    && !sample.output.as_ref().is_some_and(|o| o == &sample.input)
                 {
                     continue;
                 }

--- a/crates/gritmodule/src/testing.rs
+++ b/crates/gritmodule/src/testing.rs
@@ -223,7 +223,7 @@ pub fn test_pattern_sample(
                 });
             }
             MatchResult::Match(r) => {
-                if sample.input.contains("// @filename:") {
+                if is_multifile_sample(&sample.input) {
                     continue;
                 }
                 raw_actual_outputs.push(RichFile {
@@ -239,7 +239,7 @@ pub fn test_pattern_sample(
     if raw_actual_outputs.is_empty() {
         if sample.output.is_none() {
             return SampleTestResult::new_passing(matches, false);
-        } else {
+        } else if !is_multifile_sample(&sample.input) {
             return SampleTestResult {
                 matches,
                 state: GritTestResultState::FailedMatch,
@@ -269,7 +269,7 @@ pub fn test_pattern_sample(
     let mut raw_expected_outputs = infer_rich_files_from_content(&compiled.language, sample_output);
 
     if raw_actual_outputs.len() < raw_expected_outputs.len()
-        && sample.input.contains("// @filename:")
+        && is_multifile_sample(&sample.input)
     {
         for file in rich_files.iter() {
             if raw_actual_outputs.iter().any(|f| f.path == file.path) {
@@ -327,6 +327,10 @@ pub fn test_pattern_sample(
             actual_outputs: None,
         },
     }
+}
+
+fn is_multifile_sample(input: &str) -> bool {
+    input.contains("// @filename:")
 }
 
 #[derive(Debug)]

--- a/crates/gritmodule/src/testing.rs
+++ b/crates/gritmodule/src/testing.rs
@@ -223,9 +223,7 @@ pub fn test_pattern_sample(
                 });
             }
             MatchResult::Match(r) => {
-                if sample.input.contains("// @filename:")
-                    && !sample.output.as_ref().is_some_and(|o| o == &sample.input)
-                {
+                if sample.input.contains("// @filename:") {
                     continue;
                 }
                 raw_actual_outputs.push(RichFile {
@@ -270,7 +268,9 @@ pub fn test_pattern_sample(
 
     let mut raw_expected_outputs = infer_rich_files_from_content(&compiled.language, sample_output);
 
-    if raw_actual_outputs.len() < raw_expected_outputs.len() && compiled.is_multifile {
+    if raw_actual_outputs.len() < raw_expected_outputs.len()
+        && sample.input.contains("// @filename:")
+    {
         for file in rich_files.iter() {
             if raw_actual_outputs.iter().any(|f| f.path == file.path) {
                 continue;

--- a/crates/gritmodule/src/testing.rs
+++ b/crates/gritmodule/src/testing.rs
@@ -223,7 +223,9 @@ pub fn test_pattern_sample(
                 });
             }
             MatchResult::Match(r) => {
-                if sample.input.contains("// @filename:") {
+                if sample.input.contains("// @filename:")
+                    && !sample.output.is_some_and(|o| o == sample.input)
+                {
                     continue;
                 }
                 raw_actual_outputs.push(RichFile {


### PR DESCRIPTION
Extend distinguishing match only from no result outcomes for samples with file names or multiple files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `grit.yaml` for specifying rules to rewrite filenames in Markdown files.
- **Tests**
	- Added new tests for validating filename rewriting patterns.
	- Removed an outdated test function.
- **Refactor**
	- Updated test functionality to better handle multifile samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->