### PR TITLE
chore: extract more node compilers (I/L)

### DIFF
--- a/crates/core/src/pattern/container.rs
+++ b/crates/core/src/pattern/container.rs
@@ -7,7 +7,8 @@ use super::{
     variable::{Variable, VariableSourceLocations},
 };
 use crate::pattern_compiler::{
-    accessor_compiler::AccessorCompiler, CompilationContext, NodeCompiler,
+    accessor_compiler::AccessorCompiler, list_index_compiler::ListIndexCompiler,
+    CompilationContext, NodeCompiler,
 };
 use anyhow::{bail, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -69,7 +70,7 @@ impl Container {
                 global_vars,
                 logs,
             )?))),
-            "listIndex" => Ok(Self::ListIndex(Box::new(ListIndex::from_node(
+            "listIndex" => Ok(Self::ListIndex(Box::new(ListIndexCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/if.rs
+++ b/crates/core/src/pattern/if.rs
@@ -15,9 +15,9 @@ use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct If {
-    pub(crate) if_: Predicate,
-    pub(crate) then: Pattern,
-    pub(crate) else_: Pattern,
+    pub if_: Predicate,
+    pub then: Pattern,
+    pub else_: Pattern,
 }
 impl If {
     pub fn new(if_: Predicate, then: Pattern, else_: Option<Pattern>) -> Self {
@@ -26,58 +26,6 @@ impl If {
             then,
             else_: else_.unwrap_or(Pattern::Top),
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let if_ = node
-            .child_by_field_name("if")
-            .ok_or_else(|| anyhow!("missing condition of if"))?;
-        let if_ = Predicate::from_node(
-            &if_,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        let then = node
-            .child_by_field_name("then")
-            .ok_or_else(|| anyhow!("missing consequence of if"))?;
-        let then = Pattern::from_node(
-            &then,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        let else_ = node
-            .child_by_field_name("else")
-            .map(|e| {
-                Pattern::from_node(
-                    &e,
-                    context,
-                    vars,
-                    vars_array,
-                    scope_index,
-                    global_vars,
-                    false,
-                    logs,
-                )
-            })
-            .map_or(Ok(None), |v| v.map(Some))?;
-        Ok(If::new(if_, then, else_))
     }
 }
 

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -1,14 +1,12 @@
 use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
-    Node, State,
+    State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Context as _, Result};
+use crate::context::Context;
+use anyhow::{Context as _, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
 pub struct Includes {
@@ -18,31 +16,6 @@ pub struct Includes {
 impl Includes {
     pub fn new(includes: Pattern) -> Self {
         Self { includes }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let includes = node
-            .child_by_field_name("includes")
-            .ok_or_else(|| anyhow!("missing includes of patternIncludes"))?;
-        let includes = Pattern::from_node(
-            &includes,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        Ok(Self::new(includes))
     }
 }
 

--- a/crates/core/src/pattern/like.rs
+++ b/crates/core/src/pattern/like.rs
@@ -1,67 +1,23 @@
 use super::{
-    float_constant::FloatConstant,
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
-    Node, State,
+    State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
+use crate::context::Context;
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Like {
-    pub(crate) like: Pattern,
-    pub(crate) threshold: Pattern,
+    pub like: Pattern,
+    pub threshold: Pattern,
 }
 
 impl Like {
     pub fn new(like: Pattern, threshold: Pattern) -> Self {
         Self { like, threshold }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let threshold = node
-            .child_by_field_name("threshold")
-            .map(|n| {
-                Pattern::from_node(
-                    &n,
-                    context,
-                    vars,
-                    vars_array,
-                    scope_index,
-                    global_vars,
-                    true,
-                    logs,
-                )
-            })
-            .unwrap_or(Result::Ok(Pattern::FloatConstant(FloatConstant::new(0.9))))?;
-        let like = node
-            .child_by_field_name("example")
-            .ok_or_else(|| anyhow!("missing field example of patternLike"))?;
-        let like = Pattern::from_node(
-            &like,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            true,
-            logs,
-        )?;
-        Ok(Self::new(like, threshold))
     }
 }
 

--- a/crates/core/src/pattern/limit.rs
+++ b/crates/core/src/pattern/limit.rs
@@ -2,17 +2,14 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::context::Context;
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Limit {
@@ -28,38 +25,6 @@ impl Limit {
             limit,
             invocation_count: Arc::new(AtomicUsize::new(0)),
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Pattern> {
-        let body = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern in limit"))?;
-        let body = Pattern::from_node(
-            &body,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        let limit = node
-            .child_by_field_name("limit")
-            .ok_or_else(|| anyhow!("missing limit in limit"))?;
-        let limit = limit
-            .utf8_text(context.src.as_bytes())?
-            .trim()
-            .parse::<usize>()?;
-        Ok(Pattern::Limit(Box::new(Self::new(body, limit))))
     }
 }
 

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -5,99 +5,34 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
 use crate::{
     binding::{Binding, Constant},
     context::Context,
-    pattern_compiler::CompilationContext,
     resolve_opt,
 };
 use anyhow::{anyhow, bail, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
-pub(crate) enum ListOrContainer {
+pub enum ListOrContainer {
     Container(Container),
     List(List),
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum ContainerOrIndex {
+pub enum ContainerOrIndex {
     Container(Container),
     Index(isize),
 }
 
 #[derive(Debug, Clone)]
 pub struct ListIndex {
-    pub(crate) list: ListOrContainer,
-    pub(crate) index: ContainerOrIndex,
+    pub list: ListOrContainer,
+    pub index: ContainerOrIndex,
 }
 
 impl ListIndex {
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let list = node
-            .child_by_field_name("list")
-            .ok_or_else(|| anyhow!("missing list of listIndex"))?;
-        let list = if list.kind() == "list" {
-            ListOrContainer::List(List::from_node(
-                &list,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                false,
-                logs,
-            )?)
-        } else {
-            ListOrContainer::Container(Container::from_node(
-                &list,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                logs,
-            )?)
-        };
-
-        let index_node = node
-            .child_by_field_name("index")
-            .ok_or_else(|| anyhow!("missing index of listIndex"))?;
-
-        let index = if let "signedIntConstant" = index_node.kind().as_ref() {
-            ContainerOrIndex::Index(
-                index_node
-                    .utf8_text(context.src.as_bytes())?
-                    .parse::<isize>()
-                    .map_err(|_| anyhow!("list index must be an integer"))?,
-            )
-        } else {
-            ContainerOrIndex::Container(Container::from_node(
-                &index_node,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                logs,
-            )?)
-        };
-
-        Ok(Self { list, index })
-    }
-
     fn get_index<'a>(&'a self, state: &State<'a>) -> Result<isize> {
         match &self.index {
             ContainerOrIndex::Container(c) => {

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -58,7 +58,8 @@ use crate::{
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
         any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
         if_compiler::IfCompiler, includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
-        limit_compiler::LimitCompiler, CompilationContext, NodeCompiler,
+        limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler, CompilationContext,
+        NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -919,7 +920,7 @@ impl Pattern {
                 is_rhs,
                 logs,
             )?))),
-            "listIndex" => Ok(Pattern::ListIndex(Box::new(ListIndex::from_node(
+            "listIndex" => Ok(Pattern::ListIndex(Box::new(ListIndexCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -58,8 +58,8 @@ use crate::{
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
         any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
         if_compiler::IfCompiler, includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
-        limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler, CompilationContext,
-        NodeCompiler,
+        limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
+        log_compiler::LogCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -845,7 +845,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "log" => Ok(Pattern::Log(Box::new(Log::from_node(
+            "log" => Ok(Pattern::Log(Box::new(LogCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -56,8 +56,8 @@ use crate::{
     pattern_compiler::{
         accessor_compiler::AccessorCompiler, accumulate_compiler::AccumulateCompiler,
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
-        any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler, CompilationContext,
-        NodeCompiler,
+        any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
+        if_compiler::IfCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -853,7 +853,7 @@ impl Pattern {
                 logs,
             )?))),
             "range" => Ok(Pattern::Range(PRange::from_node(node, context.src)?)),
-            "patternIfElse" => Ok(Pattern::If(Box::new(If::from_node(
+            "patternIfElse" => Ok(Pattern::If(Box::new(IfCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -57,8 +57,8 @@ use crate::{
         accessor_compiler::AccessorCompiler, accumulate_compiler::AccumulateCompiler,
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
         any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
-        if_compiler::IfCompiler, includes_compiler::IncludesCompiler, CompilationContext,
-        NodeCompiler,
+        if_compiler::IfCompiler, includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
+        CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -983,7 +983,7 @@ impl Pattern {
                 context.lang,
                 is_rhs,
             ),
-            "like" => Ok(Pattern::Like(Box::new(Like::from_node(
+            "like" => Ok(Pattern::Like(Box::new(LikeCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -57,7 +57,8 @@ use crate::{
         accessor_compiler::AccessorCompiler, accumulate_compiler::AccumulateCompiler,
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
         any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
-        if_compiler::IfCompiler, CompilationContext, NodeCompiler,
+        if_compiler::IfCompiler, includes_compiler::IncludesCompiler, CompilationContext,
+        NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -825,7 +826,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternIncludes" => Ok(Pattern::Includes(Box::new(Includes::from_node(
+            "patternIncludes" => Ok(Pattern::Includes(Box::new(IncludesCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -58,7 +58,7 @@ use crate::{
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
         any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
         if_compiler::IfCompiler, includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
-        CompilationContext, NodeCompiler,
+        limit_compiler::LimitCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -714,7 +714,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternLimit" => Limit::from_node(
+            "patternLimit" => LimitCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/predicates.rs
+++ b/crates/core/src/pattern/predicates.rs
@@ -22,7 +22,7 @@ use crate::{
     context::Context,
     pattern_compiler::{
         accumulate_compiler::AccumulateCompiler, assignment_compiler::AssignmentCompiler,
-        CompilationContext, NodeCompiler,
+        log_compiler::LogCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -127,7 +127,7 @@ impl Predicate {
                 global_vars,
                 logs,
             )?))),
-            "log" => Ok(Predicate::Log(Log::from_node(
+            "log" => Ok(Predicate::Log(LogCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern_compiler/if_compiler.rs
+++ b/crates/core/src/pattern_compiler/if_compiler.rs
@@ -1,0 +1,66 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    patterns::Pattern, predicates::Predicate, r#if::If, variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct IfCompiler;
+
+impl NodeCompiler for IfCompiler {
+    type TargetPattern = If;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let if_ = node
+            .child_by_field_name("if")
+            .ok_or_else(|| anyhow!("missing condition of if"))?;
+        let if_ = Predicate::from_node(
+            &if_,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        let then = node
+            .child_by_field_name("then")
+            .ok_or_else(|| anyhow!("missing consequence of if"))?;
+        let then = Pattern::from_node(
+            &then,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        let else_ = node
+            .child_by_field_name("else")
+            .map(|e| {
+                Pattern::from_node(
+                    &e,
+                    context,
+                    vars,
+                    vars_array,
+                    scope_index,
+                    global_vars,
+                    false,
+                    logs,
+                )
+            })
+            .map_or(Ok(None), |v| v.map(Some))?;
+        Ok(If::new(if_, then, else_))
+    }
+}

--- a/crates/core/src/pattern_compiler/includes_compiler.rs
+++ b/crates/core/src/pattern_compiler/includes_compiler.rs
@@ -1,0 +1,37 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{includes::Includes, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct IncludesCompiler;
+
+impl NodeCompiler for IncludesCompiler {
+    type TargetPattern = Includes;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let includes = node
+            .child_by_field_name("includes")
+            .ok_or_else(|| anyhow!("missing includes of patternIncludes"))?;
+        let includes = Pattern::from_node(
+            &includes,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        Ok(Includes::new(includes))
+    }
+}

--- a/crates/core/src/pattern_compiler/like_compiler.rs
+++ b/crates/core/src/pattern_compiler/like_compiler.rs
@@ -1,0 +1,54 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    float_constant::FloatConstant, like::Like, patterns::Pattern, variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct LikeCompiler;
+
+impl NodeCompiler for LikeCompiler {
+    type TargetPattern = Like;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let threshold = node
+            .child_by_field_name("threshold")
+            .map(|n| {
+                Pattern::from_node(
+                    &n,
+                    context,
+                    vars,
+                    vars_array,
+                    scope_index,
+                    global_vars,
+                    true,
+                    logs,
+                )
+            })
+            .unwrap_or(Result::Ok(Pattern::FloatConstant(FloatConstant::new(0.9))))?;
+        let like = node
+            .child_by_field_name("example")
+            .ok_or_else(|| anyhow!("missing field example of patternLike"))?;
+        let like = Pattern::from_node(
+            &like,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            true,
+            logs,
+        )?;
+        Ok(Like::new(like, threshold))
+    }
+}

--- a/crates/core/src/pattern_compiler/limit_compiler.rs
+++ b/crates/core/src/pattern_compiler/limit_compiler.rs
@@ -1,0 +1,44 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{limit::Limit, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct LimitCompiler;
+
+impl NodeCompiler for LimitCompiler {
+    type TargetPattern = Pattern;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let body = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern in limit"))?;
+        let body = Pattern::from_node(
+            &body,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        let limit = node
+            .child_by_field_name("limit")
+            .ok_or_else(|| anyhow!("missing limit in limit"))?;
+        let limit = limit
+            .utf8_text(context.src.as_bytes())?
+            .trim()
+            .parse::<usize>()?;
+        Ok(Pattern::Limit(Box::new(Limit::new(body, limit))))
+    }
+}

--- a/crates/core/src/pattern_compiler/list_index_compiler.rs
+++ b/crates/core/src/pattern_compiler/list_index_compiler.rs
@@ -1,0 +1,78 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    container::Container,
+    list::List,
+    list_index::{ContainerOrIndex, ListIndex, ListOrContainer},
+    variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct ListIndexCompiler;
+
+impl NodeCompiler for ListIndexCompiler {
+    type TargetPattern = ListIndex;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let list = node
+            .child_by_field_name("list")
+            .ok_or_else(|| anyhow!("missing list of listIndex"))?;
+        let list = if list.kind() == "list" {
+            ListOrContainer::List(List::from_node(
+                &list,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                false,
+                logs,
+            )?)
+        } else {
+            ListOrContainer::Container(Container::from_node(
+                &list,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?)
+        };
+
+        let index_node = node
+            .child_by_field_name("index")
+            .ok_or_else(|| anyhow!("missing index of listIndex"))?;
+
+        let index = if let "signedIntConstant" = index_node.kind().as_ref() {
+            ContainerOrIndex::Index(
+                index_node
+                    .utf8_text(context.src.as_bytes())?
+                    .parse::<isize>()
+                    .map_err(|_| anyhow!("list index must be an integer"))?,
+            )
+        } else {
+            ContainerOrIndex::Container(Container::from_node(
+                &index_node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?)
+        };
+
+        Ok(ListIndex { list, index })
+    }
+}

--- a/crates/core/src/pattern_compiler/log_compiler.rs
+++ b/crates/core/src/pattern_compiler/log_compiler.rs
@@ -1,0 +1,60 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    log::{Log, VariableInfo},
+    patterns::Pattern,
+    variable::{Variable, VariableSourceLocations},
+};
+use anyhow::Result;
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct LogCompiler;
+
+impl NodeCompiler for LogCompiler {
+    type TargetPattern = Log;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let message = node.child_by_field_name("message");
+        let message = if let Some(message) = message {
+            Some(Pattern::from_node(
+                &message,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                false,
+                logs,
+            )?)
+        } else {
+            None
+        };
+        let variable_node = node.child_by_field_name("variable");
+        let variable = variable_node
+            .map(|n| {
+                let name = n.utf8_text(context.src.as_bytes()).unwrap().to_string();
+                let variable = Variable::from_node(
+                    &n,
+                    context.file,
+                    context.src,
+                    vars,
+                    global_vars,
+                    vars_array,
+                    scope_index,
+                )?;
+                Ok(VariableInfo::new(name, variable))
+            })
+            .map_or(Ok(None), |v: Result<VariableInfo>| v.map(Some))?;
+
+        Ok(Log::new(variable, message))
+    }
+}

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod any_compiler;
 pub(crate) mod assignment_compiler;
 mod auto_wrap;
 pub mod compiler;
+pub(crate) mod if_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod assignment_compiler;
 mod auto_wrap;
 pub mod compiler;
 pub(crate) mod if_compiler;
+pub(crate) mod includes_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod if_compiler;
 pub(crate) mod includes_compiler;
 pub(crate) mod like_compiler;
 pub(crate) mod limit_compiler;
+pub(crate) mod list_index_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -9,6 +9,7 @@ mod auto_wrap;
 pub mod compiler;
 pub(crate) mod if_compiler;
 pub(crate) mod includes_compiler;
+pub(crate) mod like_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -10,6 +10,7 @@ pub mod compiler;
 pub(crate) mod if_compiler;
 pub(crate) mod includes_compiler;
 pub(crate) mod like_compiler;
+pub(crate) mod limit_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod includes_compiler;
 pub(crate) mod like_compiler;
 pub(crate) mod limit_compiler;
 pub(crate) mod list_index_compiler;
+pub(crate) mod log_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 


### PR DESCRIPTION
Applies the node compiler pattern from https://github.com/getgrit/gritql/pull/164 to yet more node types.

See also: https://github.com/getgrit/gritql/pull/173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced compiler structures for `If`, `Includes`, `Like`, `Limit`, and `ListIndex` patterns, enhancing pattern compilation and processing.

- **Refactor**
	- Modified visibility and construction logic for `If`, `Includes`, `Like`, `Limit`, and `ListIndex` structures, improving module access control and pattern handling.
	- Reorganized import statements and removed unused methods, streamlining code structure and dependencies.

- **Chores**
	- Added new compiler modules to the public and crate scope, expanding the codebase's functionality and modular organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->