### PR TITLE
chore: extract more node compilers (C)

### DIFF
--- a/crates/core/src/pattern/assignment.rs
+++ b/crates/core/src/pattern/assignment.rs
@@ -6,7 +6,10 @@ use super::{
     variable::{is_reserved_metavariable, VariableSourceLocations},
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
+use crate::{
+    context::Context,
+    pattern_compiler::{container_compiler::ContainerCompiler, CompilationContext, NodeCompiler},
+};
 use anyhow::{anyhow, bail, Result};
 use marzano_language::{language::GRIT_METAVARIABLE_PREFIX, target_language::TargetLanguage};
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -54,7 +57,7 @@ impl Assignment {
         if is_reserved_metavariable(&var_text, None::<&TargetLanguage>) {
             bail!("{} is a reserved metavariable name. For more information, check out the docs at https://docs.grit.io/language/patterns#metavariables.", var_text.trim_start_matches(GRIT_METAVARIABLE_PREFIX));
         }
-        let variable = Container::from_node(
+        let variable = ContainerCompiler::from_node(
             &container,
             context,
             vars,

--- a/crates/core/src/pattern/contains.rs
+++ b/crates/core/src/pattern/contains.rs
@@ -1,63 +1,23 @@
 use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::{LazyBuiltIn, ResolvedPattern, ResolvedSnippet},
-    variable::VariableSourceLocations,
     Node, State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext, resolve};
-use anyhow::{anyhow, Result};
+use crate::{context::Context, resolve};
+use anyhow::Result;
 use core::fmt::Debug;
 use im::vector;
 use marzano_util::{analysis_logs::AnalysisLogs, node_with_source::NodeWithSource};
-use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
 pub struct Contains {
-    pub(crate) contains: Pattern,
-    pub(crate) until: Option<Pattern>,
+    pub contains: Pattern,
+    pub until: Option<Pattern>,
 }
 
 impl Contains {
     pub fn new(contains: Pattern, until: Option<Pattern>) -> Self {
         Self { contains, until }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let contains = node
-            .child_by_field_name("contains")
-            .ok_or_else(|| anyhow!("missing contains of patternContains"))?;
-        let contains = Pattern::from_node(
-            &contains,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        let until = node.child_by_field_name("until").map(|n| {
-            Pattern::from_node(
-                &n,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                false,
-                logs,
-            )
-        });
-        let until = until.map_or(Ok(None), |v| v.map(Some))?;
-        Ok(Self::new(contains, until))
     }
 }
 

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     binding::{Binding, Constant},
     context::Context,
-    pattern_compiler::CompilationContext,
+    pattern_compiler::{container_compiler::ContainerCompiler, CompilationContext, NodeCompiler},
     resolve_opt,
 };
 use anyhow::{anyhow, bail, Result};
@@ -61,7 +61,7 @@ impl ListIndex {
                 logs,
             )?)
         } else {
-            ListOrContainer::Container(Container::from_node(
+            ListOrContainer::Container(ContainerCompiler::from_node(
                 &list,
                 context,
                 vars,
@@ -84,7 +84,7 @@ impl ListIndex {
                     .map_err(|_| anyhow!("list index must be an integer"))?,
             )
         } else {
-            ContainerOrIndex::Container(Container::from_node(
+            ContainerOrIndex::Container(ContainerCompiler::from_node(
                 &index_node,
                 context,
                 vars,

--- a/crates/core/src/pattern/match.rs
+++ b/crates/core/src/pattern/match.rs
@@ -6,7 +6,11 @@ use super::{
     variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, errors::debug, pattern_compiler::CompilationContext};
+use crate::{
+    context::Context,
+    errors::debug,
+    pattern_compiler::{container_compiler::ContainerCompiler, CompilationContext, NodeCompiler},
+};
 use anyhow::{anyhow, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -34,7 +38,7 @@ impl Match {
         let value = node
             .child_by_field_name("left")
             .ok_or_else(|| anyhow!("missing lhs of predicateMatch"))?;
-        let value = Container::from_node(
+        let value = ContainerCompiler::from_node(
             &value,
             context,
             vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -53,7 +53,10 @@ use super::{
 };
 use crate::{
     context::Context,
-    pattern_compiler::{accessor_compiler::AccessorCompiler, CompilationContext, NodeCompiler},
+    pattern_compiler::{
+        accessor_compiler::AccessorCompiler, contains_compiler::ContainsCompiler,
+        CompilationContext, NodeCompiler,
+    },
 };
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
@@ -807,7 +810,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternContains" => Ok(Pattern::Contains(Box::new(Contains::from_node(
+            "patternContains" => Ok(Pattern::Contains(Box::new(ContainsCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern_compiler/accessor_compiler.rs
+++ b/crates/core/src/pattern_compiler/accessor_compiler.rs
@@ -1,7 +1,9 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use super::{
+    compiler::CompilationContext, container_compiler::ContainerCompiler,
+    node_compiler::NodeCompiler,
+};
 use crate::pattern::{
     accessor::{Accessor, AccessorKey, AccessorMap},
-    container::Container,
     map::GritMap,
     variable::{Variable, VariableSourceLocations},
 };
@@ -39,7 +41,7 @@ impl NodeCompiler for AccessorCompiler {
                 logs,
             )?)
         } else {
-            AccessorMap::Container(Container::from_node(
+            AccessorMap::Container(ContainerCompiler::from_node(
                 &map,
                 context,
                 vars,

--- a/crates/core/src/pattern_compiler/container_compiler.rs
+++ b/crates/core/src/pattern_compiler/container_compiler.rs
@@ -1,0 +1,59 @@
+use super::{
+    accessor_compiler::AccessorCompiler, compiler::CompilationContext, node_compiler::NodeCompiler,
+};
+use crate::pattern::{
+    container::Container,
+    list_index::ListIndex,
+    variable::{Variable, VariableSourceLocations},
+};
+use anyhow::{bail, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct ContainerCompiler;
+
+impl NodeCompiler for ContainerCompiler {
+    type TargetPattern = Container;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        match node.kind().as_ref() {
+            "variable" => Ok(Container::Variable(Variable::from_node(
+                node,
+                context.file,
+                context.src,
+                vars,
+                global_vars,
+                vars_array,
+                scope_index,
+            )?)),
+            "mapAccessor" => Ok(Container::Accessor(Box::new(AccessorCompiler::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            "listIndex" => Ok(Container::ListIndex(Box::new(ListIndex::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            s => bail!("Invalid kind for container: {}", s),
+        }
+    }
+}

--- a/crates/core/src/pattern_compiler/contains_compiler.rs
+++ b/crates/core/src/pattern_compiler/contains_compiler.rs
@@ -1,0 +1,50 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{contains::Contains, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct ContainsCompiler;
+
+impl NodeCompiler for ContainsCompiler {
+    type TargetPattern = Contains;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let contains = node
+            .child_by_field_name("contains")
+            .ok_or_else(|| anyhow!("missing contains of patternContains"))?;
+        let contains = Pattern::from_node(
+            &contains,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        let until = node.child_by_field_name("until").map(|n| {
+            Pattern::from_node(
+                &n,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                false,
+                logs,
+            )
+        });
+        let until = until.map_or(Ok(None), |v| v.map(Some))?;
+        Ok(Contains::new(contains, until))
+    }
+}

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod accessor_compiler;
 mod auto_wrap;
 pub mod compiler;
 pub(crate) mod container_compiler;
+pub(crate) mod contains_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod accessor_compiler;
 mod auto_wrap;
 pub mod compiler;
+pub(crate) mod container_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 


### PR DESCRIPTION
Applies the node compiler pattern from https://github.com/getgrit/gritql/pull/164 to yet more node types.

See also: https://github.com/getgrit/gritql/pull/173

PS.: I skipped `Call` and `CodeSnippet`, since they require a slightly different `from_node()` signature. I'll first do the easiest ones, and when I have a better overview of the signatures, I'll update again.