### PR TITLE
chore: extract remaining node compilers

### DIFF
--- a/crates/core/src/pattern/and.rs
+++ b/crates/core/src/pattern/and.rs
@@ -3,18 +3,15 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     predicates::Predicate,
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
+use crate::context::Context;
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct And {
-    pub(crate) patterns: Vec<Pattern>,
+    pub patterns: Vec<Pattern>,
 }
 
 impl And {
@@ -48,42 +45,12 @@ impl Matcher for And {
 
 #[derive(Debug, Clone)]
 pub struct PrAnd {
-    pub(crate) predicates: Vec<Predicate>,
+    pub predicates: Vec<Predicate>,
 }
+
 impl PrAnd {
     pub fn new(predicates: Vec<Predicate>) -> Self {
         Self { predicates }
-    }
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Predicate> {
-        let mut cursor = node.walk();
-        let children = node
-            .children_by_field_name("predicates", &mut cursor)
-            .filter(|n| n.is_named());
-        let mut predicates = Vec::new();
-        for predicate in children {
-            predicates.push(Predicate::from_node(
-                &predicate,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                logs,
-            )?);
-        }
-        if predicates.len() == 1 {
-            Ok(predicates.remove(0))
-        } else {
-            Ok(Predicate::And(Box::new(PrAnd::new(predicates))))
-        }
     }
 }
 

--- a/crates/core/src/pattern/any.rs
+++ b/crates/core/src/pattern/any.rs
@@ -3,15 +3,12 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     predicates::Predicate,
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
+use crate::context::Context;
 use anyhow::Result;
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Any {
@@ -61,44 +58,12 @@ impl Matcher for Any {
 }
 #[derive(Debug, Clone)]
 pub struct PrAny {
-    pub(crate) predicates: Vec<Predicate>,
+    pub predicates: Vec<Predicate>,
 }
 
 impl PrAny {
     pub fn new(predicates: Vec<Predicate>) -> Self {
         Self { predicates }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Predicate> {
-        let mut cursor = node.walk();
-        let children = node
-            .children_by_field_name("predicates", &mut cursor)
-            .filter(|n| n.is_named());
-        let mut predicates = Vec::new();
-        for predicate in children {
-            predicates.push(Predicate::from_node(
-                &predicate,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                logs,
-            )?);
-        }
-        if predicates.len() == 1 {
-            Ok(predicates.remove(0))
-        } else {
-            Ok(Predicate::Any(Box::new(Self::new(predicates))))
-        }
     }
 }
 

--- a/crates/core/src/pattern/contains.rs
+++ b/crates/core/src/pattern/contains.rs
@@ -1,63 +1,23 @@
 use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::{LazyBuiltIn, ResolvedPattern, ResolvedSnippet},
-    variable::VariableSourceLocations,
     Node, State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext, resolve};
-use anyhow::{anyhow, Result};
+use crate::{context::Context, resolve};
+use anyhow::Result;
 use core::fmt::Debug;
 use im::vector;
 use marzano_util::{analysis_logs::AnalysisLogs, node_with_source::NodeWithSource};
-use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
 pub struct Contains {
-    pub(crate) contains: Pattern,
-    pub(crate) until: Option<Pattern>,
+    pub contains: Pattern,
+    pub until: Option<Pattern>,
 }
 
 impl Contains {
     pub fn new(contains: Pattern, until: Option<Pattern>) -> Self {
         Self { contains, until }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let contains = node
-            .child_by_field_name("contains")
-            .ok_or_else(|| anyhow!("missing contains of patternContains"))?;
-        let contains = Pattern::from_node(
-            &contains,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        let until = node.child_by_field_name("until").map(|n| {
-            Pattern::from_node(
-                &n,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                false,
-                logs,
-            )
-        });
-        let until = until.map_or(Ok(None), |v| v.map(Some))?;
-        Ok(Self::new(contains, until))
     }
 }
 

--- a/crates/core/src/pattern/divide.rs
+++ b/crates/core/src/pattern/divide.rs
@@ -2,63 +2,20 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
-use crate::{binding::Constant, context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::{binding::Constant, context::Context};
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Divide {
-    pub(crate) lhs: Pattern,
-    pub(crate) rhs: Pattern,
+    pub lhs: Pattern,
+    pub rhs: Pattern,
 }
 
 impl Divide {
     pub fn new(lhs: Pattern, rhs: Pattern) -> Self {
         Self { lhs, rhs }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let left = node
-            .child_by_field_name("left")
-            .ok_or_else(|| anyhow!("missing left of divide"))?;
-        let left = Pattern::from_node(
-            &left,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        let right = node
-            .child_by_field_name("right")
-            .ok_or_else(|| anyhow!("missing right of divide"))?;
-        let right = Pattern::from_node(
-            &right,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        Ok(Self::new(left, right))
     }
 
     pub(crate) fn call<'a>(

--- a/crates/core/src/pattern/equal.rs
+++ b/crates/core/src/pattern/equal.rs
@@ -1,67 +1,22 @@
 use super::{
     functions::{Evaluator, FuncEvaluation},
     patterns::{Name, Pattern},
-    variable::{Variable, VariableSourceLocations},
+    variable::Variable,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::context::Context;
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Equal {
-    var: Variable,
-    pub(crate) pattern: Pattern,
+    pub var: Variable,
+    pub pattern: Pattern,
 }
+
 impl Equal {
     pub fn new(var: Variable, pattern: Pattern) -> Self {
         Self { var, pattern }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let variable = node
-            .child_by_field_name("left")
-            .ok_or_else(|| anyhow!("missing lhs of predicateEqual"))?;
-        let variable = Pattern::from_node(
-            &variable,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            true,
-            logs,
-        )?;
-        let pattern = node
-            .child_by_field_name("right")
-            .ok_or_else(|| anyhow!("missing rhs of predicateEqual"))?;
-        let pattern = Pattern::from_node(
-            &pattern,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            true,
-            logs,
-        )?;
-        if let Pattern::Variable(var) = variable {
-            Ok(Equal::new(var, pattern))
-        } else {
-            Err(anyhow!(
-                "predicateEqual must have a variable as first argument",
-            ))
-        }
     }
 }
 

--- a/crates/core/src/pattern/every.rs
+++ b/crates/core/src/pattern/every.rs
@@ -1,49 +1,21 @@
 use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext, resolve};
-use anyhow::{anyhow, Result};
+use crate::{context::Context, resolve};
+use anyhow::Result;
 use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Every {
-    pub(crate) pattern: Pattern,
+    pub pattern: Pattern,
 }
 
 impl Every {
     pub fn new(pattern: Pattern) -> Self {
         Self { pattern }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let within = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of pattern every"))?;
-        let within = Pattern::from_node(
-            &within,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        Ok(Every::new(within))
     }
 }
 

--- a/crates/core/src/pattern/function_definition.rs
+++ b/crates/core/src/pattern/function_definition.rs
@@ -1,20 +1,18 @@
 use super::{
-    and::PrAnd,
     functions::{Evaluator, FuncEvaluation},
     patterns::Pattern,
     predicates::Predicate,
     resolved_pattern::patterns_to_resolved,
     state::State,
-    variable::{get_variables, Variable, VariableSourceLocations},
+    variable::Variable,
 };
-use crate::{binding::Constant, context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, bail, Result};
+use crate::{binding::Constant, context::Context};
+use anyhow::{bail, Result};
 #[cfg(feature = "external_functions")]
 use marzano_externals::function::ExternalFunction;
 use marzano_language::foreign_language::ForeignLanguage;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::{borrow::Cow, collections::BTreeMap};
-use tree_sitter::Node;
+use std::borrow::Cow;
 
 pub(crate) trait FunctionDefinition {
     fn call<'a>(
@@ -29,7 +27,7 @@ pub(crate) trait FunctionDefinition {
 #[derive(Clone, Debug)]
 pub struct GritFunctionDefinition {
     pub name: String,
-    scope: usize,
+    pub scope: usize,
     pub params: Vec<(String, Variable)>,
     pub local_vars: Vec<usize>,
     pub function: Predicate,
@@ -50,59 +48,6 @@ impl GritFunctionDefinition {
             local_vars,
             function,
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        function_definitions: &mut Vec<GritFunctionDefinition>,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<()> {
-        let name = node
-            .child_by_field_name("name")
-            .ok_or_else(|| anyhow!("missing name of function definition"))?;
-        let name = name.utf8_text(context.src.as_bytes())?;
-        let name = name.trim();
-        let scope_index = vars_array.len();
-        vars_array.push(vec![]);
-        let mut local_vars = BTreeMap::new();
-
-        let params = get_variables(
-            &context
-                .function_definition_info
-                .get(name)
-                .ok_or_else(|| anyhow!("cannot get info for function {}", name))?
-                .parameters,
-            context.file,
-            vars_array,
-            scope_index,
-            &mut local_vars,
-            global_vars,
-        )?;
-
-        let body = node
-            .child_by_field_name("body")
-            .ok_or_else(|| anyhow!("missing body of grit function definition"))?;
-        let body = PrAnd::from_node(
-            &body,
-            context,
-            &mut local_vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        let function_definition = GritFunctionDefinition::new(
-            name.to_owned(),
-            scope_index,
-            params,
-            local_vars.values().cloned().collect(),
-            body,
-        );
-        function_definitions.push(function_definition);
-        Ok(())
     }
 }
 
@@ -141,57 +86,6 @@ impl ForeignFunctionDefinition {
             language,
             code: code.to_vec(),
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        function_definitions: &mut Vec<ForeignFunctionDefinition>,
-        global_vars: &mut BTreeMap<String, usize>,
-    ) -> Result<()> {
-        let name = node
-            .child_by_field_name("name")
-            .ok_or_else(|| anyhow!("missing name of function definition"))?;
-        let name = name.utf8_text(context.src.as_bytes())?;
-        let name = name.trim();
-        let scope_index = vars_array.len();
-        vars_array.push(vec![]);
-        let mut local_vars = BTreeMap::new();
-        let params = get_variables(
-            &context
-                .foreign_function_definition_info
-                .get(name)
-                .ok_or_else(|| anyhow!("cannot get info for function {}", name))?
-                .parameters,
-            context.file,
-            vars_array,
-            scope_index,
-            &mut local_vars,
-            global_vars,
-        )?;
-        let body = node
-            .child_by_field_name("body")
-            .ok_or_else(|| anyhow!("missing body of foreign function definition"))?
-            .child_by_field_name("code")
-            .ok_or_else(|| anyhow!("missing code of foreign function body"))?;
-        let byte_range = body.byte_range();
-        let byte_range = byte_range.start as usize..byte_range.end as usize;
-        let body = &context.src.as_bytes()[byte_range];
-        let foreign_language = ForeignLanguage::from_node(
-            node.child_by_field_name("language")
-                .ok_or_else(|| anyhow!("missing language of foreign function definition"))?,
-            context.src,
-        )?;
-        let function_definition = ForeignFunctionDefinition::new(
-            name.to_owned(),
-            scope_index,
-            params,
-            foreign_language,
-            body,
-        );
-        function_definitions.push(function_definition);
-        Ok(())
     }
 }
 

--- a/crates/core/src/pattern/if.rs
+++ b/crates/core/src/pattern/if.rs
@@ -15,9 +15,9 @@ use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct If {
-    pub(crate) if_: Predicate,
-    pub(crate) then: Pattern,
-    pub(crate) else_: Pattern,
+    pub if_: Predicate,
+    pub then: Pattern,
+    pub else_: Pattern,
 }
 impl If {
     pub fn new(if_: Predicate, then: Pattern, else_: Option<Pattern>) -> Self {
@@ -26,58 +26,6 @@ impl If {
             then,
             else_: else_.unwrap_or(Pattern::Top),
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let if_ = node
-            .child_by_field_name("if")
-            .ok_or_else(|| anyhow!("missing condition of if"))?;
-        let if_ = Predicate::from_node(
-            &if_,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        let then = node
-            .child_by_field_name("then")
-            .ok_or_else(|| anyhow!("missing consequence of if"))?;
-        let then = Pattern::from_node(
-            &then,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        let else_ = node
-            .child_by_field_name("else")
-            .map(|e| {
-                Pattern::from_node(
-                    &e,
-                    context,
-                    vars,
-                    vars_array,
-                    scope_index,
-                    global_vars,
-                    false,
-                    logs,
-                )
-            })
-            .map_or(Ok(None), |v| v.map(Some))?;
-        Ok(If::new(if_, then, else_))
     }
 }
 

--- a/crates/core/src/pattern/if.rs
+++ b/crates/core/src/pattern/if.rs
@@ -6,7 +6,10 @@ use super::{
     variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
+use crate::{
+    context::Context,
+    pattern_compiler::{predicate_compiler::PredicateCompiler, CompilationContext, NodeCompiler},
+};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -80,7 +83,7 @@ impl PrIf {
         let if_ = node
             .child_by_field_name("if")
             .ok_or_else(|| anyhow!("missing condition of if"))?;
-        let if_ = Predicate::from_node(
+        let if_ = PredicateCompiler::from_node(
             &if_,
             context,
             vars,
@@ -92,7 +95,7 @@ impl PrIf {
         let then = node
             .child_by_field_name("then")
             .ok_or_else(|| anyhow!("missing consequence of if"))?;
-        let then = Predicate::from_node(
+        let then = PredicateCompiler::from_node(
             &then,
             context,
             vars,
@@ -104,7 +107,7 @@ impl PrIf {
         let else_ = node
             .child_by_field_name("else")
             .map(|e| {
-                Predicate::from_node(
+                PredicateCompiler::from_node(
                     &e,
                     context,
                     vars,

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -1,14 +1,12 @@
 use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
-    Node, State,
+    State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Context as _, Result};
+use crate::context::Context;
+use anyhow::{Context as _, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
 pub struct Includes {
@@ -18,31 +16,6 @@ pub struct Includes {
 impl Includes {
     pub fn new(includes: Pattern) -> Self {
         Self { includes }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let includes = node
-            .child_by_field_name("includes")
-            .ok_or_else(|| anyhow!("missing includes of patternIncludes"))?;
-        let includes = Pattern::from_node(
-            &includes,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        Ok(Self::new(includes))
     }
 }
 

--- a/crates/core/src/pattern/like.rs
+++ b/crates/core/src/pattern/like.rs
@@ -1,67 +1,23 @@
 use super::{
-    float_constant::FloatConstant,
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
-    Node, State,
+    State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
+use crate::context::Context;
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Like {
-    pub(crate) like: Pattern,
-    pub(crate) threshold: Pattern,
+    pub like: Pattern,
+    pub threshold: Pattern,
 }
 
 impl Like {
     pub fn new(like: Pattern, threshold: Pattern) -> Self {
         Self { like, threshold }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let threshold = node
-            .child_by_field_name("threshold")
-            .map(|n| {
-                Pattern::from_node(
-                    &n,
-                    context,
-                    vars,
-                    vars_array,
-                    scope_index,
-                    global_vars,
-                    true,
-                    logs,
-                )
-            })
-            .unwrap_or(Result::Ok(Pattern::FloatConstant(FloatConstant::new(0.9))))?;
-        let like = node
-            .child_by_field_name("example")
-            .ok_or_else(|| anyhow!("missing field example of patternLike"))?;
-        let like = Pattern::from_node(
-            &like,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            true,
-            logs,
-        )?;
-        Ok(Self::new(like, threshold))
     }
 }
 

--- a/crates/core/src/pattern/limit.rs
+++ b/crates/core/src/pattern/limit.rs
@@ -2,17 +2,14 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::context::Context;
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Limit {
@@ -28,38 +25,6 @@ impl Limit {
             limit,
             invocation_count: Arc::new(AtomicUsize::new(0)),
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Pattern> {
-        let body = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern in limit"))?;
-        let body = Pattern::from_node(
-            &body,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        let limit = node
-            .child_by_field_name("limit")
-            .ok_or_else(|| anyhow!("missing limit in limit"))?;
-        let limit = limit
-            .utf8_text(context.src.as_bytes())?
-            .trim()
-            .parse::<usize>()?;
-        Ok(Pattern::Limit(Box::new(Self::new(body, limit))))
     }
 }
 

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     binding::{Binding, Constant},
     context::Context,
-    pattern_compiler::CompilationContext,
+    pattern_compiler::{container_compiler::ContainerCompiler, CompilationContext, NodeCompiler},
     resolve_opt,
 };
 use anyhow::{anyhow, bail, Result};
@@ -61,7 +61,7 @@ impl ListIndex {
                 logs,
             )?)
         } else {
-            ListOrContainer::Container(Container::from_node(
+            ListOrContainer::Container(ContainerCompiler::from_node(
                 &list,
                 context,
                 vars,
@@ -84,7 +84,7 @@ impl ListIndex {
                     .map_err(|_| anyhow!("list index must be an integer"))?,
             )
         } else {
-            ContainerOrIndex::Container(Container::from_node(
+            ContainerOrIndex::Container(ContainerCompiler::from_node(
                 &index_node,
                 context,
                 vars,

--- a/crates/core/src/pattern/match.rs
+++ b/crates/core/src/pattern/match.rs
@@ -6,7 +6,11 @@ use super::{
     variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, errors::debug, pattern_compiler::CompilationContext};
+use crate::{
+    context::Context,
+    errors::debug,
+    pattern_compiler::{container_compiler::ContainerCompiler, CompilationContext, NodeCompiler},
+};
 use anyhow::{anyhow, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -34,7 +38,7 @@ impl Match {
         let value = node
             .child_by_field_name("left")
             .ok_or_else(|| anyhow!("missing lhs of predicateMatch"))?;
-        let value = Container::from_node(
+        let value = ContainerCompiler::from_node(
             &value,
             context,
             vars,

--- a/crates/core/src/pattern/match.rs
+++ b/crates/core/src/pattern/match.rs
@@ -3,64 +3,20 @@ use super::{
     functions::{Evaluator, FuncEvaluation},
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     State,
 };
-use crate::{
-    context::Context,
-    errors::debug,
-    pattern_compiler::{container_compiler::ContainerCompiler, CompilationContext, NodeCompiler},
-};
-use anyhow::{anyhow, Result};
+use crate::{context::Context, errors::debug};
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Match {
-    val: Container,
-    pub(crate) pattern: Option<Pattern>,
+    pub val: Container,
+    pub pattern: Option<Pattern>,
 }
 impl Match {
-    pub(crate) fn new(val: Container, pattern: Option<Pattern>) -> Self {
+    pub fn new(val: Container, pattern: Option<Pattern>) -> Self {
         Self { val, pattern }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let value = node
-            .child_by_field_name("left")
-            .ok_or_else(|| anyhow!("missing lhs of predicateMatch"))?;
-        let value = ContainerCompiler::from_node(
-            &value,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        let pattern = node
-            .child_by_field_name("right")
-            .ok_or_else(|| anyhow!("missing rhs of predicateMatch"))?;
-        let pattern = Some(Pattern::from_node(
-            &pattern,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?);
-        Ok(Match::new(value, pattern))
     }
 }
 

--- a/crates/core/src/pattern/maybe.rs
+++ b/crates/core/src/pattern/maybe.rs
@@ -4,13 +4,10 @@ use super::{
     predicates::Predicate,
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::context::Context;
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Maybe {
@@ -51,30 +48,6 @@ pub struct PrMaybe {
 impl PrMaybe {
     pub fn new(predicate: Predicate) -> Self {
         Self { predicate }
-    }
-
-    pub(crate) fn maybe_from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let predicate = node
-            .child_by_field_name("predicate")
-            .ok_or_else(|| anyhow!("missing predicate of predicateMaybe"))?;
-        let predicate = Predicate::from_node(
-            &predicate,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        Ok(Self::new(predicate))
     }
 }
 

--- a/crates/core/src/pattern/maybe.rs
+++ b/crates/core/src/pattern/maybe.rs
@@ -14,36 +14,11 @@ use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Maybe {
-    pub(crate) pattern: Pattern,
+    pub pattern: Pattern,
 }
 impl Maybe {
     pub fn new(pattern: Pattern) -> Self {
         Self { pattern }
-    }
-
-    pub(crate) fn maybe_from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let pattern = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of patternMaybe"))?;
-        let pattern = Pattern::from_node(
-            &pattern,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        Ok(Self::new(pattern))
     }
 }
 

--- a/crates/core/src/pattern/modulo.rs
+++ b/crates/core/src/pattern/modulo.rs
@@ -2,63 +2,20 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
-use crate::{binding::Constant, context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::{binding::Constant, context::Context};
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Modulo {
-    pub(crate) lhs: Pattern,
-    pub(crate) rhs: Pattern,
+    pub lhs: Pattern,
+    pub rhs: Pattern,
 }
 
 impl Modulo {
     pub fn new(lhs: Pattern, rhs: Pattern) -> Self {
         Self { lhs, rhs }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let left = node
-            .child_by_field_name("left")
-            .ok_or_else(|| anyhow!("missing left of modulo"))?;
-        let left = Pattern::from_node(
-            &left,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        let right = node
-            .child_by_field_name("right")
-            .ok_or_else(|| anyhow!("missing right of modulo"))?;
-        let right = Pattern::from_node(
-            &right,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        Ok(Self::new(left, right))
     }
 
     pub(crate) fn call<'a>(

--- a/crates/core/src/pattern/multiply.rs
+++ b/crates/core/src/pattern/multiply.rs
@@ -2,63 +2,20 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
-use crate::{binding::Constant, context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::{binding::Constant, context::Context};
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Multiply {
-    pub(crate) lhs: Pattern,
-    pub(crate) rhs: Pattern,
+    pub lhs: Pattern,
+    pub rhs: Pattern,
 }
 
 impl Multiply {
     pub fn new(lhs: Pattern, rhs: Pattern) -> Self {
         Self { lhs, rhs }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let left = node
-            .child_by_field_name("left")
-            .ok_or_else(|| anyhow!("missing left of multiply"))?;
-        let left = Pattern::from_node(
-            &left,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        let right = node
-            .child_by_field_name("right")
-            .ok_or_else(|| anyhow!("missing right of multiply"))?;
-        let right = Pattern::from_node(
-            &right,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        Ok(Self::new(left, right))
     }
 
     pub(crate) fn call<'a>(

--- a/crates/core/src/pattern/not.rs
+++ b/crates/core/src/pattern/not.rs
@@ -23,49 +23,6 @@ impl Not {
     pub fn new(pattern: Pattern) -> Self {
         Self { pattern }
     }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let pattern = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of patternNot"))?;
-        let range: Range = pattern.range().into();
-        let pattern = Pattern::from_node(
-            &pattern,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        if pattern.iter().any(|p| {
-            matches!(
-                p,
-                PatternOrPredicate::Pattern(Pattern::Rewrite(_))
-                    | PatternOrPredicate::Predicate(Predicate::Rewrite(_))
-            )
-        }) {
-            let log = AnalysisLogBuilder::default()
-                .level(441_u16)
-                .file(context.file)
-                .source(context.src)
-                .position(range.start)
-                .range(range)
-                .message("Warning: rewrites inside of a not will never be applied")
-                .build()?;
-            logs.push(log);
-        }
-        Ok(Self::new(pattern))
-    }
 }
 
 impl Name for Not {

--- a/crates/core/src/pattern/not.rs
+++ b/crates/core/src/pattern/not.rs
@@ -7,7 +7,10 @@ use super::{
     variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
+use crate::{
+    context::Context,
+    pattern_compiler::{predicate_compiler::PredicateCompiler, CompilationContext, NodeCompiler},
+};
 use anyhow::{anyhow, bail, Ok, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
@@ -67,7 +70,7 @@ impl PrNot {
             .child_by_field_name("predicate")
             .ok_or_else(|| anyhow!("predicateNot missing predicate"))?;
         let range: Range = not.range().into();
-        let not = Predicate::from_node(
+        let not = PredicateCompiler::from_node(
             &not,
             context,
             vars,

--- a/crates/core/src/pattern/or.rs
+++ b/crates/core/src/pattern/or.rs
@@ -21,39 +21,6 @@ impl Or {
     pub fn new(patterns: Vec<Pattern>) -> Self {
         Self { patterns }
     }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Pattern> {
-        let mut cursor = node.walk();
-        let children = node
-            .children_by_field_name("patterns", &mut cursor)
-            .filter(|n| n.is_named());
-        let mut patterns = Vec::new();
-        for pattern in children {
-            patterns.push(Pattern::from_node(
-                &pattern,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                false,
-                logs,
-            )?);
-        }
-        if patterns.len() == 1 {
-            Ok(patterns.remove(0))
-        } else {
-            Ok(Pattern::Or(Box::new(Self::new(patterns))))
-        }
-    }
 }
 
 impl Name for Or {

--- a/crates/core/src/pattern/or.rs
+++ b/crates/core/src/pattern/or.rs
@@ -3,15 +3,12 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     predicates::Predicate,
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     State,
 };
-use crate::{binding::Binding, context::Context, pattern_compiler::CompilationContext};
+use crate::{binding::Binding, context::Context};
 use anyhow::Result;
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Or {
@@ -70,44 +67,11 @@ impl Matcher for Or {
 
 #[derive(Debug, Clone)]
 pub struct PrOr {
-    pub(crate) predicates: Vec<Predicate>,
+    pub predicates: Vec<Predicate>,
 }
 impl PrOr {
     pub fn new(predicates: Vec<Predicate>) -> Self {
         Self { predicates }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Predicate> {
-        let mut cursor = node.walk();
-        let children = node
-            .children_by_field_name("predicates", &mut cursor)
-            .filter(|n| n.is_named());
-        let mut predicates = Vec::new();
-        for predicate in children {
-            predicates.push(Predicate::from_node(
-                &predicate,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                logs,
-            )?);
-        }
-
-        if predicates.len() == 1 {
-            Ok(predicates.remove(0))
-        } else {
-            Ok(Predicate::Or(Box::new(PrOr::new(predicates))))
-        }
     }
 }
 

--- a/crates/core/src/pattern/pattern_definition.rs
+++ b/crates/core/src/pattern/pattern_definition.rs
@@ -1,22 +1,17 @@
 use super::{
     patterns::{Matcher, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::{get_variables, Variable, VariableSourceLocations},
+    variable::Variable,
     State,
 };
-use crate::{
-    context::Context,
-    pattern_compiler::{and_compiler::AndCompiler, CompilationContext, NodeCompiler},
-};
-use anyhow::{anyhow, Result};
+use crate::context::Context;
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Clone, Debug)]
 pub struct PatternDefinition {
     pub name: String,
-    pub(crate) scope: usize,
+    pub scope: usize,
     pub params: Vec<(String, Variable)>,
     // this could just be a usize representing the len
     pub local_vars: Vec<usize>,
@@ -38,62 +33,6 @@ impl PatternDefinition {
             local_vars,
             pattern,
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        pattern_definitions: &mut Vec<PatternDefinition>,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<()> {
-        // TODO: make sure pattern definitions are only allowed at the top level
-        let name = node
-            .child_by_field_name("name")
-            .ok_or_else(|| anyhow!("missing name of patternDefinition"))?;
-        let name = name.utf8_text(context.src.as_bytes())?;
-        let name = name.trim();
-        let scope_index = vars_array.len();
-        vars_array.push(vec![]);
-        let mut local_vars = BTreeMap::new();
-        // important that this occurs first, as calls assume
-        // that parameters are registered first
-        let params = get_variables(
-            &context
-                .pattern_definition_info
-                .get(name)
-                .ok_or_else(|| anyhow!("cannot get info for pattern {}", name))?
-                .parameters,
-            context.file,
-            vars_array,
-            scope_index,
-            &mut local_vars,
-            global_vars,
-        )?;
-
-        let body = node
-            .child_by_field_name("body")
-            .ok_or_else(|| anyhow!("missing body of patternDefinition"))?;
-        let body = AndCompiler::from_node(
-            &body,
-            context,
-            &mut local_vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        let pattern_def = PatternDefinition::new(
-            name.to_owned(),
-            scope_index,
-            params,
-            local_vars.values().cloned().collect(),
-            body,
-        );
-        // todo check for duplicate names
-        pattern_definitions.push(pattern_def);
-        Ok(())
     }
 
     pub(crate) fn call<'a>(

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -66,8 +66,8 @@ use crate::{
         multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, or_compiler::OrCompiler,
         rewrite_compiler::RewriteCompiler, sequential_compiler::SequentialCompiler,
         some_compiler::SomeCompiler, subtract_compiler::SubtractCompiler,
-        variable_compiler::VariableCompiler, where_compiler::WhereCompiler, CompilationContext,
-        NodeCompiler,
+        variable_compiler::VariableCompiler, where_compiler::WhereCompiler,
+        within_compiler::WithinCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -872,7 +872,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "within" => Ok(Pattern::Within(Box::new(Within::from_node(
+            "within" => Ok(Pattern::Within(Box::new(WithinCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -65,7 +65,7 @@ use crate::{
         log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
         multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, or_compiler::OrCompiler,
         rewrite_compiler::RewriteCompiler, sequential_compiler::SequentialCompiler,
-        CompilationContext, NodeCompiler,
+        some_compiler::SomeCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -888,7 +888,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "some" => Ok(Pattern::Some(Box::new(Some::from_node(
+            "some" => Ok(Pattern::Some(Box::new(SomeCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -57,8 +57,8 @@ use crate::{
         accessor_compiler::AccessorCompiler, accumulate_compiler::AccumulateCompiler,
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
         any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
-        before_compiler::BeforeCompiler, bubble_compiler::BubbleCompiler, CompilationContext,
-        NodeCompiler,
+        before_compiler::BeforeCompiler, bubble_compiler::BubbleCompiler,
+        contains_compiler::ContainsCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -817,7 +817,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternContains" => Ok(Pattern::Contains(Box::new(Contains::from_node(
+            "patternContains" => Ok(Pattern::Contains(Box::new(ContainsCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -63,7 +63,7 @@ use crate::{
         includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
         limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
         log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
-        CompilationContext, NodeCompiler,
+        multiply_compiler::MultiplyCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -665,7 +665,7 @@ impl Pattern {
     ) -> Result<Self> {
         let kind = node.kind();
         match kind.as_ref() {
-            "mulOperation" => Ok(Pattern::Multiply(Box::new(Multiply::from_node(
+            "mulOperation" => Ok(Pattern::Multiply(Box::new(MultiplyCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -62,7 +62,8 @@ use crate::{
         every_compiler::EveryCompiler, if_compiler::IfCompiler,
         includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
         limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
-        log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, CompilationContext, NodeCompiler,
+        log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
+        CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -682,7 +683,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "modOperation" => Ok(Pattern::Modulo(Box::new(Modulo::from_node(
+            "modOperation" => Ok(Pattern::Modulo(Box::new(ModuloCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -59,7 +59,10 @@ use crate::{
         any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
         before_compiler::BeforeCompiler, bubble_compiler::BubbleCompiler,
         contains_compiler::ContainsCompiler, divide_compiler::DivideCompiler,
-        every_compiler::EveryCompiler, CompilationContext, NodeCompiler,
+        every_compiler::EveryCompiler, if_compiler::IfCompiler,
+        includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
+        limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
+        log_compiler::LogCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -715,7 +718,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternLimit" => Limit::from_node(
+            "patternLimit" => LimitCompiler::from_node(
                 node,
                 context,
                 vars,
@@ -827,7 +830,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternIncludes" => Ok(Pattern::Includes(Box::new(Includes::from_node(
+            "patternIncludes" => Ok(Pattern::Includes(Box::new(IncludesCompiler::from_node(
                 node,
                 context,
                 vars,
@@ -845,7 +848,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "log" => Ok(Pattern::Log(Box::new(Log::from_node(
+            "log" => Ok(Pattern::Log(Box::new(LogCompiler::from_node(
                 node,
                 context,
                 vars,
@@ -855,7 +858,7 @@ impl Pattern {
                 logs,
             )?))),
             "range" => Ok(Pattern::Range(PRange::from_node(node, context.src)?)),
-            "patternIfElse" => Ok(Pattern::If(Box::new(If::from_node(
+            "patternIfElse" => Ok(Pattern::If(Box::new(IfCompiler::from_node(
                 node,
                 context,
                 vars,
@@ -920,7 +923,7 @@ impl Pattern {
                 is_rhs,
                 logs,
             )?))),
-            "listIndex" => Ok(Pattern::ListIndex(Box::new(ListIndex::from_node(
+            "listIndex" => Ok(Pattern::ListIndex(Box::new(ListIndexCompiler::from_node(
                 node,
                 context,
                 vars,
@@ -984,7 +987,7 @@ impl Pattern {
                 context.lang,
                 is_rhs,
             ),
-            "like" => Ok(Pattern::Like(Box::new(Like::from_node(
+            "like" => Ok(Pattern::Like(Box::new(LikeCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -65,7 +65,8 @@ use crate::{
         log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
         multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, or_compiler::OrCompiler,
         rewrite_compiler::RewriteCompiler, sequential_compiler::SequentialCompiler,
-        some_compiler::SomeCompiler, CompilationContext, NodeCompiler,
+        some_compiler::SomeCompiler, subtract_compiler::SubtractCompiler, CompilationContext,
+        NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -703,7 +704,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "subOperation" => Ok(Pattern::Subtract(Box::new(Subtract::from_node(
+            "subOperation" => Ok(Pattern::Subtract(Box::new(SubtractCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -62,7 +62,7 @@ use crate::{
         every_compiler::EveryCompiler, if_compiler::IfCompiler,
         includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
         limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
-        log_compiler::LogCompiler, CompilationContext, NodeCompiler,
+        log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -794,7 +794,7 @@ impl Pattern {
                 global_vars,
                 logs,
             ),
-            "patternMaybe" => Ok(Pattern::Maybe(Box::new(Maybe::maybe_from_node(
+            "patternMaybe" => Ok(Pattern::Maybe(Box::new(MaybeCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -64,7 +64,8 @@ use crate::{
         limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
         log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
         multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, or_compiler::OrCompiler,
-        rewrite_compiler::RewriteCompiler, CompilationContext, NodeCompiler,
+        rewrite_compiler::RewriteCompiler, sequential_compiler::SequentialCompiler,
+        CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -1005,7 +1006,7 @@ impl Pattern {
                 node,
                 context.src,
             )?)),
-            "sequential" => Ok(Pattern::Sequential(Sequential::from_node(
+            "sequential" => Ok(Pattern::Sequential(SequentialCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -56,10 +56,10 @@ use crate::{
     pattern_compiler::{
         accessor_compiler::AccessorCompiler, accumulate_compiler::AccumulateCompiler,
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
-        any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
-        before_compiler::BeforeCompiler, bubble_compiler::BubbleCompiler,
-        contains_compiler::ContainsCompiler, divide_compiler::DivideCompiler,
-        every_compiler::EveryCompiler, if_compiler::IfCompiler,
+        any_compiler::AnyCompiler, as_compiler::AsCompiler,
+        assignment_compiler::AssignmentCompiler, before_compiler::BeforeCompiler,
+        bubble_compiler::BubbleCompiler, contains_compiler::ContainsCompiler,
+        divide_compiler::DivideCompiler, every_compiler::EveryCompiler, if_compiler::IfCompiler,
         includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
         limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
         log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
@@ -714,7 +714,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternAs" => Ok(Pattern::Where(Box::new(Where::as_from_node(
+            "patternAs" => Ok(Pattern::Where(Box::new(AsCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -65,8 +65,8 @@ use crate::{
         log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
         multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, or_compiler::OrCompiler,
         rewrite_compiler::RewriteCompiler, sequential_compiler::SequentialCompiler,
-        some_compiler::SomeCompiler, subtract_compiler::SubtractCompiler, CompilationContext,
-        NodeCompiler,
+        some_compiler::SomeCompiler, subtract_compiler::SubtractCompiler,
+        variable_compiler::VariableCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -971,14 +971,14 @@ impl Pattern {
                 is_rhs,
                 logs,
             ),
-            "variable" => Ok(Pattern::Variable(Variable::from_node(
+            "variable" => Ok(Pattern::Variable(VariableCompiler::from_node(
                 node,
-                context.file,
-                context.src,
+                context,
                 vars,
-                global_vars,
                 vars_array,
                 scope_index,
+                global_vars,
+                logs,
             )?)),
             "codeSnippet" => CodeSnippet::from_node(
                 node,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -63,7 +63,8 @@ use crate::{
         includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
         limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
         log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
-        multiply_compiler::MultiplyCompiler, CompilationContext, NodeCompiler,
+        multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, CompilationContext,
+        NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -759,7 +760,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternNot" => Ok(Pattern::Not(Box::new(Not::from_node(
+            "patternNot" => Ok(Pattern::Not(Box::new(NotCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -66,7 +66,8 @@ use crate::{
         multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, or_compiler::OrCompiler,
         rewrite_compiler::RewriteCompiler, sequential_compiler::SequentialCompiler,
         some_compiler::SomeCompiler, subtract_compiler::SubtractCompiler,
-        variable_compiler::VariableCompiler, CompilationContext, NodeCompiler,
+        variable_compiler::VariableCompiler, where_compiler::WhereCompiler, CompilationContext,
+        NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -753,7 +754,7 @@ impl Pattern {
                     logs,
                 )?,
             ))),
-            "patternWhere" => Ok(Pattern::Where(Box::new(Where::from_node(
+            "patternWhere" => Ok(Pattern::Where(Box::new(WhereCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -63,8 +63,8 @@ use crate::{
         includes_compiler::IncludesCompiler, like_compiler::LikeCompiler,
         limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
         log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
-        multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, CompilationContext,
-        NodeCompiler,
+        multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, or_compiler::OrCompiler,
+        CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -769,7 +769,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "patternOr" => Or::from_node(
+            "patternOr" => OrCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -58,7 +58,8 @@ use crate::{
         add_compiler::AddCompiler, after_compiler::AfterCompiler, and_compiler::AndCompiler,
         any_compiler::AnyCompiler, assignment_compiler::AssignmentCompiler,
         before_compiler::BeforeCompiler, bubble_compiler::BubbleCompiler,
-        contains_compiler::ContainsCompiler, CompilationContext, NodeCompiler,
+        contains_compiler::ContainsCompiler, divide_compiler::DivideCompiler,
+        every_compiler::EveryCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -669,7 +670,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "divOperation" => Ok(Pattern::Divide(Box::new(Divide::from_node(
+            "divOperation" => Ok(Pattern::Divide(Box::new(DivideCompiler::from_node(
                 node,
                 context,
                 vars,
@@ -890,7 +891,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "every" => Ok(Pattern::Every(Box::new(Every::from_node(
+            "every" => Ok(Pattern::Every(Box::new(EveryCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -64,7 +64,7 @@ use crate::{
         limit_compiler::LimitCompiler, list_index_compiler::ListIndexCompiler,
         log_compiler::LogCompiler, maybe_compiler::MaybeCompiler, modulo_compiler::ModuloCompiler,
         multiply_compiler::MultiplyCompiler, not_compiler::NotCompiler, or_compiler::OrCompiler,
-        CompilationContext, NodeCompiler,
+        rewrite_compiler::RewriteCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -841,7 +841,7 @@ impl Pattern {
                 global_vars,
                 logs,
             )?))),
-            "rewrite" => Ok(Pattern::Rewrite(Box::new(Rewrite::from_node(
+            "rewrite" => Ok(Pattern::Rewrite(Box::new(RewriteCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/predicate_definition.rs
+++ b/crates/core/src/pattern/predicate_definition.rs
@@ -1,21 +1,14 @@
 use super::{
-    and::PrAnd,
-    functions::Evaluator,
-    patterns::Pattern,
-    predicates::Predicate,
-    variable::{get_variables, Variable, VariableSourceLocations},
-    State,
+    functions::Evaluator, patterns::Pattern, predicates::Predicate, variable::Variable, State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::context::Context;
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Clone, Debug)]
 pub struct PredicateDefinition {
     pub name: String,
-    scope: usize,
+    pub scope: usize,
     pub params: Vec<(String, Variable)>,
     // this could just be a usize representing the len
     pub local_vars: Vec<usize>,
@@ -37,61 +30,6 @@ impl PredicateDefinition {
             local_vars,
             predicate,
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        predicate_definitions: &mut Vec<PredicateDefinition>,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<()> {
-        let name = node
-            .child_by_field_name("name")
-            .ok_or_else(|| anyhow!("missing name of pattern definition"))?;
-        let name = name.utf8_text(context.src.as_bytes())?;
-        let name = name.trim();
-        let scope_index = vars_array.len();
-        vars_array.push(vec![]);
-        let mut local_vars = BTreeMap::new();
-        // important that this occurs first, as calls assume
-        // that parameters are registered first
-        let params = get_variables(
-            &context
-                .predicate_definition_info
-                .get(name)
-                .ok_or_else(|| anyhow!("cannot get info for pattern {}", name))?
-                .parameters,
-            context.file,
-            vars_array,
-            scope_index,
-            &mut local_vars,
-            global_vars,
-        )?;
-
-        let body = node
-            .child_by_field_name("body")
-            .ok_or_else(|| anyhow!("missing body of pattern definition"))?;
-        let body = PrAnd::from_node(
-            &body,
-            context,
-            &mut local_vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        let predicate_def = PredicateDefinition::new(
-            name.to_owned(),
-            scope_index,
-            params,
-            local_vars.values().cloned().collect(),
-            body,
-        );
-        // todo check for duplicate names
-        predicate_definitions.push(predicate_def);
-        Ok(())
     }
 
     pub fn call<'a>(

--- a/crates/core/src/pattern/predicate_return.rs
+++ b/crates/core/src/pattern/predicate_return.rs
@@ -3,47 +3,19 @@ use super::{
     patterns::{Name, Pattern},
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::context::Context;
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct PrReturn {
-    pub(crate) pattern: Pattern,
+    pub pattern: Pattern,
 }
 
 impl PrReturn {
     pub fn new(pattern: Pattern) -> Self {
         Self { pattern }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let pattern = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of return"))?;
-        let pattern = Pattern::from_node(
-            &pattern,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            true,
-            logs,
-        )?;
-        Ok(Self::new(pattern))
     }
 }
 

--- a/crates/core/src/pattern/predicates.rs
+++ b/crates/core/src/pattern/predicates.rs
@@ -22,7 +22,8 @@ use crate::{
     context::Context,
     pattern_compiler::{
         accumulate_compiler::AccumulateCompiler, assignment_compiler::AssignmentCompiler,
-        equal_compiler::EqualCompiler, log_compiler::LogCompiler, CompilationContext, NodeCompiler,
+        equal_compiler::EqualCompiler, log_compiler::LogCompiler, match_compiler::MatchCompiler,
+        CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -136,7 +137,7 @@ impl Predicate {
                 global_vars,
                 logs,
             )?)),
-            "predicateMatch" => Ok(Predicate::Match(Box::new(Match::from_node(
+            "predicateMatch" => Ok(Predicate::Match(Box::new(MatchCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/predicates.rs
+++ b/crates/core/src/pattern/predicates.rs
@@ -22,7 +22,7 @@ use crate::{
     context::Context,
     pattern_compiler::{
         accumulate_compiler::AccumulateCompiler, assignment_compiler::AssignmentCompiler,
-        equal_compiler::EqualCompiler, CompilationContext, NodeCompiler,
+        equal_compiler::EqualCompiler, log_compiler::LogCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -127,7 +127,7 @@ impl Predicate {
                 global_vars,
                 logs,
             )?))),
-            "log" => Ok(Predicate::Log(Log::from_node(
+            "log" => Ok(Predicate::Log(LogCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/predicates.rs
+++ b/crates/core/src/pattern/predicates.rs
@@ -22,7 +22,7 @@ use crate::{
     context::Context,
     pattern_compiler::{
         accumulate_compiler::AccumulateCompiler, assignment_compiler::AssignmentCompiler,
-        CompilationContext, NodeCompiler,
+        equal_compiler::EqualCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -145,7 +145,7 @@ impl Predicate {
                 global_vars,
                 logs,
             )?))),
-            "predicateEqual" => Ok(Predicate::Equal(Box::new(Equal::from_node(
+            "predicateEqual" => Ok(Predicate::Equal(Box::new(EqualCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern/predicates.rs
+++ b/crates/core/src/pattern/predicates.rs
@@ -23,7 +23,7 @@ use crate::{
     pattern_compiler::{
         accumulate_compiler::AccumulateCompiler, assignment_compiler::AssignmentCompiler,
         equal_compiler::EqualCompiler, log_compiler::LogCompiler, match_compiler::MatchCompiler,
-        CompilationContext, NodeCompiler,
+        predicate_return_compiler::PredicateReturnCompiler, CompilationContext, NodeCompiler,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -197,15 +197,17 @@ impl Predicate {
                     logs,
                 )?,
             ))),
-            "predicateReturn" => Ok(Predicate::Return(Box::new(PrReturn::from_node(
-                node,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                logs,
-            )?))),
+            "predicateReturn" => Ok(Predicate::Return(Box::new(
+                PredicateReturnCompiler::from_node(
+                    node,
+                    context,
+                    vars,
+                    vars_array,
+                    scope_index,
+                    global_vars,
+                    logs,
+                )?,
+            ))),
             _ => bail!("unknown predicate kind: {}", kind),
         }
     }

--- a/crates/core/src/pattern/regex.rs
+++ b/crates/core/src/pattern/regex.rs
@@ -5,7 +5,10 @@ use super::{
     variable::{Variable, VariableSourceLocations},
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
+use crate::{
+    context::Context,
+    pattern_compiler::{variable_compiler::VariableCompiler, CompilationContext, NodeCompiler},
+};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
 use marzano_language::{language::Language, target_language::TargetLanguage};
@@ -111,14 +114,14 @@ impl RegexPattern {
             .children_by_field_name("variables", &mut cursor)
             .filter(|n| n.is_named())
             .map(|n| {
-                Variable::from_node(
+                VariableCompiler::from_node(
                     &n,
-                    context.file,
-                    context.src,
+                    context,
                     vars,
-                    global_vars,
                     vars_array,
                     scope_index,
+                    global_vars,
+                    logs,
                 )
                 .unwrap()
             });

--- a/crates/core/src/pattern/rewrite.rs
+++ b/crates/core/src/pattern/rewrite.rs
@@ -1,24 +1,21 @@
 use super::{
-    code_snippet::CodeSnippet,
     dynamic_snippet::DynamicPattern,
     functions::{Evaluator, FuncEvaluation},
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     variable_content::VariableContent,
     Effect, EffectKind, State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, bail, Result};
+use crate::context::Context;
+use anyhow::{bail, Result};
 use core::fmt::Debug;
-use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
-use std::{borrow::Cow, collections::BTreeMap};
-use tree_sitter::Node;
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::borrow::Cow;
 
 #[derive(Debug, Clone)]
 pub struct Rewrite {
-    pub(crate) left: Pattern,
-    pub(crate) right: DynamicPattern,
+    pub left: Pattern,
+    pub right: DynamicPattern,
     pub(crate) _annotation: Option<String>,
 }
 
@@ -29,141 +26,6 @@ impl Rewrite {
             right,
             _annotation,
         }
-    }
-
-    // do we want to add support for annotations?
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let left = node
-            .child_by_field_name("left")
-            .ok_or_else(|| anyhow!("missing lhs of rewrite"))?;
-        let right = node
-            .child_by_field_name("right")
-            .ok_or_else(|| anyhow!("missing rhs of rewrite"))?;
-        let annotation = node.child_by_field_name("annotation");
-        let left = Pattern::from_node(
-            &left,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        let right = Pattern::from_node(
-            &right,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            true,
-            logs,
-        )?;
-
-        match (&left, &right) {
-            (
-                Pattern::CodeSnippet(CodeSnippet {
-                    source: left_source,
-                    ..
-                }),
-                Pattern::CodeSnippet(CodeSnippet {
-                    source: right_source,
-                    ..
-                }),
-            ) if left_source == right_source => {
-                let log = AnalysisLogBuilder::default()
-                .level(441_u16)
-                .file(context.file)
-                .source(context.src)
-                .position(node.start_position())
-                .range(node.range())
-                .message(
-                    format!("Warning: This is rewriting `{}` into the identical string `{}`, will have no effect.", left_source, right_source)
-                )
-                .build()?;
-                logs.push(log);
-            }
-            (_, _) => {}
-        }
-        let right = match right {
-            Pattern::Dynamic(r) => r,
-            Pattern::CodeSnippet(CodeSnippet {
-                dynamic_snippet: Some(r),
-                ..
-            }) => r,
-            Pattern::Variable(v) => DynamicPattern::Variable(v),
-            Pattern::Accessor(a) => DynamicPattern::Accessor(a),
-            Pattern::ListIndex(a) => DynamicPattern::ListIndex(a),
-            Pattern::CallBuiltIn(c) => DynamicPattern::CallBuiltIn(*c),
-            Pattern::CallFunction(c) => DynamicPattern::CallFunction(*c),
-            Pattern::CallForeignFunction(c) => DynamicPattern::CallForeignFunction(*c),
-            Pattern::ASTNode(_)
-                | Pattern::List(_)
-                | Pattern::Map(_)
-                | Pattern::Call(_)
-                | Pattern::Regex(_)
-                | Pattern::File(_)
-                | Pattern::Files(_)
-                | Pattern::Bubble(_)
-                | Pattern::Limit(_)
-                | Pattern::Assignment(_)
-                | Pattern::Accumulate(_)
-                | Pattern::And(_)
-                | Pattern::Or(_)
-                | Pattern::Maybe(_)
-                | Pattern::Any(_)
-                | Pattern::Not(_)
-                | Pattern::If(_)
-                | Pattern::Undefined
-                | Pattern::Top
-                | Pattern::Bottom
-                | Pattern::Underscore
-                | Pattern::StringConstant(_)
-                | Pattern::AstLeafNode(_)
-                | Pattern::IntConstant(_)
-                | Pattern::FloatConstant(_)
-                | Pattern::BooleanConstant(_)
-                | Pattern::CodeSnippet(_)
-                | Pattern::Rewrite(_)
-                | Pattern::Log(_)
-                | Pattern::Range(_)
-                | Pattern::Contains(_)
-                | Pattern::Includes(_)
-                | Pattern::Within(_)
-                | Pattern::After(_)
-                | Pattern::Before(_)
-                | Pattern::Where(_)
-                | Pattern::Some(_)
-                | Pattern::Every(_)
-                | Pattern::Add(_)
-                | Pattern::Subtract(_)
-                | Pattern::Multiply(_)
-                | Pattern::Divide(_)
-                | Pattern::Modulo(_)
-                | Pattern::Like(_)
-                | Pattern::Dots
-                | Pattern::Sequential(_) => Err(anyhow!(
-                "right hand side of rewrite must be a code snippet or function call, but found: {:?}",
-                right
-            ))?,
-        };
-
-        let annotation = annotation.map(|n| {
-            n.utf8_text(context.src.as_bytes())
-                .unwrap()
-                .trim()
-                .to_string()
-        });
-        Ok(Self::new(left, right, annotation))
     }
 
     /**

--- a/crates/core/src/pattern/sequential.rs
+++ b/crates/core/src/pattern/sequential.rs
@@ -16,38 +16,9 @@ use std::{collections::BTreeMap, ops};
 use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
-pub struct Sequential(pub(crate) Vec<Step>);
+pub struct Sequential(pub Vec<Step>);
 
 impl Sequential {
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let mut sequential = vec![];
-        let mut cursor = node.walk();
-        for n in node
-            .children_by_field_name("sequential", &mut cursor)
-            .filter(|n| n.is_named())
-        {
-            let step = StepCompiler::from_node(
-                &n,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                logs,
-            )?;
-            sequential.push(step);
-        }
-        Ok(sequential.into())
-    }
-
     pub(crate) fn from_files_node(
         node: &Node,
         context: &CompilationContext,

--- a/crates/core/src/pattern/some.rs
+++ b/crates/core/src/pattern/some.rs
@@ -1,49 +1,21 @@
 use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext, resolve};
-use anyhow::{anyhow, Result};
+use crate::{context::Context, resolve};
+use anyhow::Result;
 use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Some {
-    pub(crate) pattern: Pattern,
+    pub pattern: Pattern,
 }
 
 impl Some {
     pub fn new(pattern: Pattern) -> Self {
         Self { pattern }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let within = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of pattern some"))?;
-        let within = Pattern::from_node(
-            &within,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        Ok(Some::new(within))
     }
 }
 

--- a/crates/core/src/pattern/subtract.rs
+++ b/crates/core/src/pattern/subtract.rs
@@ -2,63 +2,20 @@ use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
     state::State,
-    variable::VariableSourceLocations,
 };
-use crate::{binding::Constant, context::Context, pattern_compiler::CompilationContext};
-use anyhow::{anyhow, Result};
+use crate::{binding::Constant, context::Context};
+use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Subtract {
-    pub(crate) lhs: Pattern,
-    pub(crate) rhs: Pattern,
+    pub lhs: Pattern,
+    pub rhs: Pattern,
 }
 
 impl Subtract {
     pub fn new(lhs: Pattern, rhs: Pattern) -> Self {
         Self { lhs, rhs }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let left = node
-            .child_by_field_name("left")
-            .ok_or_else(|| anyhow!("missing left of subtract"))?;
-        let left = Pattern::from_node(
-            &left,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        let right = node
-            .child_by_field_name("right")
-            .ok_or_else(|| anyhow!("missing right of subtract"))?;
-        let right = Pattern::from_node(
-            &right,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        Ok(Self::new(left, right))
     }
 
     pub(crate) fn call<'a>(

--- a/crates/core/src/pattern/variable.rs
+++ b/crates/core/src/pattern/variable.rs
@@ -29,7 +29,6 @@ use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet},
 };
-use tree_sitter::Node;
 
 struct VariableMirror<'a> {
     scope: usize,
@@ -73,28 +72,6 @@ impl Variable {
 
     pub(crate) fn file_name() -> Self {
         Self::new(GLOBAL_VARS_SCOPE_INDEX, FILENAME_INDEX)
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        file: &str,
-        src: &str,
-        vars: &mut BTreeMap<String, usize>,
-        global_vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut [Vec<VariableSourceLocations>],
-        scope_index: usize,
-    ) -> Result<Self> {
-        let name = node.utf8_text(src.as_bytes())?.trim().to_string();
-        let range = node.range().into();
-        register_variable(
-            &name,
-            file,
-            range,
-            vars,
-            global_vars,
-            vars_array,
-            scope_index,
-        )
     }
 
     pub(crate) fn from_name(

--- a/crates/core/src/pattern/where.rs
+++ b/crates/core/src/pattern/where.rs
@@ -9,7 +9,11 @@ use super::{
     variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext, split_snippet::split_snippet};
+use crate::{
+    context::Context,
+    pattern_compiler::{predicate_compiler::PredicateCompiler, CompilationContext, NodeCompiler},
+    split_snippet::split_snippet,
+};
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use grit_util::{traverse, Order};
@@ -59,7 +63,7 @@ impl Where {
         let side_condition = node
             .child_by_field_name("side_condition")
             .ok_or_else(|| anyhow!("missing side condition of patternWhere"))?;
-        let side_condition = Predicate::from_node(
+        let side_condition = PredicateCompiler::from_node(
             &side_condition,
             context,
             vars,

--- a/crates/core/src/pattern/where.rs
+++ b/crates/core/src/pattern/where.rs
@@ -5,13 +5,15 @@ use super::{
     predicates::Predicate,
     r#match::Match,
     resolved_pattern::ResolvedPattern,
-    variable::Variable,
     variable::VariableSourceLocations,
     State,
 };
 use crate::{
     context::Context,
-    pattern_compiler::{predicate_compiler::PredicateCompiler, CompilationContext, NodeCompiler},
+    pattern_compiler::{
+        predicate_compiler::PredicateCompiler, variable_compiler::VariableCompiler,
+        CompilationContext, NodeCompiler,
+    },
     split_snippet::split_snippet,
 };
 use anyhow::{anyhow, Result};
@@ -125,14 +127,14 @@ impl Where {
             logs,
         )?;
 
-        let variable = Variable::from_node(
+        let variable = VariableCompiler::from_node(
             &variable,
-            context.file,
-            context.src,
+            context,
             vars,
-            global_vars,
             vars_array,
             scope_index,
+            global_vars,
+            logs,
         )?;
         Ok(Self::new(
             Pattern::Variable(variable),

--- a/crates/core/src/pattern/where.rs
+++ b/crates/core/src/pattern/where.rs
@@ -1,27 +1,14 @@
 use super::{
-    container::Container,
     functions::Evaluator,
     patterns::{Matcher, Name, Pattern},
     predicates::Predicate,
-    r#match::Match,
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     State,
 };
-use crate::{
-    context::Context,
-    pattern_compiler::{variable_compiler::VariableCompiler, CompilationContext, NodeCompiler},
-    split_snippet::split_snippet,
-};
-use anyhow::{anyhow, Result};
+use crate::context::Context;
+use anyhow::Result;
 use core::fmt::Debug;
-use grit_util::{traverse, Order};
-use marzano_language::language::Language;
-use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
-use marzano_util::cursor_wrapper::CursorWrapper;
-use marzano_util::position::Range;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
+use marzano_util::analysis_logs::AnalysisLogs;
 
 #[derive(Debug, Clone)]
 pub struct Where {
@@ -35,74 +22,6 @@ impl Where {
             pattern,
             side_condition,
         }
-    }
-
-    // todo make as it's own pattern
-    pub(crate) fn as_from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let pattern = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of patternWhere"))?;
-
-        let variable = node
-            .child_by_field_name("variable")
-            .ok_or_else(|| anyhow!("missing variable of patternWhere"))?;
-
-        let name = variable.utf8_text(context.src.as_bytes())?;
-        let name = name.trim();
-
-        // this just searches the subtree for a variables that share the name.
-        // could possible lead to some false positives, but more precise solutions
-        // require much greater changes.
-        if pattern_repeated_variable(&pattern, name, context.src, context.lang)? {
-            let range: Range = node.range().into();
-            let log = AnalysisLogBuilder::default()
-                .level(441_u16)
-                .file(context.file)
-                .source(context.src)
-                .position(range.start)
-                .range(range)
-                .message(format!(
-                    "Warning: it is usually incorrect to redefine a variable {name} using as"
-                ))
-                .build()?;
-            logs.push(log);
-        }
-
-        let pattern = Pattern::from_node(
-            &pattern,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-
-        let variable = VariableCompiler::from_node(
-            &variable,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        Ok(Self::new(
-            Pattern::Variable(variable),
-            Predicate::Match(Box::new(Match::new(
-                Container::Variable(variable),
-                Some(pattern),
-            ))),
-        ))
     }
 }
 
@@ -140,32 +59,4 @@ impl Matcher for Where {
             Ok(false)
         }
     }
-}
-
-fn is_variables_in_snippet(name: &str, snippet: &str, lang: &impl Language) -> bool {
-    let variables = split_snippet(snippet, lang);
-    variables.iter().any(|v| v.1 == name)
-}
-
-fn pattern_repeated_variable(
-    pattern: &Node,
-    name: &str,
-    source: &str,
-    lang: &impl Language,
-) -> Result<bool> {
-    let cursor = pattern.walk();
-    let cursor = traverse(CursorWrapper::new(cursor, source), Order::Pre);
-    Ok(cursor
-        .filter(|n| n.node.kind() == "variable" || n.node.kind() == "codeSnippet")
-        .map(|n| {
-            let s = n.node.utf8_text(source.as_bytes())?.trim().to_string();
-            if n.node.kind() == "variable" {
-                Ok(s == name)
-            } else {
-                Ok(is_variables_in_snippet(name, &s, lang))
-            }
-        })
-        .collect::<Result<Vec<bool>>>()?
-        .into_iter()
-        .any(|b| b))
 }

--- a/crates/core/src/pattern/where.rs
+++ b/crates/core/src/pattern/where.rs
@@ -10,10 +10,7 @@ use super::{
 };
 use crate::{
     context::Context,
-    pattern_compiler::{
-        predicate_compiler::PredicateCompiler, variable_compiler::VariableCompiler,
-        CompilationContext, NodeCompiler,
-    },
+    pattern_compiler::{variable_compiler::VariableCompiler, CompilationContext, NodeCompiler},
     split_snippet::split_snippet,
 };
 use anyhow::{anyhow, Result};
@@ -38,43 +35,6 @@ impl Where {
             pattern,
             side_condition,
         }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let pattern = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of patternWhere"))?;
-        let pattern = Pattern::from_node(
-            &pattern,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        let side_condition = node
-            .child_by_field_name("side_condition")
-            .ok_or_else(|| anyhow!("missing side condition of patternWhere"))?;
-        let side_condition = PredicateCompiler::from_node(
-            &side_condition,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            logs,
-        )?;
-        Ok(Self::new(pattern, side_condition))
     }
 
     // todo make as it's own pattern

--- a/crates/core/src/pattern/within.rs
+++ b/crates/core/src/pattern/within.rs
@@ -1,16 +1,13 @@
 use super::{
     patterns::{Matcher, Name, Pattern},
     resolved_pattern::ResolvedPattern,
-    variable::VariableSourceLocations,
     State,
 };
-use crate::{context::Context, pattern_compiler::CompilationContext, resolve};
-use anyhow::{anyhow, Result};
+use crate::{context::Context, resolve};
+use anyhow::Result;
 use core::fmt::Debug;
 use grit_util::AstNode;
 use marzano_util::analysis_logs::AnalysisLogs;
-use std::collections::BTreeMap;
-use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Within {
@@ -20,31 +17,6 @@ pub struct Within {
 impl Within {
     pub fn new(pattern: Pattern) -> Self {
         Self { pattern }
-    }
-
-    pub(crate) fn from_node(
-        node: &Node,
-        context: &CompilationContext,
-        vars: &mut BTreeMap<String, usize>,
-        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
-        scope_index: usize,
-        global_vars: &mut BTreeMap<String, usize>,
-        logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
-        let within = node
-            .child_by_field_name("pattern")
-            .ok_or_else(|| anyhow!("missing pattern of pattern within"))?;
-        let within = Pattern::from_node(
-            &within,
-            context,
-            vars,
-            vars_array,
-            scope_index,
-            global_vars,
-            false,
-            logs,
-        )?;
-        Ok(Self::new(within))
     }
 }
 

--- a/crates/core/src/pattern_compiler/accessor_compiler.rs
+++ b/crates/core/src/pattern_compiler/accessor_compiler.rs
@@ -1,11 +1,11 @@
 use super::{
     compiler::CompilationContext, container_compiler::ContainerCompiler,
-    node_compiler::NodeCompiler,
+    node_compiler::NodeCompiler, variable_compiler::VariableCompiler,
 };
 use crate::pattern::{
     accessor::{Accessor, AccessorKey, AccessorMap},
     map::GritMap,
-    variable::{Variable, VariableSourceLocations},
+    variable::VariableSourceLocations,
 };
 use anyhow::{anyhow, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -57,14 +57,14 @@ impl NodeCompiler for AccessorCompiler {
             .ok_or_else(|| anyhow!("missing key of accessor"))?;
 
         let key = if key.kind() == "variable" {
-            AccessorKey::Variable(Variable::from_node(
+            AccessorKey::Variable(VariableCompiler::from_node(
                 &key,
-                context.file,
-                context.src,
+                context,
                 vars,
-                global_vars,
                 vars_array,
                 scope_index,
+                global_vars,
+                logs,
             )?)
         } else {
             AccessorKey::String(key.utf8_text(context.src.as_bytes())?.to_string())

--- a/crates/core/src/pattern_compiler/accessor_compiler.rs
+++ b/crates/core/src/pattern_compiler/accessor_compiler.rs
@@ -1,7 +1,9 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use super::{
+    compiler::CompilationContext, container_compiler::ContainerCompiler,
+    node_compiler::NodeCompiler,
+};
 use crate::pattern::{
     accessor::{Accessor, AccessorKey, AccessorMap},
-    container::Container,
     map::GritMap,
     variable::{Variable, VariableSourceLocations},
 };
@@ -39,7 +41,7 @@ impl NodeCompiler for AccessorCompiler {
                 logs,
             )?)
         } else {
-            AccessorMap::Container(Container::from_node(
+            AccessorMap::Container(ContainerCompiler::from_node(
                 &map,
                 context,
                 vars,

--- a/crates/core/src/pattern_compiler/and_compiler.rs
+++ b/crates/core/src/pattern_compiler/and_compiler.rs
@@ -1,5 +1,13 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
-use crate::pattern::{and::And, patterns::Pattern, variable::VariableSourceLocations};
+use super::{
+    compiler::CompilationContext, node_compiler::NodeCompiler,
+    predicate_compiler::PredicateCompiler,
+};
+use crate::pattern::{
+    and::{And, PrAnd},
+    patterns::Pattern,
+    predicates::Predicate,
+    variable::VariableSourceLocations,
+};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -44,6 +52,44 @@ impl NodeCompiler for AndCompiler {
             Ok(patterns.remove(0))
         } else {
             Ok(Pattern::And(Box::new(And::new(patterns))))
+        }
+    }
+}
+
+pub(crate) struct PrAndCompiler;
+
+impl NodeCompiler for PrAndCompiler {
+    type TargetPattern = Predicate;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let mut cursor = node.walk();
+        let children = node
+            .children_by_field_name("predicates", &mut cursor)
+            .filter(|n| n.is_named());
+        let mut predicates = Vec::new();
+        for predicate in children {
+            predicates.push(PredicateCompiler::from_node(
+                &predicate,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?);
+        }
+        if predicates.len() == 1 {
+            Ok(predicates.remove(0))
+        } else {
+            Ok(Predicate::And(Box::new(PrAnd::new(predicates))))
         }
     }
 }

--- a/crates/core/src/pattern_compiler/any_compiler.rs
+++ b/crates/core/src/pattern_compiler/any_compiler.rs
@@ -1,5 +1,13 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
-use crate::pattern::{any::Any, patterns::Pattern, variable::VariableSourceLocations};
+use super::{
+    compiler::CompilationContext, node_compiler::NodeCompiler,
+    predicate_compiler::PredicateCompiler,
+};
+use crate::pattern::{
+    any::{Any, PrAny},
+    patterns::Pattern,
+    predicates::Predicate,
+    variable::VariableSourceLocations,
+};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -40,6 +48,44 @@ impl NodeCompiler for AnyCompiler {
             Ok(patterns.remove(0))
         } else {
             Ok(Pattern::Any(Box::new(Any::new(patterns))))
+        }
+    }
+}
+
+pub(crate) struct PrAnyCompiler;
+
+impl NodeCompiler for PrAnyCompiler {
+    type TargetPattern = Predicate;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let mut cursor = node.walk();
+        let children = node
+            .children_by_field_name("predicates", &mut cursor)
+            .filter(|n| n.is_named());
+        let mut predicates = Vec::new();
+        for predicate in children {
+            predicates.push(PredicateCompiler::from_node(
+                &predicate,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?);
+        }
+        if predicates.len() == 1 {
+            Ok(predicates.remove(0))
+        } else {
+            Ok(Predicate::Any(Box::new(PrAny::new(predicates))))
         }
     }
 }

--- a/crates/core/src/pattern_compiler/as_compiler.rs
+++ b/crates/core/src/pattern_compiler/as_compiler.rs
@@ -1,0 +1,122 @@
+use super::{
+    compiler::CompilationContext, node_compiler::NodeCompiler, variable_compiler::VariableCompiler,
+};
+use crate::{
+    pattern::{
+        container::Container, patterns::Pattern, predicates::Predicate, r#match::Match,
+        r#where::Where, variable::VariableSourceLocations,
+    },
+    split_snippet::split_snippet,
+};
+use anyhow::{anyhow, Result};
+use grit_util::{traverse, Order};
+use marzano_language::language::Language;
+use marzano_util::{
+    analysis_logs::{AnalysisLogBuilder, AnalysisLogs},
+    cursor_wrapper::CursorWrapper,
+    position::Range,
+};
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct AsCompiler;
+
+impl NodeCompiler for AsCompiler {
+    type TargetPattern = Where;
+
+    // todo make `as` its own pattern
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let pattern = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of patternWhere"))?;
+
+        let variable = node
+            .child_by_field_name("variable")
+            .ok_or_else(|| anyhow!("missing variable of patternWhere"))?;
+
+        let name = variable.utf8_text(context.src.as_bytes())?;
+        let name = name.trim();
+
+        // this just searches the subtree for a variables that share the name.
+        // could possible lead to some false positives, but more precise solutions
+        // require much greater changes.
+        if pattern_repeated_variable(&pattern, name, context.src, context.lang)? {
+            let range: Range = node.range().into();
+            let log = AnalysisLogBuilder::default()
+                .level(441_u16)
+                .file(context.file)
+                .source(context.src)
+                .position(range.start)
+                .range(range)
+                .message(format!(
+                    "Warning: it is usually incorrect to redefine a variable {name} using as"
+                ))
+                .build()?;
+            logs.push(log);
+        }
+
+        let pattern = Pattern::from_node(
+            &pattern,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        let variable = VariableCompiler::from_node(
+            &variable,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        Ok(Where::new(
+            Pattern::Variable(variable),
+            Predicate::Match(Box::new(Match::new(
+                Container::Variable(variable),
+                Some(pattern),
+            ))),
+        ))
+    }
+}
+
+fn pattern_repeated_variable(
+    pattern: &Node,
+    name: &str,
+    source: &str,
+    lang: &impl Language,
+) -> Result<bool> {
+    let cursor = pattern.walk();
+    let cursor = traverse(CursorWrapper::new(cursor, source), Order::Pre);
+    Ok(cursor
+        .filter(|n| n.node.kind() == "variable" || n.node.kind() == "codeSnippet")
+        .map(|n| {
+            let s = n.node.utf8_text(source.as_bytes())?.trim().to_string();
+            if n.node.kind() == "variable" {
+                Ok(s == name)
+            } else {
+                Ok(is_variables_in_snippet(name, &s, lang))
+            }
+        })
+        .collect::<Result<Vec<bool>>>()?
+        .into_iter()
+        .any(|b| b))
+}
+
+fn is_variables_in_snippet(name: &str, snippet: &str, lang: &impl Language) -> bool {
+    let variables = split_snippet(snippet, lang);
+    variables.iter().any(|v| v.1 == name)
+}

--- a/crates/core/src/pattern_compiler/assignment_compiler.rs
+++ b/crates/core/src/pattern_compiler/assignment_compiler.rs
@@ -1,7 +1,9 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use super::{
+    compiler::CompilationContext, container_compiler::ContainerCompiler,
+    node_compiler::NodeCompiler,
+};
 use crate::pattern::{
     assignment::Assignment,
-    container::Container,
     patterns::Pattern,
     variable::{is_reserved_metavariable, VariableSourceLocations},
 };
@@ -46,7 +48,7 @@ impl NodeCompiler for AssignmentCompiler {
         if is_reserved_metavariable(&var_text, None::<&TargetLanguage>) {
             bail!("{} is a reserved metavariable name. For more information, check out the docs at https://docs.grit.io/language/patterns#metavariables.", var_text.trim_start_matches(GRIT_METAVARIABLE_PREFIX));
         }
-        let variable = Container::from_node(
+        let variable = ContainerCompiler::from_node(
             &container,
             context,
             vars,

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -1,4 +1,10 @@
-use super::auto_wrap::auto_wrap_pattern;
+use super::{
+    auto_wrap::auto_wrap_pattern,
+    function_definition_compiler::{
+        ForeignFunctionDefinitionCompiler, GritFunctionDefinitionCompiler,
+    },
+    NodeCompiler,
+};
 use crate::{
     parse::make_grit_parser,
     pattern::{
@@ -307,22 +313,25 @@ fn node_to_definitions(
                 logs,
             )?;
         } else if let Some(function_definition) = definition.child_by_field_name("function") {
-            GritFunctionDefinition::from_node(
+            function_definitions.push(GritFunctionDefinitionCompiler::from_node(
                 &function_definition,
                 context,
+                &mut BTreeMap::new(),
                 vars_array,
-                function_definitions,
+                0, // FIXME: Unused argument.
                 global_vars,
                 logs,
-            )?;
+            )?);
         } else if let Some(function_definition) = definition.child_by_field_name("foreign") {
-            ForeignFunctionDefinition::from_node(
+            foreign_function_definitions.push(ForeignFunctionDefinitionCompiler::from_node(
                 &function_definition,
                 context,
+                &mut BTreeMap::new(),
                 vars_array,
-                foreign_function_definitions,
+                0, // FIXME: Unused argument.
                 global_vars,
-            )?;
+                logs,
+            )?);
         } else {
             bail!(anyhow!(
                 "definition must be either a pattern, a predicate or a function"

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -3,6 +3,7 @@ use super::{
     function_definition_compiler::{
         ForeignFunctionDefinitionCompiler, GritFunctionDefinitionCompiler,
     },
+    pattern_definition_compiler::PatternDefinitionCompiler,
     NodeCompiler,
 };
 use crate::{
@@ -295,14 +296,16 @@ fn node_to_definitions(
         .filter(|n| n.is_named())
     {
         if let Some(pattern_definition) = definition.child_by_field_name("pattern") {
-            PatternDefinition::from_node(
+            // todo check for duplicate names
+            pattern_definitions.push(PatternDefinitionCompiler::from_node(
                 &pattern_definition,
                 context,
+                &mut BTreeMap::new(),
                 vars_array,
-                pattern_definitions,
+                0, // FIXME: Unused argument.
                 global_vars,
                 logs,
-            )?;
+            )?);
         } else if let Some(predicate_definition) = definition.child_by_field_name("predicate") {
             PredicateDefinition::from_node(
                 &predicate_definition,

--- a/crates/core/src/pattern_compiler/container_compiler.rs
+++ b/crates/core/src/pattern_compiler/container_compiler.rs
@@ -1,11 +1,9 @@
 use super::{
     accessor_compiler::AccessorCompiler, compiler::CompilationContext,
     list_index_compiler::ListIndexCompiler, node_compiler::NodeCompiler,
+    variable_compiler::VariableCompiler,
 };
-use crate::pattern::{
-    container::Container,
-    variable::{Variable, VariableSourceLocations},
-};
+use crate::pattern::{container::Container, variable::VariableSourceLocations};
 use anyhow::{bail, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -26,14 +24,14 @@ impl NodeCompiler for ContainerCompiler {
         logs: &mut AnalysisLogs,
     ) -> Result<Self::TargetPattern> {
         match node.kind().as_ref() {
-            "variable" => Ok(Container::Variable(Variable::from_node(
+            "variable" => Ok(Container::Variable(VariableCompiler::from_node(
                 node,
-                context.file,
-                context.src,
+                context,
                 vars,
-                global_vars,
                 vars_array,
                 scope_index,
+                global_vars,
+                logs,
             )?)),
             "mapAccessor" => Ok(Container::Accessor(Box::new(AccessorCompiler::from_node(
                 node,

--- a/crates/core/src/pattern_compiler/container_compiler.rs
+++ b/crates/core/src/pattern_compiler/container_compiler.rs
@@ -1,0 +1,59 @@
+use super::{
+    accessor_compiler::AccessorCompiler, compiler::CompilationContext, node_compiler::NodeCompiler,
+};
+use crate::pattern::{
+    container::Container,
+    list_index::ListIndex,
+    variable::{Variable, VariableSourceLocations},
+};
+use anyhow::{bail, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct ContainerCompiler;
+
+impl NodeCompiler for ContainerCompiler {
+    type TargetPattern = Container;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        match node.kind().as_ref() {
+            "variable" => Ok(Container::Variable(Variable::from_node(
+                node,
+                context.file,
+                context.src,
+                vars,
+                global_vars,
+                vars_array,
+                scope_index,
+            )?)),
+            "mapAccessor" => Ok(Container::Accessor(Box::new(AccessorCompiler::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            "listIndex" => Ok(Container::ListIndex(Box::new(ListIndex::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            s => bail!("Invalid kind for container: {}", s),
+        }
+    }
+}

--- a/crates/core/src/pattern_compiler/container_compiler.rs
+++ b/crates/core/src/pattern_compiler/container_compiler.rs
@@ -1,9 +1,9 @@
 use super::{
-    accessor_compiler::AccessorCompiler, compiler::CompilationContext, node_compiler::NodeCompiler,
+    accessor_compiler::AccessorCompiler, compiler::CompilationContext,
+    list_index_compiler::ListIndexCompiler, node_compiler::NodeCompiler,
 };
 use crate::pattern::{
     container::Container,
-    list_index::ListIndex,
     variable::{Variable, VariableSourceLocations},
 };
 use anyhow::{bail, Result};
@@ -44,15 +44,17 @@ impl NodeCompiler for ContainerCompiler {
                 global_vars,
                 logs,
             )?))),
-            "listIndex" => Ok(Container::ListIndex(Box::new(ListIndex::from_node(
-                node,
-                context,
-                vars,
-                vars_array,
-                scope_index,
-                global_vars,
-                logs,
-            )?))),
+            "listIndex" => Ok(Container::ListIndex(Box::new(
+                ListIndexCompiler::from_node(
+                    node,
+                    context,
+                    vars,
+                    vars_array,
+                    scope_index,
+                    global_vars,
+                    logs,
+                )?,
+            ))),
             s => bail!("Invalid kind for container: {}", s),
         }
     }

--- a/crates/core/src/pattern_compiler/contains_compiler.rs
+++ b/crates/core/src/pattern_compiler/contains_compiler.rs
@@ -1,0 +1,50 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{contains::Contains, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct ContainsCompiler;
+
+impl NodeCompiler for ContainsCompiler {
+    type TargetPattern = Contains;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let contains = node
+            .child_by_field_name("contains")
+            .ok_or_else(|| anyhow!("missing contains of patternContains"))?;
+        let contains = Pattern::from_node(
+            &contains,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        let until = node.child_by_field_name("until").map(|n| {
+            Pattern::from_node(
+                &n,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                false,
+                logs,
+            )
+        });
+        let until = until.map_or(Ok(None), |v| v.map(Some))?;
+        Ok(Contains::new(contains, until))
+    }
+}

--- a/crates/core/src/pattern_compiler/divide_compiler.rs
+++ b/crates/core/src/pattern_compiler/divide_compiler.rs
@@ -1,0 +1,52 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{divide::Divide, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct DivideCompiler;
+
+impl NodeCompiler for DivideCompiler {
+    type TargetPattern = Divide;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let left = node
+            .child_by_field_name("left")
+            .ok_or_else(|| anyhow!("missing left of divide"))?;
+        let left = Pattern::from_node(
+            &left,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        let right = node
+            .child_by_field_name("right")
+            .ok_or_else(|| anyhow!("missing right of divide"))?;
+        let right = Pattern::from_node(
+            &right,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        Ok(Divide::new(left, right))
+    }
+}

--- a/crates/core/src/pattern_compiler/equal_compiler.rs
+++ b/crates/core/src/pattern_compiler/equal_compiler.rs
@@ -1,0 +1,56 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{equal::Equal, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct EqualCompiler;
+
+impl NodeCompiler for EqualCompiler {
+    type TargetPattern = Equal;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let variable = node
+            .child_by_field_name("left")
+            .ok_or_else(|| anyhow!("missing lhs of predicateEqual"))?;
+        let variable = Pattern::from_node(
+            &variable,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            true,
+            logs,
+        )?;
+        let pattern = node
+            .child_by_field_name("right")
+            .ok_or_else(|| anyhow!("missing rhs of predicateEqual"))?;
+        let pattern = Pattern::from_node(
+            &pattern,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            true,
+            logs,
+        )?;
+        if let Pattern::Variable(var) = variable {
+            Ok(Equal::new(var, pattern))
+        } else {
+            Err(anyhow!(
+                "predicateEqual must have a variable as first argument",
+            ))
+        }
+    }
+}

--- a/crates/core/src/pattern_compiler/every_compiler.rs
+++ b/crates/core/src/pattern_compiler/every_compiler.rs
@@ -1,0 +1,37 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{every::Every, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct EveryCompiler;
+
+impl NodeCompiler for EveryCompiler {
+    type TargetPattern = Every;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let within = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of pattern every"))?;
+        let within = Pattern::from_node(
+            &within,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        Ok(Every::new(within))
+    }
+}

--- a/crates/core/src/pattern_compiler/function_definition_compiler.rs
+++ b/crates/core/src/pattern_compiler/function_definition_compiler.rs
@@ -1,0 +1,128 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    and::PrAnd,
+    function_definition::{ForeignFunctionDefinition, GritFunctionDefinition},
+    variable::{get_variables, VariableSourceLocations},
+};
+use anyhow::{anyhow, Result};
+use marzano_language::foreign_language::ForeignLanguage;
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct GritFunctionDefinitionCompiler;
+
+impl NodeCompiler for GritFunctionDefinitionCompiler {
+    type TargetPattern = GritFunctionDefinition;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        _vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        _scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let name = node
+            .child_by_field_name("name")
+            .ok_or_else(|| anyhow!("missing name of function definition"))?;
+        let name = name.utf8_text(context.src.as_bytes())?;
+        let name = name.trim();
+        let scope_index = vars_array.len();
+        vars_array.push(vec![]);
+        let mut local_vars = BTreeMap::new();
+
+        let params = get_variables(
+            &context
+                .function_definition_info
+                .get(name)
+                .ok_or_else(|| anyhow!("cannot get info for function {}", name))?
+                .parameters,
+            context.file,
+            vars_array,
+            scope_index,
+            &mut local_vars,
+            global_vars,
+        )?;
+
+        let body = node
+            .child_by_field_name("body")
+            .ok_or_else(|| anyhow!("missing body of grit function definition"))?;
+        let body = PrAnd::from_node(
+            &body,
+            context,
+            &mut local_vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        let function_definition = GritFunctionDefinition::new(
+            name.to_owned(),
+            scope_index,
+            params,
+            local_vars.values().cloned().collect(),
+            body,
+        );
+        Ok(function_definition)
+    }
+}
+
+pub(crate) struct ForeignFunctionDefinitionCompiler;
+
+impl NodeCompiler for ForeignFunctionDefinitionCompiler {
+    type TargetPattern = ForeignFunctionDefinition;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        _vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        _scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let name = node
+            .child_by_field_name("name")
+            .ok_or_else(|| anyhow!("missing name of function definition"))?;
+        let name = name.utf8_text(context.src.as_bytes())?;
+        let name = name.trim();
+        let scope_index = vars_array.len();
+        vars_array.push(vec![]);
+        let mut local_vars = BTreeMap::new();
+        let params = get_variables(
+            &context
+                .foreign_function_definition_info
+                .get(name)
+                .ok_or_else(|| anyhow!("cannot get info for function {}", name))?
+                .parameters,
+            context.file,
+            vars_array,
+            scope_index,
+            &mut local_vars,
+            global_vars,
+        )?;
+        let body = node
+            .child_by_field_name("body")
+            .ok_or_else(|| anyhow!("missing body of foreign function definition"))?
+            .child_by_field_name("code")
+            .ok_or_else(|| anyhow!("missing code of foreign function body"))?;
+        let byte_range = body.byte_range();
+        let byte_range = byte_range.start as usize..byte_range.end as usize;
+        let body = &context.src.as_bytes()[byte_range];
+        let foreign_language = ForeignLanguage::from_node(
+            node.child_by_field_name("language")
+                .ok_or_else(|| anyhow!("missing language of foreign function definition"))?,
+            context.src,
+        )?;
+        let function_definition = ForeignFunctionDefinition::new(
+            name.to_owned(),
+            scope_index,
+            params,
+            foreign_language,
+            body,
+        );
+        Ok(function_definition)
+    }
+}

--- a/crates/core/src/pattern_compiler/function_definition_compiler.rs
+++ b/crates/core/src/pattern_compiler/function_definition_compiler.rs
@@ -1,6 +1,7 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use super::{
+    and_compiler::PrAndCompiler, compiler::CompilationContext, node_compiler::NodeCompiler,
+};
 use crate::pattern::{
-    and::PrAnd,
     function_definition::{ForeignFunctionDefinition, GritFunctionDefinition},
     variable::{get_variables, VariableSourceLocations},
 };
@@ -49,7 +50,7 @@ impl NodeCompiler for GritFunctionDefinitionCompiler {
         let body = node
             .child_by_field_name("body")
             .ok_or_else(|| anyhow!("missing body of grit function definition"))?;
-        let body = PrAnd::from_node(
+        let body = PrAndCompiler::from_node(
             &body,
             context,
             &mut local_vars,

--- a/crates/core/src/pattern_compiler/if_compiler.rs
+++ b/crates/core/src/pattern_compiler/if_compiler.rs
@@ -1,0 +1,66 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    patterns::Pattern, predicates::Predicate, r#if::If, variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct IfCompiler;
+
+impl NodeCompiler for IfCompiler {
+    type TargetPattern = If;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let if_ = node
+            .child_by_field_name("if")
+            .ok_or_else(|| anyhow!("missing condition of if"))?;
+        let if_ = Predicate::from_node(
+            &if_,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        let then = node
+            .child_by_field_name("then")
+            .ok_or_else(|| anyhow!("missing consequence of if"))?;
+        let then = Pattern::from_node(
+            &then,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        let else_ = node
+            .child_by_field_name("else")
+            .map(|e| {
+                Pattern::from_node(
+                    &e,
+                    context,
+                    vars,
+                    vars_array,
+                    scope_index,
+                    global_vars,
+                    false,
+                    logs,
+                )
+            })
+            .map_or(Ok(None), |v| v.map(Some))?;
+        Ok(If::new(if_, then, else_))
+    }
+}

--- a/crates/core/src/pattern_compiler/if_compiler.rs
+++ b/crates/core/src/pattern_compiler/if_compiler.rs
@@ -1,7 +1,8 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
-use crate::pattern::{
-    patterns::Pattern, predicates::Predicate, r#if::If, variable::VariableSourceLocations,
+use super::{
+    compiler::CompilationContext, node_compiler::NodeCompiler,
+    predicate_compiler::PredicateCompiler,
 };
+use crate::pattern::{patterns::Pattern, r#if::If, variable::VariableSourceLocations};
 use anyhow::{anyhow, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -24,7 +25,7 @@ impl NodeCompiler for IfCompiler {
         let if_ = node
             .child_by_field_name("if")
             .ok_or_else(|| anyhow!("missing condition of if"))?;
-        let if_ = Predicate::from_node(
+        let if_ = PredicateCompiler::from_node(
             &if_,
             context,
             vars,

--- a/crates/core/src/pattern_compiler/includes_compiler.rs
+++ b/crates/core/src/pattern_compiler/includes_compiler.rs
@@ -1,0 +1,37 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{includes::Includes, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct IncludesCompiler;
+
+impl NodeCompiler for IncludesCompiler {
+    type TargetPattern = Includes;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let includes = node
+            .child_by_field_name("includes")
+            .ok_or_else(|| anyhow!("missing includes of patternIncludes"))?;
+        let includes = Pattern::from_node(
+            &includes,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        Ok(Includes::new(includes))
+    }
+}

--- a/crates/core/src/pattern_compiler/like_compiler.rs
+++ b/crates/core/src/pattern_compiler/like_compiler.rs
@@ -1,0 +1,54 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    float_constant::FloatConstant, like::Like, patterns::Pattern, variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct LikeCompiler;
+
+impl NodeCompiler for LikeCompiler {
+    type TargetPattern = Like;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let threshold = node
+            .child_by_field_name("threshold")
+            .map(|n| {
+                Pattern::from_node(
+                    &n,
+                    context,
+                    vars,
+                    vars_array,
+                    scope_index,
+                    global_vars,
+                    true,
+                    logs,
+                )
+            })
+            .unwrap_or(Result::Ok(Pattern::FloatConstant(FloatConstant::new(0.9))))?;
+        let like = node
+            .child_by_field_name("example")
+            .ok_or_else(|| anyhow!("missing field example of patternLike"))?;
+        let like = Pattern::from_node(
+            &like,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            true,
+            logs,
+        )?;
+        Ok(Like::new(like, threshold))
+    }
+}

--- a/crates/core/src/pattern_compiler/limit_compiler.rs
+++ b/crates/core/src/pattern_compiler/limit_compiler.rs
@@ -1,0 +1,44 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{limit::Limit, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct LimitCompiler;
+
+impl NodeCompiler for LimitCompiler {
+    type TargetPattern = Pattern;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let body = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern in limit"))?;
+        let body = Pattern::from_node(
+            &body,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        let limit = node
+            .child_by_field_name("limit")
+            .ok_or_else(|| anyhow!("missing limit in limit"))?;
+        let limit = limit
+            .utf8_text(context.src.as_bytes())?
+            .trim()
+            .parse::<usize>()?;
+        Ok(Pattern::Limit(Box::new(Limit::new(body, limit))))
+    }
+}

--- a/crates/core/src/pattern_compiler/list_index_compiler.rs
+++ b/crates/core/src/pattern_compiler/list_index_compiler.rs
@@ -1,0 +1,80 @@
+use super::{
+    compiler::CompilationContext, container_compiler::ContainerCompiler,
+    node_compiler::NodeCompiler,
+};
+use crate::pattern::{
+    list::List,
+    list_index::{ContainerOrIndex, ListIndex, ListOrContainer},
+    variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct ListIndexCompiler;
+
+impl NodeCompiler for ListIndexCompiler {
+    type TargetPattern = ListIndex;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let list = node
+            .child_by_field_name("list")
+            .ok_or_else(|| anyhow!("missing list of listIndex"))?;
+        let list = if list.kind() == "list" {
+            ListOrContainer::List(List::from_node(
+                &list,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                false,
+                logs,
+            )?)
+        } else {
+            ListOrContainer::Container(ContainerCompiler::from_node(
+                &list,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?)
+        };
+
+        let index_node = node
+            .child_by_field_name("index")
+            .ok_or_else(|| anyhow!("missing index of listIndex"))?;
+
+        let index = if let "signedIntConstant" = index_node.kind().as_ref() {
+            ContainerOrIndex::Index(
+                index_node
+                    .utf8_text(context.src.as_bytes())?
+                    .parse::<isize>()
+                    .map_err(|_| anyhow!("list index must be an integer"))?,
+            )
+        } else {
+            ContainerOrIndex::Container(ContainerCompiler::from_node(
+                &index_node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?)
+        };
+
+        Ok(ListIndex { list, index })
+    }
+}

--- a/crates/core/src/pattern_compiler/log_compiler.rs
+++ b/crates/core/src/pattern_compiler/log_compiler.rs
@@ -1,0 +1,60 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    log::{Log, VariableInfo},
+    patterns::Pattern,
+    variable::{Variable, VariableSourceLocations},
+};
+use anyhow::Result;
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct LogCompiler;
+
+impl NodeCompiler for LogCompiler {
+    type TargetPattern = Log;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let message = node.child_by_field_name("message");
+        let message = if let Some(message) = message {
+            Some(Pattern::from_node(
+                &message,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                false,
+                logs,
+            )?)
+        } else {
+            None
+        };
+        let variable_node = node.child_by_field_name("variable");
+        let variable = variable_node
+            .map(|n| {
+                let name = n.utf8_text(context.src.as_bytes()).unwrap().to_string();
+                let variable = Variable::from_node(
+                    &n,
+                    context.file,
+                    context.src,
+                    vars,
+                    global_vars,
+                    vars_array,
+                    scope_index,
+                )?;
+                Ok(VariableInfo::new(name, variable))
+            })
+            .map_or(Ok(None), |v: Result<VariableInfo>| v.map(Some))?;
+
+        Ok(Log::new(variable, message))
+    }
+}

--- a/crates/core/src/pattern_compiler/log_compiler.rs
+++ b/crates/core/src/pattern_compiler/log_compiler.rs
@@ -1,8 +1,10 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use super::{
+    compiler::CompilationContext, node_compiler::NodeCompiler, variable_compiler::VariableCompiler,
+};
 use crate::pattern::{
     log::{Log, VariableInfo},
     patterns::Pattern,
-    variable::{Variable, VariableSourceLocations},
+    variable::VariableSourceLocations,
 };
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -42,14 +44,14 @@ impl NodeCompiler for LogCompiler {
         let variable = variable_node
             .map(|n| {
                 let name = n.utf8_text(context.src.as_bytes()).unwrap().to_string();
-                let variable = Variable::from_node(
+                let variable = VariableCompiler::from_node(
                     &n,
-                    context.file,
-                    context.src,
+                    context,
                     vars,
-                    global_vars,
                     vars_array,
                     scope_index,
+                    global_vars,
+                    logs,
                 )?;
                 Ok(VariableInfo::new(name, variable))
             })

--- a/crates/core/src/pattern_compiler/match_compiler.rs
+++ b/crates/core/src/pattern_compiler/match_compiler.rs
@@ -1,0 +1,51 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    container::Container, patterns::Pattern, r#match::Match, variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct MatchCompiler;
+
+impl NodeCompiler for MatchCompiler {
+    type TargetPattern = Match;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let value = node
+            .child_by_field_name("left")
+            .ok_or_else(|| anyhow!("missing lhs of predicateMatch"))?;
+        let value = Container::from_node(
+            &value,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        let pattern = node
+            .child_by_field_name("right")
+            .ok_or_else(|| anyhow!("missing rhs of predicateMatch"))?;
+        let pattern = Some(Pattern::from_node(
+            &pattern,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?);
+        Ok(Match::new(value, pattern))
+    }
+}

--- a/crates/core/src/pattern_compiler/match_compiler.rs
+++ b/crates/core/src/pattern_compiler/match_compiler.rs
@@ -1,7 +1,8 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
-use crate::pattern::{
-    container::Container, patterns::Pattern, r#match::Match, variable::VariableSourceLocations,
+use super::{
+    compiler::CompilationContext, container_compiler::ContainerCompiler,
+    node_compiler::NodeCompiler,
 };
+use crate::pattern::{patterns::Pattern, r#match::Match, variable::VariableSourceLocations};
 use anyhow::{anyhow, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -24,7 +25,7 @@ impl NodeCompiler for MatchCompiler {
         let value = node
             .child_by_field_name("left")
             .ok_or_else(|| anyhow!("missing lhs of predicateMatch"))?;
-        let value = Container::from_node(
+        let value = ContainerCompiler::from_node(
             &value,
             context,
             vars,

--- a/crates/core/src/pattern_compiler/maybe_compiler.rs
+++ b/crates/core/src/pattern_compiler/maybe_compiler.rs
@@ -1,0 +1,37 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{maybe::Maybe, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct MaybeCompiler;
+
+impl NodeCompiler for MaybeCompiler {
+    type TargetPattern = Maybe;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let pattern = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of patternMaybe"))?;
+        let pattern = Pattern::from_node(
+            &pattern,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        Ok(Maybe::new(pattern))
+    }
+}

--- a/crates/core/src/pattern_compiler/maybe_compiler.rs
+++ b/crates/core/src/pattern_compiler/maybe_compiler.rs
@@ -1,5 +1,12 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
-use crate::pattern::{maybe::Maybe, patterns::Pattern, variable::VariableSourceLocations};
+use super::{
+    compiler::CompilationContext, node_compiler::NodeCompiler,
+    predicate_compiler::PredicateCompiler,
+};
+use crate::pattern::{
+    maybe::{Maybe, PrMaybe},
+    patterns::Pattern,
+    variable::VariableSourceLocations,
+};
 use anyhow::{anyhow, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -33,5 +40,35 @@ impl NodeCompiler for MaybeCompiler {
             logs,
         )?;
         Ok(Maybe::new(pattern))
+    }
+}
+
+pub(crate) struct PrMaybeCompiler;
+
+impl NodeCompiler for PrMaybeCompiler {
+    type TargetPattern = PrMaybe;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let predicate = node
+            .child_by_field_name("predicate")
+            .ok_or_else(|| anyhow!("missing predicate of predicateMaybe"))?;
+        let predicate = PredicateCompiler::from_node(
+            &predicate,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        Ok(PrMaybe::new(predicate))
     }
 }

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -29,6 +29,7 @@ mod node_compiler;
 pub(crate) mod not_compiler;
 pub(crate) mod or_compiler;
 pub(crate) mod pattern_definition_compiler;
+pub(crate) mod predicate_definition_compiler;
 pub(crate) mod step_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -15,6 +15,12 @@ pub(crate) mod divide_compiler;
 pub(crate) mod equal_compiler;
 pub(crate) mod every_compiler;
 pub(crate) mod function_definition_compiler;
+pub(crate) mod if_compiler;
+pub(crate) mod includes_compiler;
+pub(crate) mod like_compiler;
+pub(crate) mod limit_compiler;
+pub(crate) mod list_index_compiler;
+pub(crate) mod log_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod limit_compiler;
 pub(crate) mod list_index_compiler;
 pub(crate) mod log_compiler;
 pub(crate) mod match_compiler;
+pub(crate) mod maybe_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod modulo_compiler;
 pub(crate) mod multiply_compiler;
 mod node_compiler;
 pub(crate) mod not_compiler;
+pub(crate) mod or_compiler;
 pub(crate) mod step_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod add_compiler;
 pub(crate) mod after_compiler;
 pub(crate) mod and_compiler;
 pub(crate) mod any_compiler;
+pub(crate) mod as_compiler;
 pub(crate) mod assignment_compiler;
 mod auto_wrap;
 pub(crate) mod before_compiler;

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -11,6 +11,10 @@ pub(crate) mod bubble_compiler;
 pub mod compiler;
 pub(crate) mod container_compiler;
 pub(crate) mod contains_compiler;
+pub(crate) mod divide_compiler;
+pub(crate) mod equal_compiler;
+pub(crate) mod every_compiler;
+pub(crate) mod function_definition_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod maybe_compiler;
 pub(crate) mod modulo_compiler;
 pub(crate) mod multiply_compiler;
 mod node_compiler;
+pub(crate) mod not_compiler;
 pub(crate) mod step_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod like_compiler;
 pub(crate) mod limit_compiler;
 pub(crate) mod list_index_compiler;
 pub(crate) mod log_compiler;
+pub(crate) mod match_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -9,6 +9,8 @@ mod auto_wrap;
 pub(crate) mod before_compiler;
 pub(crate) mod bubble_compiler;
 pub mod compiler;
+pub(crate) mod container_compiler;
+pub(crate) mod contains_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod not_compiler;
 pub(crate) mod or_compiler;
 pub(crate) mod pattern_definition_compiler;
 pub(crate) mod predicate_definition_compiler;
+pub(crate) mod predicate_return_compiler;
 pub(crate) mod step_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod log_compiler;
 pub(crate) mod match_compiler;
 pub(crate) mod maybe_compiler;
 pub(crate) mod modulo_compiler;
+pub(crate) mod multiply_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod step_compiler;
 pub(crate) mod subtract_compiler;
 pub(crate) mod variable_compiler;
 pub(crate) mod where_compiler;
+pub(crate) mod within_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};
 pub use compiler::{src_to_problem_libs, src_to_problem_libs_for_language, CompilationResult};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod list_index_compiler;
 pub(crate) mod log_compiler;
 pub(crate) mod match_compiler;
 pub(crate) mod maybe_compiler;
+pub(crate) mod modulo_compiler;
 mod node_compiler;
 pub(crate) mod step_compiler;
 

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod rewrite_compiler;
 pub(crate) mod sequential_compiler;
 pub(crate) mod some_compiler;
 pub(crate) mod step_compiler;
+pub(crate) mod subtract_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};
 pub use compiler::{src_to_problem_libs, src_to_problem_libs_for_language, CompilationResult};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod multiply_compiler;
 mod node_compiler;
 pub(crate) mod not_compiler;
 pub(crate) mod or_compiler;
+pub(crate) mod pattern_definition_compiler;
 pub(crate) mod step_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod sequential_compiler;
 pub(crate) mod some_compiler;
 pub(crate) mod step_compiler;
 pub(crate) mod subtract_compiler;
+pub(crate) mod variable_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};
 pub use compiler::{src_to_problem_libs, src_to_problem_libs_for_language, CompilationResult};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod predicate_definition_compiler;
 pub(crate) mod predicate_return_compiler;
 pub(crate) mod rewrite_compiler;
 pub(crate) mod sequential_compiler;
+pub(crate) mod some_compiler;
 pub(crate) mod step_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod some_compiler;
 pub(crate) mod step_compiler;
 pub(crate) mod subtract_compiler;
 pub(crate) mod variable_compiler;
+pub(crate) mod where_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};
 pub use compiler::{src_to_problem_libs, src_to_problem_libs_for_language, CompilationResult};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod pattern_definition_compiler;
 pub(crate) mod predicate_compiler;
 pub(crate) mod predicate_definition_compiler;
 pub(crate) mod predicate_return_compiler;
+pub(crate) mod rewrite_compiler;
 pub(crate) mod step_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod predicate_compiler;
 pub(crate) mod predicate_definition_compiler;
 pub(crate) mod predicate_return_compiler;
 pub(crate) mod rewrite_compiler;
+pub(crate) mod sequential_compiler;
 pub(crate) mod step_compiler;
 
 pub(crate) use compiler::{parse_one, CompilationContext};

--- a/crates/core/src/pattern_compiler/mod.rs
+++ b/crates/core/src/pattern_compiler/mod.rs
@@ -29,6 +29,7 @@ mod node_compiler;
 pub(crate) mod not_compiler;
 pub(crate) mod or_compiler;
 pub(crate) mod pattern_definition_compiler;
+pub(crate) mod predicate_compiler;
 pub(crate) mod predicate_definition_compiler;
 pub(crate) mod predicate_return_compiler;
 pub(crate) mod step_compiler;

--- a/crates/core/src/pattern_compiler/modulo_compiler.rs
+++ b/crates/core/src/pattern_compiler/modulo_compiler.rs
@@ -1,0 +1,52 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{modulo::Modulo, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct ModuloCompiler;
+
+impl NodeCompiler for ModuloCompiler {
+    type TargetPattern = Modulo;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let left = node
+            .child_by_field_name("left")
+            .ok_or_else(|| anyhow!("missing left of modulo"))?;
+        let left = Pattern::from_node(
+            &left,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        let right = node
+            .child_by_field_name("right")
+            .ok_or_else(|| anyhow!("missing right of modulo"))?;
+        let right = Pattern::from_node(
+            &right,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        Ok(Modulo::new(left, right))
+    }
+}

--- a/crates/core/src/pattern_compiler/multiply_compiler.rs
+++ b/crates/core/src/pattern_compiler/multiply_compiler.rs
@@ -1,0 +1,52 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{multiply::Multiply, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct MultiplyCompiler;
+
+impl NodeCompiler for MultiplyCompiler {
+    type TargetPattern = Multiply;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let left = node
+            .child_by_field_name("left")
+            .ok_or_else(|| anyhow!("missing left of multiply"))?;
+        let left = Pattern::from_node(
+            &left,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        let right = node
+            .child_by_field_name("right")
+            .ok_or_else(|| anyhow!("missing right of multiply"))?;
+        let right = Pattern::from_node(
+            &right,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        Ok(Multiply::new(left, right))
+    }
+}

--- a/crates/core/src/pattern_compiler/not_compiler.rs
+++ b/crates/core/src/pattern_compiler/not_compiler.rs
@@ -1,0 +1,61 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    iter_pattern::PatternOrPredicate, not::Not, patterns::Pattern, predicates::Predicate,
+    variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::{
+    analysis_logs::{AnalysisLogBuilder, AnalysisLogs},
+    position::Range,
+};
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct NotCompiler;
+
+impl NodeCompiler for NotCompiler {
+    type TargetPattern = Not;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let pattern = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of patternNot"))?;
+        let range: Range = pattern.range().into();
+        let pattern = Pattern::from_node(
+            &pattern,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        if pattern.iter().any(|p| {
+            matches!(
+                p,
+                PatternOrPredicate::Pattern(Pattern::Rewrite(_))
+                    | PatternOrPredicate::Predicate(Predicate::Rewrite(_))
+            )
+        }) {
+            let log = AnalysisLogBuilder::default()
+                .level(441_u16)
+                .file(context.file)
+                .source(context.src)
+                .position(range.start)
+                .range(range)
+                .message("Warning: rewrites inside of a not will never be applied")
+                .build()?;
+            logs.push(log);
+        }
+        Ok(Not::new(pattern))
+    }
+}

--- a/crates/core/src/pattern_compiler/or_compiler.rs
+++ b/crates/core/src/pattern_compiler/or_compiler.rs
@@ -1,5 +1,13 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
-use crate::pattern::{or::Or, patterns::Pattern, variable::VariableSourceLocations};
+use super::{
+    compiler::CompilationContext, node_compiler::NodeCompiler,
+    predicate_compiler::PredicateCompiler,
+};
+use crate::pattern::{
+    or::{Or, PrOr},
+    patterns::Pattern,
+    predicates::Predicate,
+    variable::VariableSourceLocations,
+};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -40,6 +48,45 @@ impl NodeCompiler for OrCompiler {
             Ok(patterns.remove(0))
         } else {
             Ok(Pattern::Or(Box::new(Or::new(patterns))))
+        }
+    }
+}
+
+pub(crate) struct PrOrCompiler;
+
+impl NodeCompiler for PrOrCompiler {
+    type TargetPattern = Predicate;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let mut cursor = node.walk();
+        let children = node
+            .children_by_field_name("predicates", &mut cursor)
+            .filter(|n| n.is_named());
+        let mut predicates = Vec::new();
+        for predicate in children {
+            predicates.push(PredicateCompiler::from_node(
+                &predicate,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?);
+        }
+
+        if predicates.len() == 1 {
+            Ok(predicates.remove(0))
+        } else {
+            Ok(Predicate::Or(Box::new(PrOr::new(predicates))))
         }
     }
 }

--- a/crates/core/src/pattern_compiler/or_compiler.rs
+++ b/crates/core/src/pattern_compiler/or_compiler.rs
@@ -1,0 +1,45 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{or::Or, patterns::Pattern, variable::VariableSourceLocations};
+use anyhow::Result;
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct OrCompiler;
+
+impl NodeCompiler for OrCompiler {
+    type TargetPattern = Pattern;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let mut cursor = node.walk();
+        let children = node
+            .children_by_field_name("patterns", &mut cursor)
+            .filter(|n| n.is_named());
+        let mut patterns = Vec::new();
+        for pattern in children {
+            patterns.push(Pattern::from_node(
+                &pattern,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                false,
+                logs,
+            )?);
+        }
+        if patterns.len() == 1 {
+            Ok(patterns.remove(0))
+        } else {
+            Ok(Pattern::Or(Box::new(Or::new(patterns))))
+        }
+    }
+}

--- a/crates/core/src/pattern_compiler/pattern_definition_compiler.rs
+++ b/crates/core/src/pattern_compiler/pattern_definition_compiler.rs
@@ -1,0 +1,70 @@
+use super::{and_compiler::AndCompiler, compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    pattern_definition::PatternDefinition,
+    variable::{get_variables, VariableSourceLocations},
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct PatternDefinitionCompiler;
+
+impl NodeCompiler for PatternDefinitionCompiler {
+    type TargetPattern = PatternDefinition;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        _vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        _scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        // TODO: make sure pattern definitions are only allowed at the top level
+        let name = node
+            .child_by_field_name("name")
+            .ok_or_else(|| anyhow!("missing name of patternDefinition"))?;
+        let name = name.utf8_text(context.src.as_bytes())?;
+        let name = name.trim();
+        let scope_index = vars_array.len();
+        vars_array.push(vec![]);
+        let mut local_vars = BTreeMap::new();
+        // important that this occurs first, as calls assume
+        // that parameters are registered first
+        let params = get_variables(
+            &context
+                .pattern_definition_info
+                .get(name)
+                .ok_or_else(|| anyhow!("cannot get info for pattern {}", name))?
+                .parameters,
+            context.file,
+            vars_array,
+            scope_index,
+            &mut local_vars,
+            global_vars,
+        )?;
+
+        let body = node
+            .child_by_field_name("body")
+            .ok_or_else(|| anyhow!("missing body of patternDefinition"))?;
+        let body = AndCompiler::from_node(
+            &body,
+            context,
+            &mut local_vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        let pattern_def = PatternDefinition::new(
+            name.to_owned(),
+            scope_index,
+            params,
+            local_vars.values().cloned().collect(),
+            body,
+        );
+        Ok(pattern_def)
+    }
+}

--- a/crates/core/src/pattern_compiler/predicate_compiler.rs
+++ b/crates/core/src/pattern_compiler/predicate_compiler.rs
@@ -1,14 +1,12 @@
 use super::{
     accumulate_compiler::AccumulateCompiler, and_compiler::PrAndCompiler,
     any_compiler::PrAnyCompiler, assignment_compiler::AssignmentCompiler,
-    compiler::CompilationContext, equal_compiler::EqualCompiler, log_compiler::LogCompiler,
-    match_compiler::MatchCompiler, maybe_compiler::PrMaybeCompiler, node_compiler::NodeCompiler,
-    or_compiler::PrOrCompiler, predicate_return_compiler::PredicateReturnCompiler,
-    rewrite_compiler::RewriteCompiler,
+    compiler::CompilationContext, equal_compiler::EqualCompiler, if_compiler::PrIfCompiler,
+    log_compiler::LogCompiler, match_compiler::MatchCompiler, maybe_compiler::PrMaybeCompiler,
+    node_compiler::NodeCompiler, not_compiler::PrNotCompiler, or_compiler::PrOrCompiler,
+    predicate_return_compiler::PredicateReturnCompiler, rewrite_compiler::RewriteCompiler,
 };
-use crate::pattern::{
-    call::PrCall, not::PrNot, predicates::Predicate, r#if::PrIf, variable::VariableSourceLocations,
-};
+use crate::pattern::{call::PrCall, predicates::Predicate, variable::VariableSourceLocations};
 use anyhow::{anyhow, bail, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
@@ -31,7 +29,7 @@ impl NodeCompiler for PredicateCompiler {
         let kind = node.kind();
         let kind = kind.as_ref();
         match kind {
-            "predicateNot" => Ok(Predicate::Not(Box::new(PrNot::from_node(
+            "predicateNot" => Ok(Predicate::Not(Box::new(PrNotCompiler::from_node(
                 node,
                 context,
                 vars,
@@ -76,7 +74,7 @@ impl NodeCompiler for PredicateCompiler {
                 global_vars,
                 logs,
             ),
-            "predicateIfElse" => Ok(Predicate::If(Box::new(PrIf::from_node(
+            "predicateIfElse" => Ok(Predicate::If(Box::new(PrIfCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern_compiler/predicate_compiler.rs
+++ b/crates/core/src/pattern_compiler/predicate_compiler.rs
@@ -1,0 +1,180 @@
+use super::{
+    accumulate_compiler::AccumulateCompiler, and_compiler::PrAndCompiler,
+    any_compiler::PrAnyCompiler, assignment_compiler::AssignmentCompiler,
+    compiler::CompilationContext, equal_compiler::EqualCompiler, log_compiler::LogCompiler,
+    match_compiler::MatchCompiler, maybe_compiler::PrMaybeCompiler, node_compiler::NodeCompiler,
+    or_compiler::PrOrCompiler, predicate_return_compiler::PredicateReturnCompiler,
+};
+use crate::pattern::{
+    call::PrCall, not::PrNot, predicates::Predicate, r#if::PrIf, rewrite::Rewrite,
+    variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, bail, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct PredicateCompiler;
+
+impl NodeCompiler for PredicateCompiler {
+    type TargetPattern = Predicate;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let kind = node.kind();
+        let kind = kind.as_ref();
+        match kind {
+            "predicateNot" => Ok(Predicate::Not(Box::new(PrNot::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            "predicateAnd" => PrAndCompiler::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            ),
+            "predicateOr" => PrOrCompiler::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            ),
+            "predicateMaybe" => Ok(Predicate::Maybe(Box::new(PrMaybeCompiler::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            "predicateAny" => PrAnyCompiler::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            ),
+            "predicateIfElse" => Ok(Predicate::If(Box::new(PrIf::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            "predicateRewrite" => Ok(Predicate::Rewrite(Box::new(Rewrite::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            "log" => Ok(Predicate::Log(LogCompiler::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?)),
+            "predicateMatch" => Ok(Predicate::Match(Box::new(MatchCompiler::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            "predicateEqual" => Ok(Predicate::Equal(Box::new(EqualCompiler::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            "predicateCall" => Ok(Predicate::Call(Box::new(PrCall::from_node(
+                node,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?))),
+            "booleanConstant" => {
+                let value = node.utf8_text(context.src.as_bytes())?;
+                let value = value.trim();
+                if value == "true" {
+                    Ok(Predicate::True)
+                } else if value == "false" {
+                    Ok(Predicate::False)
+                } else {
+                    Err(anyhow!("invalid booleanConstant"))
+                }
+            }
+            "predicateAssignment" => Ok(Predicate::Assignment(Box::new(
+                AssignmentCompiler::from_node(
+                    node,
+                    context,
+                    vars,
+                    vars_array,
+                    scope_index,
+                    global_vars,
+                    logs,
+                )?,
+            ))),
+            "predicateAccumulate" => Ok(Predicate::Accumulate(Box::new(
+                AccumulateCompiler::from_node(
+                    node,
+                    context,
+                    vars,
+                    vars_array,
+                    scope_index,
+                    global_vars,
+                    logs,
+                )?,
+            ))),
+            "predicateReturn" => Ok(Predicate::Return(Box::new(
+                PredicateReturnCompiler::from_node(
+                    node,
+                    context,
+                    vars,
+                    vars_array,
+                    scope_index,
+                    global_vars,
+                    logs,
+                )?,
+            ))),
+            _ => bail!("unknown predicate kind: {}", kind),
+        }
+    }
+}

--- a/crates/core/src/pattern_compiler/predicate_compiler.rs
+++ b/crates/core/src/pattern_compiler/predicate_compiler.rs
@@ -4,10 +4,10 @@ use super::{
     compiler::CompilationContext, equal_compiler::EqualCompiler, log_compiler::LogCompiler,
     match_compiler::MatchCompiler, maybe_compiler::PrMaybeCompiler, node_compiler::NodeCompiler,
     or_compiler::PrOrCompiler, predicate_return_compiler::PredicateReturnCompiler,
+    rewrite_compiler::RewriteCompiler,
 };
 use crate::pattern::{
-    call::PrCall, not::PrNot, predicates::Predicate, r#if::PrIf, rewrite::Rewrite,
-    variable::VariableSourceLocations,
+    call::PrCall, not::PrNot, predicates::Predicate, r#if::PrIf, variable::VariableSourceLocations,
 };
 use anyhow::{anyhow, bail, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -85,7 +85,7 @@ impl NodeCompiler for PredicateCompiler {
                 global_vars,
                 logs,
             )?))),
-            "predicateRewrite" => Ok(Predicate::Rewrite(Box::new(Rewrite::from_node(
+            "predicateRewrite" => Ok(Predicate::Rewrite(Box::new(RewriteCompiler::from_node(
                 node,
                 context,
                 vars,

--- a/crates/core/src/pattern_compiler/predicate_definition_compiler.rs
+++ b/crates/core/src/pattern_compiler/predicate_definition_compiler.rs
@@ -1,6 +1,7 @@
-use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use super::{
+    and_compiler::PrAndCompiler, compiler::CompilationContext, node_compiler::NodeCompiler,
+};
 use crate::pattern::{
-    and::PrAnd,
     predicate_definition::PredicateDefinition,
     variable::{get_variables, VariableSourceLocations},
 };
@@ -49,7 +50,7 @@ impl NodeCompiler for PredicateDefinitionCompiler {
         let body = node
             .child_by_field_name("body")
             .ok_or_else(|| anyhow!("missing body of pattern definition"))?;
-        let body = PrAnd::from_node(
+        let body = PrAndCompiler::from_node(
             &body,
             context,
             &mut local_vars,

--- a/crates/core/src/pattern_compiler/predicate_definition_compiler.rs
+++ b/crates/core/src/pattern_compiler/predicate_definition_compiler.rs
@@ -1,0 +1,70 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    and::PrAnd,
+    predicate_definition::PredicateDefinition,
+    variable::{get_variables, VariableSourceLocations},
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct PredicateDefinitionCompiler;
+
+impl NodeCompiler for PredicateDefinitionCompiler {
+    type TargetPattern = PredicateDefinition;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        _vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        _scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let name = node
+            .child_by_field_name("name")
+            .ok_or_else(|| anyhow!("missing name of pattern definition"))?;
+        let name = name.utf8_text(context.src.as_bytes())?;
+        let name = name.trim();
+        let scope_index = vars_array.len();
+        vars_array.push(vec![]);
+        let mut local_vars = BTreeMap::new();
+        // important that this occurs first, as calls assume
+        // that parameters are registered first
+        let params = get_variables(
+            &context
+                .predicate_definition_info
+                .get(name)
+                .ok_or_else(|| anyhow!("cannot get info for pattern {}", name))?
+                .parameters,
+            context.file,
+            vars_array,
+            scope_index,
+            &mut local_vars,
+            global_vars,
+        )?;
+
+        let body = node
+            .child_by_field_name("body")
+            .ok_or_else(|| anyhow!("missing body of pattern definition"))?;
+        let body = PrAnd::from_node(
+            &body,
+            context,
+            &mut local_vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        let predicate_def = PredicateDefinition::new(
+            name.to_owned(),
+            scope_index,
+            params,
+            local_vars.values().cloned().collect(),
+            body,
+        );
+        Ok(predicate_def)
+    }
+}

--- a/crates/core/src/pattern_compiler/predicate_return_compiler.rs
+++ b/crates/core/src/pattern_compiler/predicate_return_compiler.rs
@@ -1,0 +1,39 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    patterns::Pattern, predicate_return::PrReturn, variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct PredicateReturnCompiler;
+
+impl NodeCompiler for PredicateReturnCompiler {
+    type TargetPattern = PrReturn;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let pattern = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of return"))?;
+        let pattern = Pattern::from_node(
+            &pattern,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            true,
+            logs,
+        )?;
+        Ok(PrReturn::new(pattern))
+    }
+}

--- a/crates/core/src/pattern_compiler/rewrite_compiler.rs
+++ b/crates/core/src/pattern_compiler/rewrite_compiler.rs
@@ -1,0 +1,150 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{
+    code_snippet::CodeSnippet, dynamic_snippet::DynamicPattern, patterns::Pattern,
+    rewrite::Rewrite, variable::VariableSourceLocations,
+};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct RewriteCompiler;
+
+impl NodeCompiler for RewriteCompiler {
+    type TargetPattern = Rewrite;
+
+    // do we want to add support for annotations?
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let left = node
+            .child_by_field_name("left")
+            .ok_or_else(|| anyhow!("missing lhs of rewrite"))?;
+        let right = node
+            .child_by_field_name("right")
+            .ok_or_else(|| anyhow!("missing rhs of rewrite"))?;
+        let annotation = node.child_by_field_name("annotation");
+        let left = Pattern::from_node(
+            &left,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        let right = Pattern::from_node(
+            &right,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            true,
+            logs,
+        )?;
+
+        match (&left, &right) {
+            (
+                Pattern::CodeSnippet(CodeSnippet {
+                    source: left_source,
+                    ..
+                }),
+                Pattern::CodeSnippet(CodeSnippet {
+                    source: right_source,
+                    ..
+                }),
+            ) if left_source == right_source => {
+                let log = AnalysisLogBuilder::default()
+                .level(441_u16)
+                .file(context.file)
+                .source(context.src)
+                .position(node.start_position())
+                .range(node.range())
+                .message(
+                    format!("Warning: This is rewriting `{}` into the identical string `{}`, will have no effect.", left_source, right_source)
+                )
+                .build()?;
+                logs.push(log);
+            }
+            (_, _) => {}
+        }
+        let right = match right {
+            Pattern::Dynamic(r) => r,
+            Pattern::CodeSnippet(CodeSnippet {
+                dynamic_snippet: Some(r),
+                ..
+            }) => r,
+            Pattern::Variable(v) => DynamicPattern::Variable(v),
+            Pattern::Accessor(a) => DynamicPattern::Accessor(a),
+            Pattern::ListIndex(a) => DynamicPattern::ListIndex(a),
+            Pattern::CallBuiltIn(c) => DynamicPattern::CallBuiltIn(*c),
+            Pattern::CallFunction(c) => DynamicPattern::CallFunction(*c),
+            Pattern::CallForeignFunction(c) => DynamicPattern::CallForeignFunction(*c),
+            Pattern::ASTNode(_)
+                | Pattern::List(_)
+                | Pattern::Map(_)
+                | Pattern::Call(_)
+                | Pattern::Regex(_)
+                | Pattern::File(_)
+                | Pattern::Files(_)
+                | Pattern::Bubble(_)
+                | Pattern::Limit(_)
+                | Pattern::Assignment(_)
+                | Pattern::Accumulate(_)
+                | Pattern::And(_)
+                | Pattern::Or(_)
+                | Pattern::Maybe(_)
+                | Pattern::Any(_)
+                | Pattern::Not(_)
+                | Pattern::If(_)
+                | Pattern::Undefined
+                | Pattern::Top
+                | Pattern::Bottom
+                | Pattern::Underscore
+                | Pattern::StringConstant(_)
+                | Pattern::AstLeafNode(_)
+                | Pattern::IntConstant(_)
+                | Pattern::FloatConstant(_)
+                | Pattern::BooleanConstant(_)
+                | Pattern::CodeSnippet(_)
+                | Pattern::Rewrite(_)
+                | Pattern::Log(_)
+                | Pattern::Range(_)
+                | Pattern::Contains(_)
+                | Pattern::Includes(_)
+                | Pattern::Within(_)
+                | Pattern::After(_)
+                | Pattern::Before(_)
+                | Pattern::Where(_)
+                | Pattern::Some(_)
+                | Pattern::Every(_)
+                | Pattern::Add(_)
+                | Pattern::Subtract(_)
+                | Pattern::Multiply(_)
+                | Pattern::Divide(_)
+                | Pattern::Modulo(_)
+                | Pattern::Like(_)
+                | Pattern::Dots
+                | Pattern::Sequential(_) => Err(anyhow!(
+                "right hand side of rewrite must be a code snippet or function call, but found: {:?}",
+                right
+            ))?,
+        };
+
+        let annotation = annotation.map(|n| {
+            n.utf8_text(context.src.as_bytes())
+                .unwrap()
+                .trim()
+                .to_string()
+        });
+        Ok(Rewrite::new(left, right, annotation))
+    }
+}

--- a/crates/core/src/pattern_compiler/sequential_compiler.rs
+++ b/crates/core/src/pattern_compiler/sequential_compiler.rs
@@ -1,0 +1,43 @@
+use super::{
+    compiler::CompilationContext, node_compiler::NodeCompiler, step_compiler::StepCompiler,
+};
+use crate::pattern::{sequential::Sequential, variable::VariableSourceLocations};
+use anyhow::Result;
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct SequentialCompiler;
+
+impl NodeCompiler for SequentialCompiler {
+    type TargetPattern = Sequential;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let mut sequential = vec![];
+        let mut cursor = node.walk();
+        for n in node
+            .children_by_field_name("sequential", &mut cursor)
+            .filter(|n| n.is_named())
+        {
+            let step = StepCompiler::from_node(
+                &n,
+                context,
+                vars,
+                vars_array,
+                scope_index,
+                global_vars,
+                logs,
+            )?;
+            sequential.push(step);
+        }
+        Ok(sequential.into())
+    }
+}

--- a/crates/core/src/pattern_compiler/some_compiler.rs
+++ b/crates/core/src/pattern_compiler/some_compiler.rs
@@ -1,0 +1,37 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{patterns::Pattern, some::Some, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct SomeCompiler;
+
+impl NodeCompiler for SomeCompiler {
+    type TargetPattern = Some;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let within = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of pattern some"))?;
+        let within = Pattern::from_node(
+            &within,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        Ok(Some::new(within))
+    }
+}

--- a/crates/core/src/pattern_compiler/subtract_compiler.rs
+++ b/crates/core/src/pattern_compiler/subtract_compiler.rs
@@ -1,0 +1,52 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{patterns::Pattern, subtract::Subtract, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct SubtractCompiler;
+
+impl NodeCompiler for SubtractCompiler {
+    type TargetPattern = Subtract;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let left = node
+            .child_by_field_name("left")
+            .ok_or_else(|| anyhow!("missing left of subtract"))?;
+        let left = Pattern::from_node(
+            &left,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        let right = node
+            .child_by_field_name("right")
+            .ok_or_else(|| anyhow!("missing right of subtract"))?;
+        let right = Pattern::from_node(
+            &right,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+
+        Ok(Subtract::new(left, right))
+    }
+}

--- a/crates/core/src/pattern_compiler/variable_compiler.rs
+++ b/crates/core/src/pattern_compiler/variable_compiler.rs
@@ -1,0 +1,34 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::variable::{register_variable, Variable, VariableSourceLocations};
+use anyhow::Result;
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct VariableCompiler;
+
+impl NodeCompiler for VariableCompiler {
+    type TargetPattern = Variable;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let name = node.utf8_text(context.src.as_bytes())?.trim().to_string();
+        let range = node.range().into();
+        register_variable(
+            &name,
+            context.file,
+            range,
+            vars,
+            global_vars,
+            vars_array,
+            scope_index,
+        )
+    }
+}

--- a/crates/core/src/pattern_compiler/where_compiler.rs
+++ b/crates/core/src/pattern_compiler/where_compiler.rs
@@ -1,0 +1,52 @@
+use super::{
+    compiler::CompilationContext, node_compiler::NodeCompiler,
+    predicate_compiler::PredicateCompiler,
+};
+use crate::pattern::{patterns::Pattern, r#where::Where, variable::VariableSourceLocations};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct WhereCompiler;
+
+impl NodeCompiler for WhereCompiler {
+    type TargetPattern = Where;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let pattern = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of patternWhere"))?;
+        let pattern = Pattern::from_node(
+            &pattern,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        let side_condition = node
+            .child_by_field_name("side_condition")
+            .ok_or_else(|| anyhow!("missing side condition of patternWhere"))?;
+        let side_condition = PredicateCompiler::from_node(
+            &side_condition,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            logs,
+        )?;
+        Ok(Where::new(pattern, side_condition))
+    }
+}

--- a/crates/core/src/pattern_compiler/within_compiler.rs
+++ b/crates/core/src/pattern_compiler/within_compiler.rs
@@ -1,0 +1,37 @@
+use super::{compiler::CompilationContext, node_compiler::NodeCompiler};
+use crate::pattern::{patterns::Pattern, variable::VariableSourceLocations, within::Within};
+use anyhow::{anyhow, Result};
+use marzano_util::analysis_logs::AnalysisLogs;
+use std::collections::BTreeMap;
+use tree_sitter::Node;
+
+pub(crate) struct WithinCompiler;
+
+impl NodeCompiler for WithinCompiler {
+    type TargetPattern = Within;
+
+    fn from_node(
+        node: &Node,
+        context: &CompilationContext,
+        vars: &mut BTreeMap<String, usize>,
+        vars_array: &mut Vec<Vec<VariableSourceLocations>>,
+        scope_index: usize,
+        global_vars: &mut BTreeMap<String, usize>,
+        logs: &mut AnalysisLogs,
+    ) -> Result<Self::TargetPattern> {
+        let within = node
+            .child_by_field_name("pattern")
+            .ok_or_else(|| anyhow!("missing pattern of pattern within"))?;
+        let within = Pattern::from_node(
+            &within,
+            context,
+            vars,
+            vars_array,
+            scope_index,
+            global_vars,
+            false,
+            logs,
+        )?;
+        Ok(Within::new(within))
+    }
+}


### PR DESCRIPTION
Applies the node compiler pattern from https://github.com/getgrit/gritql/pull/164 to the remaining node types *with compatible `from_node()` signatures*. Once these are done, I'll do another pass for the more complex cases.

Obsoletes #175, #176, #177.

See also: https://github.com/getgrit/gritql/pull/173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced pattern compilation abilities with support for new patterns: function definitions, conditional statements (`if` and `pr_if`), includes patterns, `like` patterns, limit specifications, list indexing, logging, matching patterns, optional (`Maybe` and `PrMaybe`) patterns, and modulo operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->