### PR TITLE
fix: `--exclude ai` should not exclude pattern names with ai substring

### DIFF
--- a/crates/cli/src/commands/patterns.rs
+++ b/crates/cli/src/commands/patterns.rs
@@ -41,8 +41,11 @@ pub struct PatternsTestArgs {
     /// Regex of a specific pattern to test
     #[clap(long = "filter")]
     pub filter: Option<String>,
-    /// Regex of tags and pattern names to exclude
-    #[clap(long = "exclude")]
+    /// Tags and pattern names to exclude
+    #[clap(
+        long = "exclude",
+        help = "Tags and pattern names to exclude. Only direct matches will be excluded."
+    )]
     pub exclude: Vec<String>,
     /// Show verbose output
     #[clap(long = "verbose")]

--- a/crates/cli/src/commands/patterns_test.rs
+++ b/crates/cli/src/commands/patterns_test.rs
@@ -261,12 +261,9 @@ pub(crate) async fn run_patterns_test(
 
     if !arg.exclude.is_empty() {
         for exclusion in &arg.exclude {
-            let regex = regex::Regex::new(exclusion)?;
             patterns = patterns
                 .into_iter()
-                .filter(|p| {
-                    !regex.is_match(&p.local_name) && p.tags().iter().all(|t| !regex.is_match(t))
-                })
+                .filter(|p| &p.local_name != exclusion && p.tags().iter().all(|t| t != exclusion))
                 .collect::<Vec<_>>()
         }
     }

--- a/crates/cli_bin/tests/patterns_test.rs
+++ b/crates/cli_bin/tests/patterns_test.rs
@@ -82,6 +82,25 @@ fn test_excludes_patterns() -> Result<()> {
 }
 
 #[test]
+fn does_not_exclude_substring_name_match() -> Result<()> {
+    let (_temp_dir, _) = get_fixture("patterns_list", true)?;
+    let mut cmd = get_test_cmd()?;
+
+    cmd.arg("patterns")
+        .arg("test")
+        .arg("--exclude")
+        .arg("pattern")
+        .current_dir(_temp_dir.path().join("patterns_list"));
+
+    let stdout = String::from_utf8(cmd.output()?.stdout)?;
+
+    assert!(stdout.contains("multiple_broken_patterns"));
+    assert!(stdout.contains("broken_pattern"));
+
+    Ok(())
+}
+
+#[test]
 fn updates_multiple_invalid_patterns() -> Result<()> {
     let (_temp_dir, _) = get_fixture("patterns_list", true)?;
 


### PR DESCRIPTION
fixes #167 

I think this is a better solution since you sometimes still want to exclude a single pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Improved the exclusion filtering logic in pattern tests for more precise matches.
- **Documentation**
	- Updated documentation for the `exclude` field in pattern tests to clarify behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->