### PR TITLE
chore: move `CodeRange` to `grit-util` crate

### DIFF
--- a/crates/core/src/pattern/ast_node.rs
+++ b/crates/core/src/pattern/ast_node.rs
@@ -71,7 +71,10 @@ impl Matcher for ASTNode {
 
             let res = if *is_list {
                 pattern.execute(
-                    &ResolvedPattern::from_list(source, node.clone(), *field_id),
+                    &ResolvedPattern::from_list(
+                        NodeWithSource::new(node.clone(), source),
+                        *field_id,
+                    ),
                     &mut cur_state,
                     context,
                     logs,
@@ -85,7 +88,10 @@ impl Matcher for ASTNode {
                 )
             } else {
                 pattern.execute(
-                    &ResolvedPattern::empty_field(source, node.clone(), *field_id),
+                    &ResolvedPattern::empty_field(
+                        NodeWithSource::new(node.clone(), source),
+                        *field_id,
+                    ),
                     &mut cur_state,
                     context,
                     logs,

--- a/crates/core/src/pattern/state.rs
+++ b/crates/core/src/pattern/state.rs
@@ -1,13 +1,11 @@
 use super::{
-    constants::MATCH_VAR,
-    patterns::Pattern,
-    resolved_pattern::{CodeRange, ResolvedPattern},
-    variable::Variable,
+    constants::MATCH_VAR, patterns::Pattern, resolved_pattern::ResolvedPattern, variable::Variable,
     variable_content::VariableContent,
 };
 use crate::intervals::{earliest_deadline_sort, get_top_level_intervals_in_range, Interval};
 use crate::problem::{Effect, FileOwner};
 use anyhow::{anyhow, bail, Result};
+use grit_util::CodeRange;
 use im::{vector, Vector};
 use marzano_language::target_language::TargetLanguage;
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -88,9 +86,8 @@ fn get_top_level_effect_ranges<'a>(
         .filter(|effect| {
             let binding = &effect.binding;
             if let Some(src) = binding.source() {
-                if let Some(position) = binding.position() {
-                    range.equal_address(src)
-                        && !matches!(memo.get(&CodeRange::from_range(src, position)), Some(None))
+                if let Some(binding_range) = binding.code_range() {
+                    range.applies_to(src) && !matches!(memo.get(&binding_range), Some(None))
                 } else {
                     let _ = binding.log_empty_field_rewrite_error(language, logs);
                     false

--- a/crates/core/src/text_unparser.rs
+++ b/crates/core/src/text_unparser.rs
@@ -1,8 +1,8 @@
 use crate::binding::linearize_binding;
-use crate::pattern::resolved_pattern::CodeRange;
 use crate::pattern::state::FileRegistry;
 use crate::problem::Effect;
 use anyhow::Result;
+use grit_util::CodeRange;
 use im::Vector;
 use marzano_language::target_language::TargetLanguage;
 use marzano_util::analysis_logs::AnalysisLogs;

--- a/crates/grit-util/src/ast_node.rs
+++ b/crates/grit-util/src/ast_node.rs
@@ -1,3 +1,5 @@
+use crate::CodeRange;
+
 /// Represents an AST node and offers convenient AST-specific functionality.
 ///
 /// This trait should be free from dependencies on TreeSitter.
@@ -29,4 +31,7 @@ pub trait AstNode: Sized {
 
     /// Returns the text representation of the node.
     fn text(&self) -> &str;
+
+    /// Returns the code range of the node.
+    fn code_range(&self) -> CodeRange;
 }

--- a/crates/grit-util/src/code_range.rs
+++ b/crates/grit-util/src/code_range.rs
@@ -1,0 +1,34 @@
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub struct CodeRange {
+    /// Start byte of the range.
+    pub start: u32,
+
+    /// End byte of the range.
+    pub end: u32,
+
+    /// Address of the source code to which the range applies.
+    ///
+    /// Stored as only the address to improve the performance of hashing.
+    pub address: usize,
+}
+
+impl CodeRange {
+    pub fn new(start: u32, end: u32, src: &str) -> Self {
+        let raw_ptr = src as *const str;
+        let thin_ptr = raw_ptr as *const u8;
+        let address = thin_ptr as usize;
+        Self {
+            start,
+            end,
+            address,
+        }
+    }
+
+    /// Returns whether the code range applies to the given source code.
+    pub fn applies_to(&self, source: &str) -> bool {
+        let raw_ptr = source as *const str;
+        let thin_ptr = raw_ptr as *const u8;
+        let address = thin_ptr as usize;
+        self.address == address
+    }
+}

--- a/crates/grit-util/src/lib.rs
+++ b/crates/grit-util/src/lib.rs
@@ -1,5 +1,7 @@
 mod ast_node;
 mod ast_node_traversal;
+mod code_range;
 
 pub use ast_node::AstNode;
 pub use ast_node_traversal::{traverse, AstCursor, Order};
+pub use code_range::CodeRange;

--- a/crates/util/src/node_with_source.rs
+++ b/crates/util/src/node_with_source.rs
@@ -3,7 +3,7 @@ use std::ptr;
 use crate::position::Range;
 
 use super::cursor_wrapper::CursorWrapper;
-use grit_util::{AstCursor, AstNode};
+use grit_util::{AstCursor, AstNode, CodeRange};
 use tree_sitter::Node;
 
 /// A TreeSitter node, including a reference to the source code from which it
@@ -120,6 +120,16 @@ impl<'a> AstNode for NodeWithSource<'a> {
         let start_byte = self.node.start_byte() as usize;
         let end_byte = self.node.end_byte() as usize;
         &self.source[start_byte..end_byte]
+    }
+
+    fn code_range(&self) -> CodeRange {
+        CodeRange::new(self.node.start_byte(), self.node.end_byte(), self.source)
+    }
+}
+
+impl<'a> From<NodeWithSource<'a>> for CodeRange {
+    fn from(value: NodeWithSource<'a>) -> Self {
+        Self::new(value.node.start_byte(), value.node.end_byte(), value.source)
     }
 }
 


### PR DESCRIPTION
This makes it easier to create `CodeRange`s from abstract `AstNode`s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced code efficiency and clarity in core pattern matching and text parsing functionalities.
- **New Features**
	- Improved precision in text processing by integrating advanced code range handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->