### PR TITLE
chore: move `analysis.rs` out of `pattern` module

### DIFF
--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -1,100 +1,91 @@
 use crate::pattern_compiler::parse_one;
 use anyhow::{anyhow, Result};
+use grit_util::AstNode;
 use grit_util::{traverse, Order};
-use marzano_util::cursor_wrapper::CursorWrapper;
+use marzano_util::{cursor_wrapper::CursorWrapper, node_with_source::NodeWithSource};
 use std::collections::BTreeMap;
-use tree_sitter::{Node, Parser};
+use std::ffi::OsStr;
+use tree_sitter::Parser;
 
 /// Walks the call tree and returns true if the predicate is true for any node.
 /// This is potentially error-prone, so not entirely recommended
-pub fn walk_call_tree(
-    node: &Node,
-    source: &str,
+fn walk_call_tree(
+    node: &NodeWithSource,
     libs: &BTreeMap<String, String>,
     grit_parser: &mut Parser,
-    is_true: &dyn Fn(&Node, &str) -> Result<bool>,
+    predicate: &dyn Fn(&NodeWithSource) -> Result<bool>,
 ) -> Result<bool> {
-    let cursor = node.walk();
-    for n in traverse(CursorWrapper::new(cursor, source), Order::Pre) {
-        let n = n.node;
-        if is_true(&n, source)? {
+    let cursor = node.node.walk();
+    for n in traverse(CursorWrapper::new(cursor, node.source), Order::Pre) {
+        if predicate(&n)? {
             return Ok(true);
         }
-        if !(n.is_named() && n.kind() == "nodeLike") {
+        if !(n.node.is_named() && n.node.kind() == "nodeLike") {
             continue;
         }
         let name = n
             .child_by_field_name("name")
             .ok_or_else(|| anyhow!("missing name of nodeLike"))?;
-        let name = name.utf8_text(source.as_bytes())?;
-        let name = name.trim();
+        let name = OsStr::new(name.text().trim());
         let maybe_call = libs
             .iter()
             .find(|(k, _)| k.strip_suffix(".grit").unwrap_or(k) == name);
         if let Some((k, v)) = maybe_call {
             let src_tree = parse_one(grit_parser, v, k)?;
-            let source_file = src_tree.root_node();
-            return walk_call_tree(&source_file, v, libs, grit_parser, is_true);
+            let source_file = NodeWithSource::new(src_tree.root_node(), v);
+            return walk_call_tree(&source_file, libs, grit_parser, predicate);
         }
     }
     Ok(false)
 }
 
 pub fn is_multifile(
-    root: &Node,
-    source: &str,
+    root: &NodeWithSource,
     libs: &BTreeMap<String, String>,
     grit_parser: &mut Parser,
 ) -> Result<bool> {
-    walk_call_tree(root, source, libs, grit_parser, &|n, _| {
-        Ok(n.kind() == "files")
-    })
+    walk_call_tree(root, libs, grit_parser, &|n| Ok(n.node.kind() == "files"))
 }
 
 pub fn has_limit(
-    root: &Node,
-    source: &str,
+    root: &NodeWithSource,
     libs: &BTreeMap<String, String>,
     grit_parser: &mut Parser,
 ) -> Result<bool> {
-    walk_call_tree(root, source, libs, grit_parser, &|n, _| {
-        Ok(n.kind() == "patternLimit")
+    walk_call_tree(root, libs, grit_parser, &|n| {
+        Ok(n.node.kind() == "patternLimit")
     })
 }
 
 #[allow(dead_code)]
 pub fn is_async(
-    root: &Node,
-    source: &str,
+    root: &NodeWithSource,
     libs: &BTreeMap<String, String>,
     grit_parser: &mut Parser,
 ) -> Result<bool> {
-    walk_call_tree(root, source, libs, grit_parser, &|n, current_source| {
-        if n.kind() != "nodeLike" {
+    walk_call_tree(root, libs, grit_parser, &|n| {
+        if n.node.kind() != "nodeLike" {
             return Ok(false);
         }
         let name = n
             .child_by_field_name("name")
             .ok_or_else(|| anyhow!("missing name of nodeLike"))?;
-        let name = name.utf8_text(current_source.as_bytes())?;
-        let name = name.trim();
+        let name = name.text().trim();
         Ok(name == "llm_chat")
     })
 }
 
 /// Return true if the pattern attempts to define itself
-pub fn defines_itself(root: &Node, source: &str, root_name: &str) -> Result<bool> {
-    let cursor = root.walk();
-    for n in traverse(CursorWrapper::new(cursor, source), Order::Pre) {
-        let n = n.node;
-        if n.kind() != "patternDefinition" {
+pub fn defines_itself(root: &NodeWithSource, root_name: &str) -> Result<bool> {
+    let cursor = root.node.walk();
+    for n in traverse(CursorWrapper::new(cursor, root.source), Order::Pre) {
+        if n.node.kind() != "patternDefinition" {
             continue;
         }
         let name = n
             .child_by_field_name("name")
             .ok_or_else(|| anyhow!("missing name of patternDefinition"))?;
-        let name = name.utf8_text(source.as_bytes())?;
-        let name = name.trim();
+        let name = name.text().trim();
         if name == root_name {
             return Ok(true);
         }
@@ -119,7 +110,12 @@ mod tests {
         let libs = BTreeMap::new();
         let mut parser = make_grit_parser().unwrap();
         let parsed = parse_one(&mut parser, &src_code, "test.grit").unwrap();
-        assert!(!is_async(&parsed.root_node(), &src_code, &libs, &mut parser).unwrap());
+        assert!(!is_async(
+            &NodeWithSource::new(parsed.root_node(), &src_code),
+            &libs,
+            &mut parser
+        )
+        .unwrap());
     }
 
     #[test]
@@ -131,7 +127,12 @@ mod tests {
         let libs = BTreeMap::new();
         let mut parser = make_grit_parser().unwrap();
         let parsed = parse_one(&mut parser, &src_code, "test.grit").unwrap();
-        assert!(is_async(&parsed.root_node(), &src_code, &libs, &mut parser).unwrap());
+        assert!(is_async(
+            &NodeWithSource::new(parsed.root_node(), &src_code),
+            &libs,
+            &mut parser
+        )
+        .unwrap());
     }
 
     #[test]
@@ -146,7 +147,12 @@ mod tests {
         let libs = BTreeMap::new();
         let mut parser = make_grit_parser().unwrap();
         let parsed = parse_one(&mut parser, &src_code, "test.grit").unwrap();
-        assert!(is_async(&parsed.root_node(), &src_code, &libs, &mut parser).unwrap());
+        assert!(is_async(
+            &NodeWithSource::new(parsed.root_node(), &src_code),
+            &libs,
+            &mut parser
+        )
+        .unwrap());
     }
 
     #[test]
@@ -162,7 +168,12 @@ mod tests {
         );
         let mut parser = make_grit_parser().unwrap();
         let parsed = parse_one(&mut parser, &src_code, "test.grit").unwrap();
-        let decided = is_async(&parsed.root_node(), &src_code, &libs, &mut parser).unwrap();
+        let decided = is_async(
+            &NodeWithSource::new(parsed.root_node(), &src_code),
+            &libs,
+            &mut parser,
+        )
+        .unwrap();
         assert!(decided);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::wildcard_enum_match_arm)]
+pub mod analysis;
 pub mod binding;
 pub mod compact_api;
 pub mod context;

--- a/crates/core/src/pattern.rs
+++ b/crates/core/src/pattern.rs
@@ -2,7 +2,6 @@ pub mod accessor;
 pub mod accumulate;
 pub mod add;
 pub mod after;
-pub mod analysis;
 pub mod and;
 pub mod any;
 pub mod api;

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -9,9 +9,9 @@ use super::{
     NodeCompiler,
 };
 use crate::{
+    analysis::{has_limit, is_multifile},
     parse::make_grit_parser,
     pattern::{
-        analysis::{has_limit, is_multifile},
         built_in_functions::BuiltIns,
         constants::{
             ABSOLUTE_PATH_INDEX, DEFAULT_FILE_NAME, FILENAME_INDEX, NEW_FILES_INDEX, PROGRAM_INDEX,
@@ -24,6 +24,7 @@ use crate::{
     },
 };
 use anyhow::{anyhow, bail, Result};
+use grit_util::AstNode;
 use grit_util::{traverse, Order};
 use itertools::Itertools;
 use marzano_language::{self, target_language::TargetLanguage};
@@ -147,20 +148,17 @@ fn get_duplicates(list: &[(String, Range)]) -> Vec<&String> {
 // errors only refer to pattern, but could also be predicate
 fn insert_definition_index(
     indices: &mut BTreeMap<String, DefinitionInfo>,
-    definition: Node,
+    definition: NodeWithSource,
     index: &mut usize,
-    src: &[u8],
 ) -> Result<()> {
     let name = definition
         .child_by_field_name("name")
         .ok_or_else(|| anyhow!("missing name of patternDefinition"))?;
-    let name = name.utf8_text(src)?;
-    let name = name.trim();
-    let parameters = definition
-        .children_by_field_name("args", &mut definition.walk())
-        .filter(|n| n.is_named())
-        .map(|n| Ok((n.utf8_text(src)?.trim().to_string(), n.range().into())))
-        .collect::<Result<Vec<(String, Range)>>>()?;
+    let name = name.text().trim();
+    let parameters: Vec<_> = definition
+        .named_children_by_field_name("args")
+        .map(|n| (n.text().trim().to_string(), n.range()))
+        .collect();
     let duplicates = get_duplicates(&parameters);
     if !duplicates.is_empty() {
         bail!(
@@ -185,8 +183,7 @@ fn insert_definition_index(
 
 #[allow(clippy::too_many_arguments)]
 fn node_to_definition_info(
-    node: &Node,
-    src: &[u8],
+    node: &NodeWithSource,
     pattern_indices: &mut BTreeMap<String, DefinitionInfo>,
     pattern_index: &mut usize,
     predicate_indices: &mut BTreeMap<String, DefinitionInfo>,
@@ -196,28 +193,18 @@ fn node_to_definition_info(
     foreign_function_indices: &mut BTreeMap<String, DefinitionInfo>,
     foreign_function_index: &mut usize,
 ) -> Result<()> {
-    let mut cursor = node.walk();
-    for definition in node
-        .children_by_field_name("definitions", &mut cursor)
-        .filter(|n| n.is_named())
-    {
+    for definition in node.named_children_by_field_name("definitions") {
         if let Some(pattern_definition) = definition.child_by_field_name("pattern") {
-            insert_definition_index(pattern_indices, pattern_definition, pattern_index, src)?;
+            insert_definition_index(pattern_indices, pattern_definition, pattern_index)?;
         } else if let Some(predicate_definition) = definition.child_by_field_name("predicate") {
-            insert_definition_index(
-                predicate_indices,
-                predicate_definition,
-                predicate_index,
-                src,
-            )?;
+            insert_definition_index(predicate_indices, predicate_definition, predicate_index)?;
         } else if let Some(function_definition) = definition.child_by_field_name("function") {
-            insert_definition_index(function_indices, function_definition, function_index, src)?;
+            insert_definition_index(function_indices, function_definition, function_index)?;
         } else if let Some(foreign_definition) = definition.child_by_field_name("foreign") {
             insert_definition_index(
                 foreign_function_indices,
                 foreign_definition,
                 foreign_function_index,
-                src,
             )?;
         } else {
             bail!("definition must be either a pattern, a predicate or a function");
@@ -240,8 +227,7 @@ struct DefinitionInfoKinds {
 
 fn get_definition_info(
     libs: &[(String, String)],
-    source_file: &Node,
-    src: &str,
+    root: &NodeWithSource,
     parser: &mut Parser,
 ) -> Result<DefinitionInfoKinds> {
     let mut pattern_indices: BTreeMap<String, DefinitionInfo> = BTreeMap::new();
@@ -254,10 +240,9 @@ fn get_definition_info(
     let mut foreign_function_index = 0;
     for (file, pattern) in libs.iter() {
         let tree = parse_one(parser, pattern, file)?;
-        let node = tree.root_node();
+        let root = NodeWithSource::new(tree.root_node(), pattern);
         node_to_definition_info(
-            &node,
-            pattern.as_bytes(),
+            &root,
             &mut pattern_indices,
             &mut pattern_index,
             &mut predicate_indices,
@@ -267,7 +252,7 @@ fn get_definition_info(
             &mut foreign_function_indices,
             &mut foreign_function_index,
         )?;
-        if node.child_by_field_name("pattern").is_some() {
+        if root.child_by_field_name("pattern").is_some() {
             let path = Path::new(file);
             if let Some(name) = path.file_stem().and_then(|n| n.to_str()) {
                 let info = DefinitionInfo {
@@ -287,8 +272,7 @@ fn get_definition_info(
         }
     }
     node_to_definition_info(
-        source_file,
-        src.as_bytes(),
+        root,
         &mut pattern_indices,
         &mut pattern_index,
         &mut predicate_indices,
@@ -698,7 +682,7 @@ pub fn src_to_problem_libs_for_language(
     }
     let src_tree = parse_one(grit_parser, &src, DEFAULT_FILE_NAME)?;
 
-    let source_file = src_tree.root_node();
+    let root = NodeWithSource::new(src_tree.root_node(), &src);
     let mut built_ins = BuiltIns::get_built_in_functions();
     if let Some(custom_built_ins) = custom_built_ins {
         built_ins.extend_builtins(custom_built_ins)?;
@@ -710,15 +694,15 @@ pub fn src_to_problem_libs_for_language(
         ("$program".to_owned(), PROGRAM_INDEX),
         ("$absolute_filename".to_owned(), ABSOLUTE_PATH_INDEX),
     ]);
-    let is_multifile = is_multifile(&source_file, &src, libs, grit_parser)?;
-    let has_limit = has_limit(&source_file, &src, libs, grit_parser)?;
+    let is_multifile = is_multifile(&root, libs, grit_parser)?;
+    let has_limit = has_limit(&root, libs, grit_parser)?;
     let libs = filter_libs(libs, &src, grit_parser, !is_multifile)?;
     let DefinitionInfoKinds {
         pattern_indices: pattern_definition_indices,
         predicate_indices: predicate_definition_indices,
         function_indices: function_definition_indices,
         foreign_function_indices,
-    } = get_definition_info(&libs, &source_file, &src, grit_parser)?;
+    } = get_definition_info(&libs, &root, grit_parser)?;
 
     let context = CompilationContext {
         file: DEFAULT_FILE_NAME,
@@ -738,7 +722,7 @@ pub fn src_to_problem_libs_for_language(
         foreign_function_definitions,
     } = get_definitions(
         &libs,
-        &NodeWithSource::new(source_file.clone(), &src),
+        &root,
         grit_parser,
         &context,
         &mut global_vars,
@@ -757,8 +741,8 @@ pub fn src_to_problem_libs_for_language(
         logs: &mut logs,
     };
 
-    let pattern = if let Some(node) = source_file.child_by_field_name("pattern") {
-        PatternCompiler::from_node(&NodeWithSource::new(node, &src), &mut node_context)?
+    let pattern = if let Some(node) = root.child_by_field_name("pattern") {
+        PatternCompiler::from_node(&node, &mut node_context)?
     } else {
         let long_message = "No pattern found.
         If you have written a pattern definition in the form `pattern myPattern() {{ }}`,

--- a/crates/gritmodule/src/markdown.rs
+++ b/crates/gritmodule/src/markdown.rs
@@ -1,5 +1,6 @@
+use marzano_core::analysis::defines_itself;
 use marzano_core::parse::make_grit_parser;
-use marzano_core::pattern::analysis::defines_itself;
+use marzano_util::node_with_source::NodeWithSource;
 use marzano_util::position::{Position, Range};
 use marzano_util::rich_path::RichFile;
 use std::fs::OpenOptions;
@@ -412,7 +413,7 @@ pub fn get_patterns_from_md(
         .parse(&body, None)?
         .ok_or_else(|| anyhow!("parse error"))?;
 
-    if defines_itself(&src_tree.root_node(), &body, name)? {
+    if defines_itself(&NodeWithSource::new(src_tree.root_node(), &body), name)? {
         bail!("Pattern {} attempts to define itself - this is not allowed. Tip: Markdown patterns use the file name as their pattern name.", name);
     }
 


### PR DESCRIPTION
I had already begun updating it to use `NodeWithSource`, when I realized it isn't needed in the `pattern` module at all :)