### PR TITLE
fix: small fixes for edit_grammar.mjs

### DIFF
--- a/resources/edit_grammars.mjs
+++ b/resources/edit_grammars.mjs
@@ -324,6 +324,10 @@ async function buildLanguage(language) {
     await buildSimpleLanguage(log, language);
   }
 
+  await execPromise(
+    `find "${tsLangDir}" -name "build.rs" -exec sed -i '' -e 's/Wno-unused-parameter/w/g' {} \\;`,
+  );
+
   log(`Done`);
 }
 
@@ -343,9 +347,7 @@ async function run() {
   }
   process.chdir(LANGUAGE_METAVARIABLES);
   await Promise.all(languagesTobuild.map(buildLanguage));
-  await execPromise(
-    `find . -name "build.rs" -exec sed -i '' -e 's/Wno-unused-parameter/w/g' {} \\;`,
-  );
+
 }
 
 run().catch(console.error);

--- a/resources/edit_grammars.mjs
+++ b/resources/edit_grammars.mjs
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import fs from 'fs/promises';
+import path from 'path';
 
 ///////////////////////////////////////////////////
 // Scripting helpers
@@ -327,9 +328,12 @@ async function buildLanguage(language) {
 }
 
 async function run() {
+  const wd = path.dirname(process.argv[1]);
   const args = process.argv.slice(2);
   const buildAll = args.length == 0;
   const languagesTobuild = buildAll ? allLanguages : args;
+
+  process.chdir(wd);
 
   console.log('Syncing upstream grammars');
   if (buildAll) {

--- a/resources/edit_grammars.mjs
+++ b/resources/edit_grammars.mjs
@@ -288,7 +288,7 @@ async function buildLanguage(language) {
     await buildSimpleLanguage(log, language);
   } else if (language === 'php') {
     //php has sub-grammars
-    log(`Copying  files`);  
+    log(`Copying  files`);
     await Promise.all([
       await fs.copyFile(
         `${METAVARIABLE_GRAMMARS}/${language}-common-metavariable-grammar.js`,
@@ -319,7 +319,7 @@ async function buildLanguage(language) {
       `tree-sitter-php/php/tree-sitter-php.wasm`,
       `../../crates/wasm-bindings/wasm_parsers/tree-sitter-php.wasm`,
     );
-  }else {
+  } else {
     await buildSimpleLanguage(log, language);
   }
 


### PR DESCRIPTION
fix: fix formatting in edit_grammar.js


fix: stop assuming working directory in edit_grammar.mjs

    Explicitly change the working directory in edit_grammar.mjs so that the
    script can be executed from outside its directory.

fix: don't touch all build.rs in edit_grammar.mjs

    Editing a single grammar currently causes all build.rs to be touched. This
    in turn means that cargo will recompile all the language crates.

    Move the replacement logic into the invidual language build. This speeds up

        edit_grammar.mjs c
       cargo test

    workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved grammar editing features with enhanced language support and directory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->