### PR TITLE
fix: remove a mistaken println

### DIFF
--- a/.grit/grit.yaml
+++ b/.grit/grit.yaml
@@ -19,5 +19,16 @@ patterns:
 
       `println!($_)` => .  where {
         $filename <: not includes "test.rs",
-        $absolute_filename <: includes "apps/marzano/lsp",
+        $absolute_filename <: includes "lsp",
+      }
+  - name: no_println_in_core
+    description: Don't use println or other debugging macros in core code.
+    level: error
+    body: |
+      engine marzano(0.1)
+      language rust
+
+      `println!($_)` as $print => .  where {
+        $absolute_filename <: includes "crates/gritmodule",
+        $print <: not within `mod tests { $_ }`
       }

--- a/crates/gritmodule/src/markdown.rs
+++ b/crates/gritmodule/src/markdown.rs
@@ -280,7 +280,6 @@ pub fn replace_sample_in_md_file(
 
     let byte_range =
         (range.start_byte as isize + offset) as usize..(range.end_byte as isize + offset) as usize;
-    println!("Transform by {}", offset);
 
     let mut file = OpenOptions::new()
         .read(true)


### PR DESCRIPTION
I accidentally added this when debugging. Remove and make sure we don't make the same mistake again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Restricted the use of debugging macros in core code to enhance performance and maintain code cleanliness.
	- Removed unnecessary console output from markdown processing module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->