### PR TITLE
chore: extract more node compilers (B)

### DIFF
--- a/crates/core/src/pattern/before.rs
+++ b/crates/core/src/pattern/before.rs
@@ -1,52 +1,21 @@
 use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::{pattern_to_binding, ResolvedPattern},
-    variable::VariableSourceLocations,
-    Node, State,
+    State,
 };
-use crate::{
-    binding::Constant, context::Context, errors::debug, pattern_compiler::CompilationContext,
-    resolve,
-};
-use anyhow::{anyhow, bail, Result};
-use core::fmt::Debug;
+use crate::{binding::Constant, context::Context, errors::debug, resolve};
+use anyhow::{bail, Result};
 use grit_util::AstNode;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
 pub struct Before {
-    pub(crate) before: Pattern,
+    pub before: Pattern,
 }
 
 impl Before {
     pub fn new(before: Pattern) -> Self {
         Self { before }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let pattern = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of patternBefore"))?;
-        let pattern = Pattern::from_node(
-            &pattern,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        Ok(Self::new(pattern))
     }
 
     pub(crate) fn prev_pattern<'a>(

--- a/crates/core/src/pattern/bubble.rs
+++ b/crates/core/src/pattern/bubble.rs
@@ -1,19 +1,14 @@
 use super::patterns::Name;
 use super::resolved_pattern::ResolvedPattern;
-use super::variable::{get_variables, register_variable, VariableSourceLocations};
 use super::{patterns::Matcher, patterns::Pattern, PatternDefinition, State};
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, bail, Result};
-use itertools::Itertools;
+use crate::context::Context;
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use marzano_util::position::Range;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Bubble {
-    pub(crate) pattern_def: PatternDefinition,
-    pub(crate) args: Vec<Option<Pattern>>,
+    pub pattern_def: PatternDefinition,
+    pub args: Vec<Option<Pattern>>,
 }
 
 impl Bubble {
@@ -22,84 +17,6 @@ impl Bubble {
             pattern_def,
             args: args.into_iter().map(Some).collect(),
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Pattern> {
-        let local_scope_index = vars_array.len();
-        vars_array.push(vec![]);
-        let mut local_vars = BTreeMap::new();
-        // important that this occurs first, as calls assume
-        // that parameters are registered first
-
-        let parameters = node
-            .children_by_field_name("variables", &mut node.walk())
-            .filter(|n| n.is_named())
-            .map(|n| {
-                Ok((
-                    n.utf8_text(context.src.as_bytes())?.trim().to_string(),
-                    n.range().into(),
-                ))
-            })
-            .collect::<Result<Vec<(String, Range)>>>()?;
-        if parameters.iter().unique_by(|n| n.0.clone()).count() != parameters.len() {
-            bail!("bubble parameters must be unique, but had a repeated name in its parameters.")
-        }
-        let params = get_variables(
-            &parameters,
-            context.file,
-            vars_array,
-            local_scope_index,
-            &mut local_vars,
-            global_vars,
-        )?;
-
-        let body = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing body of patternDefinition"))?;
-        let body = Pattern::from_node(
-            &body,
-            context,
-            &mut local_vars,
-            vars_array,
-            local_scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        let args = parameters
-            .iter()
-            .map(|(name, range)| {
-                let v = Pattern::Variable(register_variable(
-                    name,
-                    context.file,
-                    *range,
-                    vars,
-                    global_vars,
-                    vars_array,
-                    scope_index,
-                )?);
-                Ok(v)
-            })
-            .collect::<Result<Vec<Pattern>>>()?;
-
-        let pattern_def = PatternDefinition::new(
-            "<bubble>".to_string(),
-            local_scope_index,
-            params,
-            local_vars.values().cloned().collect(),
-            body,
-        );
-
-        Ok(Pattern::Bubble(Box::new(Self::new(pattern_def, args))))
     }
 }
 

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -54,8 +54,8 @@ use super::{
 use crate::{
     context::Context,
     pattern_compiler::{
-        accessor_compiler::AccessorCompiler, before_compiler::BeforeCompiler, CompilationContext,
-        NodeCompiler,
+        accessor_compiler::AccessorCompiler, before_compiler::BeforeCompiler,
+        bubble_compiler::BubbleCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -865,7 +865,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "bubble" => Bubble::from_node(
+            "bubble" => Ok(Pattern::Bubble(Box::new(BubbleCompiler::from_node(
                 node,
                 context,
                 vars,
@@ -873,7 +873,7 @@ impl Pattern {
                 scope_index,
                 global_vars,
                 logs,
-            ),
+            )?))),
             "some" => Ok(Pattern::Some(Box::new(Some::from_node(
                 node,
                 context,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -53,7 +53,10 @@ use super::{
 };
 use crate::{
     context::Context,
-    pattern_compiler::{accessor_compiler::AccessorCompiler, CompilationContext, NodeCompiler},
+    pattern_compiler::{
+        accessor_compiler::AccessorCompiler, before_compiler::BeforeCompiler, CompilationContext,
+        NodeCompiler,
+    },
 };
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
@@ -798,7 +801,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternBefore" => Ok(Pattern::Before(Box::new(Before::from_node(
+            "patternBefore" => Ok(Pattern::Before(Box::new(BeforeCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern_compiler/before_compiler.rs
+++ b/crates/core/src/pattern_compiler/before_compiler.rs
@@ -1,0 +1,37 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{before::Before, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct BeforeCompiler;
+
+impl NodeCompiler for BeforeCompiler {
+    type TargetPattern = Before;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let pattern = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of patternBefore"))?;
+        let pattern = Pattern::from_node(
+            &pattern,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        Ok(Before::new(pattern))
+    }
+}

--- a/crates/core/src/pattern_compiler/bubble_compiler.rs
+++ b/crates/core/src/pattern_compiler/bubble_compiler.rs
@@ -1,0 +1,96 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    bubble::Bubble,
+    pattern_definition::PatternDefinition,
+    patterns::Pattern,
+    variable::{get_variables, register_variable, VariableSourceLocations},
+};
+use anyhow::{anyhow, bail, Result};
+use itertools::Itertools;
+use marzano_util::{analysis_logs::AnalysisLogs, position::Range};
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct BubbleCompiler;
+
+impl NodeCompiler for BubbleCompiler {
+    type TargetPattern = Bubble;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let local_scope_index = vars_array.len();
+        vars_array.push(vec![]);
+        let mut local_vars = BTreeMap::new();
+        // important that this occurs first, as calls assume
+        // that parameters are registered first
+
+        let parameters = node
+            .children_by_field_name("variables", &mut node.walk())
+            .filter(|n| n.is_named())
+            .map(|n| {
+                Ok((
+                    n.utf8_text(context.src.as_bytes())?.trim().to_string(),
+                    n.range().into(),
+                ))
+            })
+            .collect::<Result<Vec<(String, Range)>>>()?;
+        if parameters.iter().unique_by(|n| n.0.clone()).count() != parameters.len() {
+            bail!("bubble parameters must be unique, but had a repeated name in its parameters.")
+        }
+        let params = get_variables(
+            &parameters,
+            context.file,
+            vars_array,
+            local_scope_index,
+            &mut local_vars,
+            global_vars,
+        )?;
+
+        let body = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing body of patternDefinition"))?;
+        let body = Pattern::from_node(
+            &body,
+            context,
+            &mut local_vars,
+            vars_array,
+            local_scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        let args = parameters
+            .iter()
+            .map(|(name, range)| {
+                let v = Pattern::Variable(register_variable(
+                    name,
+                    context.file,
+                    *range,
+                    vars,
+                    global_vars,
+                    vars_array,
+                    scope_index,
+                )?);
+                Ok(v)
+            })
+            .collect::<Result<Vec<Pattern>>>()?;
+
+        let pattern_def = PatternDefinition::new(
+            "<bubble>".to_string(),
+            local_scope_index,
+            params,
+            local_vars.values().cloned().collect(),
+            body,
+        );
+
+        Ok(Bubble::new(pattern_def, args))
+    }
+}

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod accessor_compiler;
 mod auto_wrap;
 pub(crate) mod before_compiler;
+pub(crate) mod bubble_compiler;
 pub mod compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod accessor_compiler;
 mod auto_wrap;
+pub(crate) mod before_compiler;
 pub mod compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;


### PR DESCRIPTION
Applies the node compiler pattern from https://github.com/getgrit/gritql/pull/164 to yet more node types.

See also: https://github.com/getgrit/gritql/pull/173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Adjusted visibility and simplified the `Before` and `Bubble` structs.
	- Removed unused imports across various modules.
- **New Features**
	- Introduced `BeforeCompiler` and `BubbleCompiler` for compiling `Before` and `Bubble` patterns from nodes.
- **Chores**
	- Added new modules for pattern compilation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->