### PR TITLE
feat: add a ` --limit` arg

### DIFF
--- a/crates/cli/src/analyze.rs
+++ b/crates/cli/src/analyze.rs
@@ -59,6 +59,7 @@ impl<'b> RichPattern<'b> {
             self.name.to_owned(),
             targets,
             injected_builtins,
+            None
         )
     }
 }

--- a/crates/cli/src/analyze.rs
+++ b/crates/cli/src/analyze.rs
@@ -45,6 +45,7 @@ impl<'b> RichPattern<'b> {
         pattern_libs: &BTreeMap<String, String>,
         language: Option<PatternLanguage>,
         targets: Option<Vec<FileRange>>,
+        injected_limit: Option<usize>,
     ) -> Result<CompilationResult> {
         let lang = language.unwrap_or_default();
         #[cfg(not(feature = "ai_builtins"))]
@@ -59,7 +60,7 @@ impl<'b> RichPattern<'b> {
             self.name.to_owned(),
             targets,
             injected_builtins,
-            None
+            None,
         )
     }
 }

--- a/crates/cli/src/analyze.rs
+++ b/crates/cli/src/analyze.rs
@@ -60,7 +60,7 @@ impl<'b> RichPattern<'b> {
             self.name.to_owned(),
             targets,
             injected_builtins,
-            None,
+            injected_limit,
         )
     }
 }

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -65,6 +65,10 @@ pub struct ApplyPatternArgs {
         default_value_t = OutputMode::Standard,
     )]
     output: OutputMode,
+    // Inject a [limit](https://docs.grit.io/language/modifiers#limit-clause) to show only the first N results
+    #[clap(short = 'm')]
+    pub limit: Option<usize>,
+    // TODO: consider removing this
     #[clap(long = "ignore-limit", default_value = "false", hide = true)]
     ignore_limit: bool,
     // Dry run
@@ -134,6 +138,7 @@ impl Default for ApplyPatternArgs {
     fn default() -> Self {
         Self {
             output: Default::default(),
+            limit: Default::default(),
             ignore_limit: Default::default(),
             dry_run: Default::default(),
             force: Default::default(),

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -66,7 +66,8 @@ pub struct ApplyPatternArgs {
     )]
     output: OutputMode,
     // Inject a [limit](https://docs.grit.io/language/modifiers#limit-clause) to show only the first N results
-    #[clap(short = 'm')]
+    // If the pattern already has a limit, this will override it
+    #[clap(short = 'm', long = "limit")]
     pub limit: Option<usize>,
     // TODO: consider removing this
     #[clap(long = "ignore-limit", default_value = "false", hide = true)]

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -388,7 +388,7 @@ pub(crate) async fn run_apply_pattern(
     let CompilationResult {
         problem: compiled,
         compilation_warnings,
-    } = match pattern.compile(&my_input.pattern_libs, lang, filter_range) {
+    } = match pattern.compile(&my_input.pattern_libs, lang, filter_range, arg.limit) {
         Ok(c) => c,
         Err(e) => {
             let log = match e.downcast::<marzano_util::analysis_logs::AnalysisLog>() {

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -148,7 +148,7 @@ pub(crate) async fn run_check(
                 .make_pattern(&body, Some(p.local_name.to_string()))
                 .unwrap();
             let lang = PatternLanguage::get_language(&p.body);
-            match rich_pattern.compile(&grit_files, lang, filter_range.clone()) {
+            match rich_pattern.compile(&grit_files, lang, filter_range.clone(), None) {
                 Ok(c) => Ok((p.local_name.clone(), c.problem)),
                 Err(e) => {
                     bail!("Unable to compile pattern {}:\n{}", p.local_name, e);

--- a/crates/cli/src/commands/parse.rs
+++ b/crates/cli/src/commands/parse.rs
@@ -94,7 +94,7 @@ async fn parse_one_pattern(body: String, path: Option<&PathBuf>) -> Result<Match
     let pattern = resolver.make_pattern(&body, None)?;
     let pattern_libs = get_grit_files_from_cwd().await?;
     let pattern_libs = pattern_libs.get_language_directory_or_default(lang)?;
-    let problem = match pattern.compile(&pattern_libs, None, None) {
+    let problem = match pattern.compile(&pattern_libs, None, None, None) {
         Ok(problem) => problem,
         Err(e) => {
             let log = match e.downcast::<marzano_util::analysis_logs::AnalysisLog>() {

--- a/crates/cli/src/commands/patterns_test.rs
+++ b/crates/cli/src/commands/patterns_test.rs
@@ -56,7 +56,9 @@ pub async fn get_marzano_pattern_test_results(
                 .make_pattern(&pattern.body, pattern.local_name.clone())
                 .unwrap_or_else(|_| panic!("Failed to parse pattern {}", pattern.body));
 
-            let compiled = rich_pattern.compile(&libs, None, None).map(|cr| cr.problem);
+            let compiled = rich_pattern
+                .compile(&libs, None, None, None)
+                .map(|cr| cr.problem);
 
             match compiled {
                 Ok(compiled) => {

--- a/crates/cli_bin/tests/apply.rs
+++ b/crates/cli_bin/tests/apply.rs
@@ -1827,6 +1827,60 @@ fn applies_limit_on_multifile() -> Result<()> {
 }
 
 #[test]
+fn overrides_limit() -> Result<()> {
+    let (_temp_dir, fixture_dir) = get_fixture("limit_files", false)?;
+    let mut cmd = get_test_cmd()?;
+    cmd.arg("apply")
+        .arg("pattern.grit")
+        .arg("file1.js")
+        .arg("file2.js")
+        .arg("--limit=2")
+        .current_dir(&fixture_dir);
+
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    println!("stdout: {:?}", stdout);
+    println!("stderr: {:?}", stderr);
+
+    assert!(
+        output.status.success(),
+        "Command didn't finish successfully"
+    );
+
+    assert!(stdout.contains("found 2 matches"));
+
+    Ok(())
+}
+
+#[test]
+fn injects_limit() -> Result<()> {
+    let (_temp_dir, fixture_dir) = get_fixture("limit_files", false)?;
+    let mut cmd = get_test_cmd()?;
+    cmd.arg("apply")
+        .arg("`x` => `y`")
+        .arg("file1.js")
+        .arg("file2.js")
+        .arg("--limit=1")
+        .current_dir(&fixture_dir);
+
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    println!("stdout: {:?}", stdout);
+    println!("stderr: {:?}", stderr);
+
+    assert!(
+        output.status.success(),
+        "Command didn't finish successfully"
+    );
+
+    assert!(stdout.contains("found 1 matches"));
+
+    Ok(())
+}
+
+#[test]
 fn test_ignores_limit_on_scans() -> Result<()> {
     let (_temp_dir, fixture_dir) = get_fixture("limit_files", false)?;
 

--- a/crates/core/src/pattern_compiler/auto_wrap.rs
+++ b/crates/core/src/pattern_compiler/auto_wrap.rs
@@ -32,7 +32,7 @@ pub(super) fn auto_wrap_pattern(
     is_not_multifile: bool,
     file_ranges: Option<Vec<FileRange>>,
     context: &mut NodeCompilationContext,
-    injected_limt: Option<usize>,
+    injected_limit: Option<usize>,
 ) -> Result<Pattern> {
     let is_sequential = is_sequential(&pattern, pattern_definitions);
     let should_wrap_in_sequential = !is_sequential;
@@ -63,7 +63,7 @@ pub(super) fn auto_wrap_pattern(
         } else {
             first_wrap
         };
-        let third_wrap = if let Some(limit) = injected_limt {
+        let third_wrap = if let Some(limit) = injected_limit {
             Pattern::Limit(Box::new(Limit::new(second_wrap, limit)))
         } else if let Some(limit) = extracted_limit {
             Pattern::Limit(Box::new(Limit::new(second_wrap, limit)))

--- a/crates/core/src/pattern_compiler/auto_wrap.rs
+++ b/crates/core/src/pattern_compiler/auto_wrap.rs
@@ -32,6 +32,7 @@ pub(super) fn auto_wrap_pattern(
     is_not_multifile: bool,
     file_ranges: Option<Vec<FileRange>>,
     context: &mut NodeCompilationContext,
+    injected_limt: Option<usize>,
 ) -> Result<Pattern> {
     let is_sequential = is_sequential(&pattern, pattern_definitions);
     let should_wrap_in_sequential = !is_sequential;
@@ -62,7 +63,9 @@ pub(super) fn auto_wrap_pattern(
         } else {
             first_wrap
         };
-        let third_wrap = if let Some(limit) = extracted_limit {
+        let third_wrap = if let Some(limit) = injected_limt {
+            Pattern::Limit(Box::new(Limit::new(second_wrap, limit)))
+        } else if let Some(limit) = extracted_limit {
             Pattern::Limit(Box::new(Limit::new(second_wrap, limit)))
         } else {
             second_wrap

--- a/crates/core/src/pattern_compiler/auto_wrap.rs
+++ b/crates/core/src/pattern_compiler/auto_wrap.rs
@@ -64,7 +64,9 @@ pub(super) fn auto_wrap_pattern(
             first_wrap
         };
         let third_wrap = if let Some(limit) = injected_limit {
-            Pattern::Limit(Box::new(Limit::new(second_wrap, limit)))
+            // Strip the limit if there is one
+            let (pattern, _) = extract_limit_pattern(second_wrap, pattern_definitions);
+            Pattern::Limit(Box::new(Limit::new(pattern, limit)))
         } else if let Some(limit) = extracted_limit {
             Pattern::Limit(Box::new(Limit::new(second_wrap, limit)))
         } else {

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -762,6 +762,7 @@ pub fn src_to_problem_libs_for_language(
         !is_multifile,
         file_ranges,
         &mut node_context,
+        injected_limit,
     )?;
 
     let problem = Problem::new(

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -653,6 +653,7 @@ pub fn src_to_problem_libs(
     name: Option<String>,
     file_ranges: Option<Vec<FileRange>>,
     custom_built_ins: Option<BuiltIns>,
+    injected_limit: Option<usize>,
 ) -> Result<CompilationResult> {
     let mut parser = make_grit_parser()?;
     let src_tree = parse_one(&mut parser, &src, DEFAULT_FILE_NAME)?;
@@ -665,10 +666,11 @@ pub fn src_to_problem_libs(
         file_ranges,
         &mut parser,
         custom_built_ins,
-        None
+        injected_limit,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn src_to_problem_libs_for_language(
     src: String,
     libs: &BTreeMap<String, String>,
@@ -677,6 +679,7 @@ pub fn src_to_problem_libs_for_language(
     file_ranges: Option<Vec<FileRange>>,
     grit_parser: &mut Parser,
     custom_built_ins: Option<BuiltIns>,
+    injected_limit: Option<usize>,
 ) -> Result<CompilationResult> {
     if src == "." {
         let error = ". never matches and should not be used as a pattern. Did you mean to run 'grit apply <pattern> .'?";
@@ -816,7 +819,7 @@ mod tests {
             None,
             None,
             None,
-            None
+            None,
         )
         .unwrap();
         let language = pattern.problem.language.language_name();

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -665,6 +665,7 @@ pub fn src_to_problem_libs(
         file_ranges,
         &mut parser,
         custom_built_ins,
+        None
     )
 }
 

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -816,6 +816,7 @@ mod tests {
             None,
             None,
             None,
+            None
         )
         .unwrap();
         let language = pattern.problem.language.language_name();

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -23,7 +23,7 @@ use super::*;
 
 pub fn src_to_problem(src: String, default_lang: TargetLanguage) -> Result<Problem> {
     let libs = BTreeMap::new();
-    src_to_problem_libs(src, &libs, default_lang, None, None, None).map(|cr| cr.problem)
+    src_to_problem_libs(src, &libs, default_lang, None, None, None, None).map(|cr| cr.problem)
 }
 
 // #[deprecated(note = "remove after migrating tests to MatchResult")]
@@ -97,7 +97,7 @@ fn match_pattern_libs(
     let default_context = ExecutionContext::default();
     let context = TEST_EXECUTION_CONTEXT.as_ref().unwrap_or(&default_context);
 
-    let pattern = src_to_problem_libs(pattern, libs, default_language, None, None, None)?.problem;
+    let pattern = src_to_problem_libs(pattern, libs, default_language, None, None, None, None)?.problem;
     let results = pattern.execute_file(&RichFile::new(file.to_owned(), src.to_owned()), context);
     let mut execution_result = ExecutionResult {
         input_file_debug_text: "".to_string(),
@@ -424,7 +424,7 @@ fn test_compile_time_logging() {
     .to_string();
     let libs = BTreeMap::new();
     let default_language = PatternLanguage::Tsx.try_into().unwrap();
-    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None).unwrap();
+    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None, None).unwrap();
     let res = format!("{:?}", pattern.compilation_warnings);
     assert_snapshot!(res);
 }
@@ -439,7 +439,7 @@ fn warns_against_snippet_useless_rewrite() {
     .to_string();
     let libs = BTreeMap::new();
     let default_language = PatternLanguage::Tsx.try_into().unwrap();
-    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None).unwrap();
+    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None, None).unwrap();
     let res = format!("{:?}", pattern.compilation_warnings);
     assert_snapshot!(res);
 }
@@ -456,7 +456,7 @@ fn does_not_warn_against_regular_snippet_rewrite() {
     .to_string();
     let libs = BTreeMap::new();
     let default_language = PatternLanguage::Tsx.try_into().unwrap();
-    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None).unwrap();
+    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None, None).unwrap();
     assert!(pattern.compilation_warnings.is_empty())
 }
 
@@ -470,7 +470,7 @@ fn warns_against_snippet_regex_without_metavars() {
     .to_string();
     let libs = BTreeMap::new();
     let default_language = PatternLanguage::Tsx.try_into().unwrap();
-    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None).unwrap();
+    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None, None).unwrap();
     let res = format!("{:?}", pattern.compilation_warnings);
     assert_snapshot!(res);
 }
@@ -486,7 +486,7 @@ fn does_not_warn_against_snippet_regex_with_metavars() {
     .to_string();
     let libs = BTreeMap::new();
     let default_language = PatternLanguage::Tsx.try_into().unwrap();
-    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None).unwrap();
+    let pattern = src_to_problem_libs(pattern, &libs, default_language, None, None, None, None).unwrap();
     assert!(pattern.compilation_warnings.is_empty())
 }
 
@@ -3264,7 +3264,7 @@ fn warning_rewrite_in_not() {
 
     let js_lang: TargetLanguage = PatternLanguage::Tsx.try_into().unwrap();
     let libs = BTreeMap::new();
-    let cr = src_to_problem_libs(pattern, &libs, js_lang, None, None, None).unwrap();
+    let cr = src_to_problem_libs(pattern, &libs, js_lang, None, None, None, None).unwrap();
     assert_debug_snapshot!(cr.compilation_warnings)
 }
 
@@ -8347,7 +8347,7 @@ fn distinct_on_primitives() {
 fn correct_variable_index() {
     let pattern = "`function () { $body }`".to_owned();
     let tsx: TargetLanguage = PatternLanguage::Tsx.try_into().unwrap();
-    let _pattern = src_to_problem_libs(pattern, &BTreeMap::new(), tsx, None, None, None).unwrap();
+    let _pattern = src_to_problem_libs(pattern, &BTreeMap::new(), tsx, None, None, None, None).unwrap();
 }
 
 #[test]

--- a/crates/lsp/src/apply.rs
+++ b/crates/lsp/src/apply.rs
@@ -77,6 +77,7 @@ pub async fn apply_pattern_body(
             }]
         }),
         get_ai_built_in_functions_for_feature(),
+        None
     ) {
         Ok(p) => p,
         Err(e) => {

--- a/crates/lsp/src/check.rs
+++ b/crates/lsp/src/check.rs
@@ -88,6 +88,7 @@ pub fn check_file(
             Some(pattern.local_name.to_string()),
             None,
             get_ai_built_in_functions_for_feature(),
+            None
         )?;
         let logs = compilation_warnings
             .clone()

--- a/crates/lsp/src/search.rs
+++ b/crates/lsp/src/search.rs
@@ -52,6 +52,7 @@ pub async fn search_query(
             None,
             None,
             get_ai_built_in_functions_for_feature(),
+            None
         ) {
             Ok(p) => p,
             Err(e) => {

--- a/crates/lsp/src/testing.rs
+++ b/crates/lsp/src/testing.rs
@@ -115,6 +115,7 @@ pub async fn maybe_test_pattern(
         Some(our_pattern.local_name.to_string()),
         None,
         get_ai_built_in_functions_for_feature(),
+        None
     ) {
         Ok(p) => {
             client

--- a/crates/wasm-bindings/src/match_pattern.rs
+++ b/crates/wasm-bindings/src/match_pattern.rs
@@ -105,6 +105,7 @@ pub async fn parse_input_files(
         None,
         parser,
         injected_builtins,
+        None
     ) {
         Ok(c) => {
             let warning_logs = c
@@ -228,6 +229,7 @@ pub async fn match_pattern(
         None,
         parser,
         injected_builtins,
+        None
     ) {
         Ok(c) => c,
         Err(e) => {


### PR DESCRIPTION
For exploratory analysis, it's helpful to inject/override a pattern limit directly on the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to set and override limits on injected items during pattern application in the CLI tool.
- **Tests**
	- Added tests to ensure the correct application of new limit settings on file processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->