### PR TITLE
chore: cleanup outdated annotation

### DIFF
--- a/crates/core/src/pattern_compiler/auto_wrap.rs
+++ b/crates/core/src/pattern_compiler/auto_wrap.rs
@@ -26,7 +26,6 @@ use anyhow::Result;
 use marzano_util::position::FileRange;
 use std::collections::BTreeMap;
 
-#[allow(clippy::too_many_arguments)]
 pub(super) fn auto_wrap_pattern(
     pattern: Pattern,
     pattern_definitions: &mut [PatternDefinition],

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -306,7 +306,6 @@ fn get_definition_info(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn node_to_definitions(
     node: NodeWithSource,
     context: &mut NodeCompilationContext,

--- a/crates/core/src/pattern_compiler/pattern_compiler.rs
+++ b/crates/core/src/pattern_compiler/pattern_compiler.rs
@@ -84,7 +84,6 @@ impl PatternCompiler {
         let ranges = metavariable_ranges(&node, context.compilation.lang);
         let range_map = metavariable_range_mapping(ranges, snippet_start);
 
-        #[allow(clippy::too_many_arguments)]
         fn node_to_astnode(
             node: NodeWithSource,
             context_range: Range,


### PR DESCRIPTION
removes too many arguments annotations where unnecessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code quality by addressing issues with excessive function arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->