### PR TITLE
chore: extract more node compilers (D/E/F)

### DIFF
--- a/crates/core/src/pattern/divide.rs
+++ b/crates/core/src/pattern/divide.rs
@@ -2,63 +2,20 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
-use crate::{binding::Constant, context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::{binding::Constant, context::Context};
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Divide {
-    pub(crate) lhs: Pattern,
-    pub(crate) rhs: Pattern,
+    pub lhs: Pattern,
+    pub rhs: Pattern,
 }
 
 impl Divide {
     pub fn new(lhs: Pattern, rhs: Pattern) -> Self {
         Self { lhs, rhs }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let left = node
-            .child_by_field_name("left")
-            .ok_or_else(|| anyhow!("missing left of divide"))?;
-        let left = Pattern::from_node(
-            &left,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        let right = node
-            .child_by_field_name("right")
-            .ok_or_else(|| anyhow!("missing right of divide"))?;
-        let right = Pattern::from_node(
-            &right,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        Ok(Self::new(left, right))
     }
 
     pub(crate) fn call<'a>(

--- a/crates/core/src/pattern/equal.rs
+++ b/crates/core/src/pattern/equal.rs
@@ -1,67 +1,22 @@
 use super::{
     functions::{Evaluator, FuncEvaluation},
     patterns::{Name, Pattern},
-    variable::{Variable, VariableSourceLocations},
+    variable::Variable,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::context::Context;
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Equal {
-    var: Variable,
-    pub(crate) pattern: Pattern,
+    pub var: Variable,
+    pub pattern: Pattern,
 }
+
 impl Equal {
     pub fn new(var: Variable, pattern: Pattern) -> Self {
         Self { var, pattern }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let variable = node
-            .child_by_field_name("left")
-            .ok_or_else(|| anyhow!("missing lhs of predicateEqual"))?;
-        let variable = Pattern::from_node(
-            &variable,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            true,
-            logs,
-        )?;
-        let pattern = node
-            .child_by_field_name("right")
-            .ok_or_else(|| anyhow!("missing rhs of predicateEqual"))?;
-        let pattern = Pattern::from_node(
-            &pattern,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            true,
-            logs,
-        )?;
-        if let Pattern::Variable(var) = variable {
-            Ok(Equal::new(var, pattern))
-        } else {
-            Err(anyhow!(
-                "predicateEqual must have a variable as first argument",
-            ))
-        }
     }
 }
 

--- a/crates/core/src/pattern/every.rs
+++ b/crates/core/src/pattern/every.rs
@@ -1,49 +1,21 @@
 use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext, resolve};
-use anyhow::{anyhow, Result};
+use crate::{context::Context, resolve};
+use anyhow::Result;
 use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Every {
-    pub(crate) pattern: Pattern,
+    pub pattern: Pattern,
 }
 
 impl Every {
     pub fn new(pattern: Pattern) -> Self {
         Self { pattern }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let within = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of pattern every"))?;
-        let within = Pattern::from_node(
-            &within,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        Ok(Every::new(within))
     }
 }
 

--- a/crates/core/src/pattern/function_definition.rs
+++ b/crates/core/src/pattern/function_definition.rs
@@ -1,20 +1,18 @@
 use super::{
-    and::PrAnd,
     functions::{Evaluator, FuncEvaluation},
     patterns::Pattern,
     predicates::Predicate,
     resolved_pattern::patterns_to_resolved,
     state::State,
-    variable::{get_variables, Variable, VariableSourceLocations},
+    variable::Variable,
 };
-use crate::{binding::Constant, context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, bail, Result};
+use crate::{binding::Constant, context::Context};
+use anyhow::{bail, Result};
 #[cfg(feature = "external_functions")]
 use marzano_externals::function::ExternalFunction;
 use marzano_language::foreign_language::ForeignLanguage;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::{borrow::Cow, collections::BTreeMap};
-use tree_sitter::Node;
+use std::borrow::Cow;
 
 pub(crate) trait FunctionDefinition {
     fn call<'a>(
@@ -29,7 +27,7 @@ pub(crate) trait FunctionDefinition {
 #[derive(Clone, Debug)]
 pub struct GritFunctionDefinition {
     pub name: String,
-    scope: usize,
+    pub scope: usize,
     pub params: Vec<(String, Variable)>,
     pub local_vars: Vec<usize>,
     pub function: Predicate,
@@ -50,59 +48,6 @@ impl GritFunctionDefinition {
             local_vars,
             function,
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        function_definitions: &mut Vec<GritFunctionDefinition>,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<()> {
-        let name = node
-            .child_by_field_name("name")
-            .ok_or_else(|| anyhow!("missing name of function definition"))?;
-        let name = name.utf8_text(context.src.as_bytes())?;
-        let name = name.trim();
-        let scope_index = vars_array.len();
-        vars_array.push(vec![]);
-        let mut local_vars = BTreeMap::new();
-
-        let params = get_variables(
-            &context
-                .function_definition_info
-                .get(name)
-                .ok_or_else(|| anyhow!("cannot get info for function {}", name))?
-                .parameters,
-            context.file,
-            vars_array,
-            scope_index,
-            &mut local_vars,
-            global_vars,
-        )?;
-
-        let body = node
-            .child_by_field_name("body")
-            .ok_or_else(|| anyhow!("missing body of grit function definition"))?;
-        let body = PrAnd::from_node(
-            &body,
-            context,
-            &mut local_vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        let function_definition = GritFunctionDefinition::new(
-            name.to_owned(),
-            scope_index,
-            params,
-            local_vars.values().cloned().collect(),
-            body,
-        );
-        function_definitions.push(function_definition);
-        Ok(())
     }
 }
 
@@ -141,57 +86,6 @@ impl ForeignFunctionDefinition {
             language,
             code: code.to_vec(),
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        function_definitions: &mut Vec<ForeignFunctionDefinition>,
-        global_vars: &mut BTreeMap<String, usize>,
-    ) -> Result<()> {
-        let name = node
-            .child_by_field_name("name")
-            .ok_or_else(|| anyhow!("missing name of function definition"))?;
-        let name = name.utf8_text(context.src.as_bytes())?;
-        let name = name.trim();
-        let scope_index = vars_array.len();
-        vars_array.push(vec![]);
-        let mut local_vars = BTreeMap::new();
-        let params = get_variables(
-            &context
-                .foreign_function_definition_info
-                .get(name)
-                .ok_or_else(|| anyhow!("cannot get info for function {}", name))?
-                .parameters,
-            context.file,
-            vars_array,
-            scope_index,
-            &mut local_vars,
-            global_vars,
-        )?;
-        let body = node
-            .child_by_field_name("body")
-            .ok_or_else(|| anyhow!("missing body of foreign function definition"))?
-            .child_by_field_name("code")
-            .ok_or_else(|| anyhow!("missing code of foreign function body"))?;
-        let byte_range = body.byte_range();
-        let byte_range = byte_range.start as usize..byte_range.end as usize;
-        let body = &context.src.as_bytes()[byte_range];
-        let foreign_language = ForeignLanguage::from_node(
-            node.child_by_field_name("language")
-                .ok_or_else(|| anyhow!("missing language of foreign function definition"))?,
-            context.src,
-        )?;
-        let function_definition = ForeignFunctionDefinition::new(
-            name.to_owned(),
-            scope_index,
-            params,
-            foreign_language,
-            body,
-        );
-        function_definitions.push(function_definition);
-        Ok(())
     }
 }
 

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -56,8 +56,8 @@ use crate::{
     pattern_compiler::{
         accessor_compiler::AccessorCompiler, accumulate_compiler::AccumulateCompiler,
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
-        any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler, CompilationContext,
-        NodeCompiler,
+        any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
+        divide_compiler::DivideCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -668,7 +668,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "divOperation" => Ok(Pattern::Divide(Box::new(Divide::from_node(
+            "divOperation" => Ok(Pattern::Divide(Box::new(DivideCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -57,7 +57,8 @@ use crate::{
         accessor_compiler::AccessorCompiler, accumulate_compiler::AccumulateCompiler,
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
         any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
-        divide_compiler::DivideCompiler, CompilationContext, NodeCompiler,
+        divide_compiler::DivideCompiler, every_compiler::EveryCompiler, CompilationContext,
+        NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -889,7 +890,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "every" => Ok(Pattern::Every(Box::new(Every::from_node(
+            "every" => Ok(Pattern::Every(Box::new(EveryCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/predicates.rs
+++ b/crates/core/src/pattern/predicates.rs
@@ -22,7 +22,7 @@ use crate::{
     context::Context,
     pattern_compiler::{
         accumulate_compiler::AccumulateCompiler, assignment_compiler::AssignmentCompiler,
-        CompilationContext, NodeCompiler,
+        equal_compiler::EqualCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -145,7 +145,7 @@ impl Predicate {
                 global_vars,
                 logs,
             )?))),
-            "predicateEqual" => Ok(Predicate::Equal(Box::new(Equal::from_node(
+            "predicateEqual" => Ok(Predicate::Equal(Box::new(EqualCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -1,4 +1,10 @@
-use super::auto_wrap::auto_wrap_pattern;
+use super::{
+    auto_wrap::auto_wrap_pattern,
+    function_definition_compiler::{
+        ForeignFunctionDefinitionCompiler, GritFunctionDefinitionCompiler,
+    },
+    NodeCompiler,
+};
 use crate::{
     parse::make_grit_parser,
     pattern::{
@@ -307,22 +313,25 @@ fn node_to_definitions(
                 logs,
             )?;
         } else if let Some(function_definition) = definition.child_by_field_name("function") {
-            GritFunctionDefinition::from_node(
+            function_definitions.push(GritFunctionDefinitionCompiler::from_node(
                 &function_definition,
                 context,
+                &mut BTreeMap::new(),
                 vars_array,
-                function_definitions,
+                0, // FIXME: Unused argument.
                 global_vars,
                 logs,
-            )?;
+            )?);
         } else if let Some(function_definition) = definition.child_by_field_name("foreign") {
-            ForeignFunctionDefinition::from_node(
+            foreign_function_definitions.push(ForeignFunctionDefinitionCompiler::from_node(
                 &function_definition,
                 context,
+                &mut BTreeMap::new(),
                 vars_array,
-                foreign_function_definitions,
+                0, // FIXME: Unused argument.
                 global_vars,
-            )?;
+                logs,
+            )?);
         } else {
             bail!(anyhow!(
                 "definition must be either a pattern, a predicate or a function"

--- a/crates/core/src/pattern_compiler/divide_compiler.rs
+++ b/crates/core/src/pattern_compiler/divide_compiler.rs
@@ -1,0 +1,52 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{divide::Divide, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct DivideCompiler;
+
+impl NodeCompiler for DivideCompiler {
+    type TargetPattern = Divide;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let left = node
+            .child_by_field_name("left")
+            .ok_or_else(|| anyhow!("missing left of divide"))?;
+        let left = Pattern::from_node(
+            &left,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        let right = node
+            .child_by_field_name("right")
+            .ok_or_else(|| anyhow!("missing right of divide"))?;
+        let right = Pattern::from_node(
+            &right,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        Ok(Divide::new(left, right))
+    }
+}

--- a/crates/core/src/pattern_compiler/equal_compiler.rs
+++ b/crates/core/src/pattern_compiler/equal_compiler.rs
@@ -1,0 +1,56 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{equal::Equal, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct EqualCompiler;
+
+impl NodeCompiler for EqualCompiler {
+    type TargetPattern = Equal;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let variable = node
+            .child_by_field_name("left")
+            .ok_or_else(|| anyhow!("missing lhs of predicateEqual"))?;
+        let variable = Pattern::from_node(
+            &variable,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            true,
+            logs,
+        )?;
+        let pattern = node
+            .child_by_field_name("right")
+            .ok_or_else(|| anyhow!("missing rhs of predicateEqual"))?;
+        let pattern = Pattern::from_node(
+            &pattern,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            true,
+            logs,
+        )?;
+        if let Pattern::Variable(var) = variable {
+            Ok(Equal::new(var, pattern))
+        } else {
+            Err(anyhow!(
+                "predicateEqual must have a variable as first argument",
+            ))
+        }
+    }
+}

--- a/crates/core/src/pattern_compiler/every_compiler.rs
+++ b/crates/core/src/pattern_compiler/every_compiler.rs
@@ -1,0 +1,37 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{every::Every, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct EveryCompiler;
+
+impl NodeCompiler for EveryCompiler {
+    type TargetPattern = Every;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let within = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of pattern every"))?;
+        let within = Pattern::from_node(
+            &within,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        Ok(Every::new(within))
+    }
+}

--- a/crates/core/src/pattern_compiler/function_definition_compiler.rs
+++ b/crates/core/src/pattern_compiler/function_definition_compiler.rs
@@ -1,0 +1,128 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    and::PrAnd,
+    function_definition::{ForeignFunctionDefinition, GritFunctionDefinition},
+    variable::{get_variables, VariableSourceLocations},
+};
+use anyhow::{anyhow, Result};
+use marzano_language::foreign_language::ForeignLanguage;
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct GritFunctionDefinitionCompiler;
+
+impl NodeCompiler for GritFunctionDefinitionCompiler {
+    type TargetPattern = GritFunctionDefinition;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        _vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        _scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let name = node
+            .child_by_field_name("name")
+            .ok_or_else(|| anyhow!("missing name of function definition"))?;
+        let name = name.utf8_text(context.src.as_bytes())?;
+        let name = name.trim();
+        let scope_index = vars_array.len();
+        vars_array.push(vec![]);
+        let mut local_vars = BTreeMap::new();
+
+        let params = get_variables(
+            &context
+                .function_definition_info
+                .get(name)
+                .ok_or_else(|| anyhow!("cannot get info for function {}", name))?
+                .parameters,
+            context.file,
+            vars_array,
+            scope_index,
+            &mut local_vars,
+            global_vars,
+        )?;
+
+        let body = node
+            .child_by_field_name("body")
+            .ok_or_else(|| anyhow!("missing body of grit function definition"))?;
+        let body = PrAnd::from_node(
+            &body,
+            context,
+            &mut local_vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        let function_definition = GritFunctionDefinition::new(
+            name.to_owned(),
+            scope_index,
+            params,
+            local_vars.values().cloned().collect(),
+            body,
+        );
+        Ok(function_definition)
+    }
+}
+
+pub(crate) struct ForeignFunctionDefinitionCompiler;
+
+impl NodeCompiler for ForeignFunctionDefinitionCompiler {
+    type TargetPattern = ForeignFunctionDefinition;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        _vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        _scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let name = node
+            .child_by_field_name("name")
+            .ok_or_else(|| anyhow!("missing name of function definition"))?;
+        let name = name.utf8_text(context.src.as_bytes())?;
+        let name = name.trim();
+        let scope_index = vars_array.len();
+        vars_array.push(vec![]);
+        let mut local_vars = BTreeMap::new();
+        let params = get_variables(
+            &context
+                .foreign_function_definition_info
+                .get(name)
+                .ok_or_else(|| anyhow!("cannot get info for function {}", name))?
+                .parameters,
+            context.file,
+            vars_array,
+            scope_index,
+            &mut local_vars,
+            global_vars,
+        )?;
+        let body = node
+            .child_by_field_name("body")
+            .ok_or_else(|| anyhow!("missing body of foreign function definition"))?
+            .child_by_field_name("code")
+            .ok_or_else(|| anyhow!("missing code of foreign function body"))?;
+        let byte_range = body.byte_range();
+        let byte_range = byte_range.start as usize..byte_range.end as usize;
+        let body = &context.src.as_bytes()[byte_range];
+        let foreign_language = ForeignLanguage::from_node(
+            node.child_by_field_name("language")
+                .ok_or_else(|| anyhow!("missing language of foreign function definition"))?,
+            context.src,
+        )?;
+        let function_definition = ForeignFunctionDefinition::new(
+            name.to_owned(),
+            scope_index,
+            params,
+            foreign_language,
+            body,
+        );
+        Ok(function_definition)
+    }
+}

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -9,6 +9,8 @@ mod auto_wrap;
 pub mod compiler;
 pub(crate) mod divide_compiler;
 pub(crate) mod equal_compiler;
+pub(crate) mod every_compiler;
+pub(crate) mod function_definition_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod any_compiler;
 pub(crate) mod assignment_compiler;
 mod auto_wrap;
 pub mod compiler;
+pub(crate) mod divide_compiler;
+pub(crate) mod equal_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 


### PR DESCRIPTION
Applies the node compiler pattern from https://github.com/getgrit/gritql/pull/164 to yet more node types.

See also: https://github.com/getgrit/gritql/pull/173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced visibility of specific struct fields to facilitate broader usage.
	- Simplified structures by making certain fields public and removing obsolete methods.
- **New Features**
	- Introduced compiler structures for division, equality, iteration, and function definitions to streamline pattern compilation processes.
- **Chores**
	- Updated and restructured imports across various modules for better organization and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->