### PR TITLE
feat: add a --lang flag to list

### DIFF
--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -125,6 +125,7 @@ pub struct ApplyPatternArgs {
     /// Interpret the request as a natural language request
     #[clap(long)]
     ai: bool,
+    /// Change the default language to use for the pattern (if unset, JavaScript is used by default)
     #[clap(long = "language", alias = "lang")]
     pub language: Option<PatternLanguage>,
 }

--- a/crates/cli/src/commands/list.rs
+++ b/crates/cli/src/commands/list.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::Args;
 use marzano_core::pattern::api::EnforcementLevel;
+use marzano_language::target_language::PatternLanguage;
 use serde::Serialize;
 
 use crate::{
@@ -17,9 +18,22 @@ pub struct ListArgs {
     /// List items from a specific source.
     #[clap(long = "source", default_value = "all", value_enum)]
     pub source: Source,
+    /// List only items targeting a specific language.
+    #[clap(long = "language", alias = "lang")]
+    pub language: Option<PatternLanguage>,
 }
 
 pub async fn run_list_all(arg: &ListArgs, parent: &GlobalFormatFlags) -> Result<()> {
     let (resolved, curr_repo) = resolve_from_cwd(&arg.source).await?;
+
+    let resolved = if let Some(lang) = &arg.language {
+        resolved
+            .into_iter()
+            .filter(|pattern| pattern.language == *lang)
+            .collect()
+    } else {
+        resolved
+    };
+
     list_applyables(true, true, resolved, arg.level.clone(), parent, curr_repo).await
 }


### PR DESCRIPTION
Allow filtering the `patterns list` command to only a specific language. This is particularly useful for monorepos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced the ability to change the default language for patterns, with JavaScript set as the default.
	- Added a filter option to list items by a specific language, enhancing the targeting functionality.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->