### PR TITLE
chore: cleanup clean

### DIFF
--- a/crates/cli_bin/tests/snapshots/apply__gives_helpful_error_for_file.snap.new
+++ b/crates/cli_bin/tests/snapshots/apply__gives_helpful_error_for_file.snap.new
@@ -1,6 +1,0 @@
----
-source: crates/cli_bin/tests/apply.rs
-assertion_line: 1098
-expression: stdout
----
-

--- a/crates/core/src/clean.rs
+++ b/crates/core/src/clean.rs
@@ -1,12 +1,9 @@
 use anyhow::Result;
 use grit_util::{traverse, Order};
 use itertools::Itertools;
+use marzano_language::language::Replacement;
 use marzano_language::{language::Language, target_language::TargetLanguage};
-use marzano_util::cursor_wrapper::CursorWrapper;
-use marzano_util::position::Range;
-use tree_sitter::{Tree};
-
-pub(crate) type Replacement = (Range, Option<String>);
+use marzano_util::{cursor_wrapper::CursorWrapper, node_with_source::NodeWithSource};
 
 fn merge_ranges(ranges: Vec<Replacement>) -> Vec<Replacement> {
     if ranges.is_empty() {
@@ -15,14 +12,17 @@ fn merge_ranges(ranges: Vec<Replacement>) -> Vec<Replacement> {
 
     let sorted: Vec<Replacement> = ranges
         .into_iter()
-        .sorted_by(|a, b| b.0.start_byte.cmp(&a.0.start_byte))
+        .sorted_by(|a, b| b.range.start_byte.cmp(&a.range.start_byte))
         .collect_vec();
     let mut result = vec![];
     let mut current_range = sorted[0].to_owned();
 
     for range in sorted.into_iter().skip(1) {
-        if current_range.0.start_byte <= range.0.end_byte && current_range.1 == range.1 {
-            current_range.0.start_byte = current_range.0.start_byte.min(range.0.start_byte);
+        if current_range.range.start_byte <= range.range.end_byte
+            && current_range.replacement == range.replacement
+        {
+            current_range.range.start_byte =
+                current_range.range.start_byte.min(range.range.start_byte);
         } else {
             result.push(current_range);
             current_range = range.to_owned();
@@ -42,22 +42,18 @@ pub(crate) fn replace_cleaned_ranges(
     let replacement_ranges = merge_ranges(replacement_ranges);
     let mut src = src.to_string();
     for range in &replacement_ranges {
-        if let Some(replacement) = &range.1 {
-            src.replace_range(
-                range.0.start_byte as usize..range.0.end_byte as usize,
-                replacement,
-            );
-        } else {
-            src.drain(range.0.start_byte as usize..range.0.end_byte as usize);
-        }
+        src.replace_range(
+            range.range.start_byte as usize..range.range.end_byte as usize,
+            range.replacement,
+        );
     }
     Ok(Some(src))
 }
 
-pub fn get_replacement_ranges(tree: &Tree, src: &str, lang: &TargetLanguage) -> Vec<Replacement> {
+pub fn get_replacement_ranges(node: NodeWithSource, lang: &TargetLanguage) -> Vec<Replacement> {
     let mut replacement_ranges = vec![];
-    let cursor = tree.walk();
-    for n in traverse(CursorWrapper::new(cursor, src), Order::Pre) {
+    let cursor = node.node.walk();
+    for n in traverse(CursorWrapper::new(cursor, node.source), Order::Pre) {
         lang.check_replacements(n, &mut replacement_ranges);
     }
     replacement_ranges

--- a/crates/core/src/pattern/step.rs
+++ b/crates/core/src/pattern/step.rs
@@ -5,15 +5,15 @@ use super::{
     state::{FilePtr, State},
 };
 use crate::{
-    context::Context,
     clean::{get_replacement_ranges, replace_cleaned_ranges},
+    context::Context,
     problem::{FileOwner, InputRanges, MatchRanges},
     text_unparser::apply_effects,
 };
 use anyhow::{anyhow, bail, Result};
 use im::vector;
 use marzano_language::language::Language;
-use marzano_util::{analysis_logs::AnalysisLogs};
+use marzano_util::{analysis_logs::AnalysisLogs, node_with_source::NodeWithSource};
 use std::path::PathBuf;
 use tree_sitter::Parser;
 
@@ -143,8 +143,8 @@ impl Matcher for Step {
                 )?;
                 if let Some(new_ranges) = new_ranges {
                     let tree = parser.parse(new_src.as_bytes(), None).unwrap().unwrap();
-                    let replacement_ranges =
-                        get_replacement_ranges(&tree, &new_src, context.language());
+                    let root = NodeWithSource::new(tree.root_node(), &new_src);
+                    let replacement_ranges = get_replacement_ranges(root, context.language());
                     let cleaned_src = replace_cleaned_ranges(replacement_ranges, &new_src)?;
                     let new_src = if let Some(src) = cleaned_src {
                         src

--- a/crates/language/src/javascript.rs
+++ b/crates/language/src/javascript.rs
@@ -1,6 +1,6 @@
 use crate::{
     language::{
-        fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, RangeReplacement,
+        fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, Replacement,
         SortId, TSLanguage,
     },
     xscript_util::{
@@ -165,7 +165,7 @@ impl Language for JavaScript {
         self.metavariable_sort
     }
 
-    fn check_replacements(&self, n: NodeWithSource<'_>, orphan_ranges: &mut Vec<RangeReplacement>) {
+    fn check_replacements(&self, n: NodeWithSource<'_>, orphan_ranges: &mut Vec<Replacement>) {
         jslike_check_replacements(n, orphan_ranges)
     }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -20,7 +20,17 @@ pub static GRIT_METAVARIABLE_PREFIX: &str = "$";
 pub type SortId = u16;
 pub type FieldId = u16;
 
-pub type RangeReplacement = (Range, Option<String>);
+#[derive(Debug, Clone)]
+pub struct Replacement {
+    pub range: Range,
+    pub replacement: &'static str,
+}
+
+impl Replacement {
+    pub fn new(range: Range, replacement: &'static str) -> Self {
+        Self { range, replacement }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct LeafNormalizer {
@@ -302,12 +312,7 @@ pub trait Language {
     /// Check for nodes that should be removed or replaced
     /// This is used to "repair" the program after rewriting, such as by deleting orphaned ranges (like a variable declaration without any variables)
     /// If the node should be removed, add range with a None value, if the node should be replaced, add a range with the replacement value
-    fn check_replacements(
-        &self,
-        _n: NodeWithSource<'_>,
-        _replacements: &mut Vec<RangeReplacement>,
-    ) {
-    }
+    fn check_replacements(&self, _n: NodeWithSource<'_>, _replacements: &mut Vec<Replacement>) {}
 
     fn get_equivalence_class(
         &self,

--- a/crates/language/src/python.rs
+++ b/crates/language/src/python.rs
@@ -1,6 +1,6 @@
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, Replacement, SortId, TSLanguage};
 use grit_util::AstNode;
-use marzano_util::{node_with_source::NodeWithSource};
+use marzano_util::node_with_source::NodeWithSource;
 use std::sync::OnceLock;
 
 static NODE_TYPES_STRING: &str =
@@ -82,10 +82,10 @@ impl Language for Python {
     fn check_replacements(
         &self,
         n: NodeWithSource<'_>,
-        replacements: &mut Vec<crate::language::RangeReplacement>,
+        replacements: &mut Vec<crate::language::Replacement>,
     ) {
         if n.node.is_error() && n.text() == "->" {
-            replacements.push((n.range(), None));
+            replacements.push(Replacement::new(n.range(), ""));
         }
     }
 }

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -1,4 +1,4 @@
-use crate::language::RangeReplacement;
+use crate::language::Replacement;
 use crate::language::{GritMetaValue, LeafEquivalenceClass, SnippetTree, TSLanguage};
 use crate::{
     csharp::CSharp,

--- a/crates/language/src/tsx.rs
+++ b/crates/language/src/tsx.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, sync::OnceLock};
 
 use crate::{
     language::{
-        fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, RangeReplacement,
+        fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, Replacement,
         SortId, TSLanguage,
     },
     xscript_util::{
@@ -178,7 +178,7 @@ impl Language for Tsx {
         self.metavariable_sort
     }
 
-    fn check_replacements(&self, n: NodeWithSource<'_>, orphan_ranges: &mut Vec<RangeReplacement>) {
+    fn check_replacements(&self, n: NodeWithSource<'_>, orphan_ranges: &mut Vec<Replacement>) {
         jslike_check_replacements(n, orphan_ranges)
     }
 

--- a/crates/language/src/typescript.rs
+++ b/crates/language/src/typescript.rs
@@ -179,7 +179,7 @@ impl Language for TypeScript {
     fn check_replacements(
         &self,
         n: NodeWithSource<'_>,
-        replacements: &mut Vec<crate::language::RangeReplacement>,
+        replacements: &mut Vec<crate::language::Replacement>,
     ) {
         jslike_check_replacements(n, replacements)
     }

--- a/crates/language/src/xscript_util.rs
+++ b/crates/language/src/xscript_util.rs
@@ -1,5 +1,5 @@
 use crate::{
-    language::{default_parse_file, Language, RangeReplacement, SortId, TSLanguage},
+    language::{default_parse_file, Language, Replacement, SortId, TSLanguage},
     vue::get_vue_ranges,
 };
 use anyhow::anyhow;
@@ -117,25 +117,25 @@ pub(crate) fn parse_file(
 
 pub(crate) fn jslike_check_replacements(
     n: NodeWithSource<'_>,
-    replacement_ranges: &mut Vec<RangeReplacement>,
+    replacement_ranges: &mut Vec<Replacement>,
 ) {
     if n.node.kind() == "arrow_function" {
         let child = n.node.child_by_field_name("body");
         if let Some(child) = child {
             let range = child.range();
             if range.start_byte() == range.end_byte() {
-                replacement_ranges.push((range.into(), Some("{}".to_string())));
+                replacement_ranges.push(Replacement::new(range.into(), "{}"));
             }
         }
     } else if n.node.is_error() && ["var", "let", "const"].contains(&n.text())
         || n.node.kind() == "empty_statement"
     {
-        replacement_ranges.push((n.range(), None));
+        replacement_ranges.push(Replacement::new(n.range(), ""));
     } else if n.node.kind() == "import_statement" {
         for n in n.named_children().filter(|n| n.node.is_error()) {
             if let Some(n) = n.children().last() {
                 if n.node.kind() == "," {
-                    replacement_ranges.push((n.range(), None))
+                    replacement_ranges.push(Replacement::new(n.range(), ""))
                 }
             }
         }
@@ -144,14 +144,14 @@ pub(crate) fn jslike_check_replacements(
                 let named_imports = imports.named_children_by_field_name("imports").count();
                 let namespace_import = imports.named_children_by_field_name("namespace").count();
                 if named_imports == 0 && namespace_import == 0 {
-                    replacement_ranges.push((n.range(), None));
+                    replacement_ranges.push(Replacement::new(n.range(), ""));
                 }
             }
         }
     } else if n.node.is_error() && n.text() == "," {
         for ancestor in n.ancestors() {
             if ancestor.node.kind() == "class_body" {
-                replacement_ranges.push((n.range(), None));
+                replacement_ranges.push(Replacement::new(n.range(), ""));
                 break;
             }
         }


### PR DESCRIPTION
Use a shared struct instead of multiple typedefs, and remove some unnecessary branching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the internal handling and processing of replacement ranges across various language implementations to improve consistency and maintainability.
- **Bug Fixes**
	- Enhanced the accuracy of code replacements in multiple programming languages by refining the replacement data structures used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->