### PR TITLE
chore: Use language trait over struct

### DIFF
--- a/crates/cli/src/commands/parse.rs
+++ b/crates/cli/src/commands/parse.rs
@@ -12,7 +12,7 @@ use marzano_core::{
     api::{AnalysisLog, MatchResult, PatternInfo},
     parse::parse_input_file,
 };
-use marzano_language::target_language::PatternLanguage;
+use marzano_language::target_language::{PatternLanguage, TargetLanguage};
 use marzano_messenger::{
     emit::{Messager, VisibilityLevels},
     output_mode::OutputMode,
@@ -56,7 +56,7 @@ pub(crate) async fn run_parse(
     };
 
     // we should be reading the default from a config
-    let lang = PatternLanguage::get_language(&parse_input.pattern_body)
+    let lang: TargetLanguage = PatternLanguage::get_language(&parse_input.pattern_body)
         .unwrap_or_default()
         .try_into()
         .map_err(|e: String| anyhow!(e))?;

--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -4,7 +4,6 @@ use crate::problem::{Effect, EffectKind};
 use anyhow::{anyhow, Result};
 use grit_util::{AstNode, CodeRange};
 use marzano_language::language::{FieldId, Language};
-use marzano_language::target_language::TargetLanguage;
 use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
 use marzano_util::node_with_source::NodeWithSource;
 use marzano_util::position::{Position, Range};
@@ -199,7 +198,7 @@ impl EffectRange {
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn linearize_binding<'a>(
-    language: &TargetLanguage,
+    language: &impl Language,
     effects: &[Effect<'a>],
     files: &FileRegistry<'a>,
     memo: &mut HashMap<CodeRange, Option<String>>,
@@ -396,7 +395,7 @@ impl<'a> Binding<'a> {
 
     pub(crate) fn linearized_text(
         &self,
-        language: &TargetLanguage,
+        language: &impl Language,
         effects: &[Effect<'a>],
         files: &FileRegistry<'a>,
         memo: &mut HashMap<CodeRange, Option<String>>,
@@ -549,7 +548,7 @@ impl<'a> Binding<'a> {
 
     pub(crate) fn log_empty_field_rewrite_error(
         &self,
-        language: &TargetLanguage,
+        language: &impl Language,
         logs: &mut AnalysisLogs,
     ) -> Result<()> {
         match self {

--- a/crates/core/src/clean.rs
+++ b/crates/core/src/clean.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use grit_util::{traverse, Order};
 use itertools::Itertools;
+use marzano_language::language::Language;
 use marzano_language::language::Replacement;
-use marzano_language::{language::Language, target_language::TargetLanguage};
 use marzano_util::{cursor_wrapper::CursorWrapper, node_with_source::NodeWithSource};
 
 fn merge_ranges(ranges: Vec<Replacement>) -> Vec<Replacement> {
@@ -50,7 +50,7 @@ pub(crate) fn replace_cleaned_ranges(
     Ok(Some(src))
 }
 
-pub fn get_replacement_ranges(node: NodeWithSource, lang: &TargetLanguage) -> Vec<Replacement> {
+pub fn get_replacement_ranges(node: NodeWithSource, lang: &impl Language) -> Vec<Replacement> {
     let mut replacement_ranges = vec![];
     let cursor = node.node.walk();
     for n in traverse(CursorWrapper::new(cursor, node.source), Order::Pre) {

--- a/crates/core/src/inline_snippets.rs
+++ b/crates/core/src/inline_snippets.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Result};
 use itertools::Itertools;
-use marzano_language::{language::Language, target_language::TargetLanguage};
+use marzano_language::language::Language;
 use std::{cell::RefCell, collections::HashSet, ops::Range, rc::Rc};
 
 use crate::binding::EffectRange;
@@ -81,7 +81,7 @@ fn sort_range_start(replacements: &mut [(EffectRange, String)]) {
 }
 
 fn pad_snippet(
-    language: &TargetLanguage,
+    language: &impl Language,
     context: &str,
     range_start: usize,
     snippet: &str,
@@ -126,7 +126,7 @@ fn pad_snippet(
 // maybe convert these to a debug assertion?
 // also probably worth merging with the originial above.
 pub(crate) fn inline_sorted_snippets_with_offset(
-    language: &TargetLanguage,
+    language: &impl Language,
     code: String,
     offset: usize,
     replacements: &mut Vec<(EffectRange, String)>,

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -1,14 +1,13 @@
 use crate::api::InputFile;
 use anyhow::Result;
-use marzano_language::target_language::TargetLanguage;
+use marzano_language::language::Language;
 use std::path::Path;
 use tree_sitter::Parser;
 
 #[cfg(feature = "grit-parser")]
-pub fn parse_input_file(lang: &TargetLanguage, input: &str, path: &Path) -> Result<InputFile> {
+pub fn parse_input_file(lang: &impl Language, input: &str, path: &Path) -> Result<InputFile> {
     use crate::tree_sitter_serde::tree_sitter_node_to_json;
     use anyhow::Context;
-    use marzano_language::language::Language;
     use serde_json::to_string_pretty;
 
     let mut parser = Parser::new().context("Failed to create new parser")?;
@@ -31,7 +30,7 @@ pub fn parse_input_file(lang: &TargetLanguage, input: &str, path: &Path) -> Resu
     })
 }
 #[cfg(not(feature = "grit-parser"))]
-pub fn parse_input_file(_lang: &TargetLanguage, _input: &str, _path: &Path) -> Result<InputFile> {
+pub fn parse_input_file(_lang: &impl Language, _input: &str, _path: &Path) -> Result<InputFile> {
     use anyhow::anyhow;
 
     Err(anyhow!(

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -18,7 +18,7 @@ use anyhow::{anyhow, bail, Result};
 use grit_util::CodeRange;
 use im::{vector, Vector};
 use itertools::Itertools;
-use marzano_language::{language::FieldId, target_language::TargetLanguage};
+use marzano_language::language::{FieldId, Language};
 use marzano_util::{
     analysis_logs::AnalysisLogs, node_with_source::NodeWithSource, position::Range,
 };
@@ -118,7 +118,7 @@ impl<'a> JoinFn<'a> {
 
     fn linearized_text(
         &self,
-        language: &TargetLanguage,
+        language: &impl Language,
         effects: &[Effect<'a>],
         files: &FileRegistry<'a>,
         memo: &mut HashMap<CodeRange, Option<String>>,
@@ -166,7 +166,7 @@ pub enum LazyBuiltIn<'a> {
 impl<'a> LazyBuiltIn<'a> {
     fn linearized_text(
         &self,
-        language: &TargetLanguage,
+        language: &impl Language,
         effects: &[Effect<'a>],
         files: &FileRegistry<'a>,
         memo: &mut HashMap<CodeRange, Option<String>>,
@@ -243,7 +243,7 @@ impl<'a> ResolvedSnippet<'a> {
 
     pub(crate) fn linearized_text(
         &self,
-        language: &TargetLanguage,
+        language: &impl Language,
         effects: &[Effect<'a>],
         files: &FileRegistry<'a>,
         memo: &mut HashMap<CodeRange, Option<String>>,
@@ -285,7 +285,7 @@ impl<'a> ResolvedPattern<'a> {
         &mut self,
         mut with: ResolvedPattern<'a>,
         effects: &mut Vector<Effect<'a>>,
-        language: &TargetLanguage,
+        language: &impl Language,
     ) -> Result<()> {
         match self {
             ResolvedPattern::Binding(bindings) => {
@@ -699,7 +699,7 @@ impl<'a> ResolvedPattern<'a> {
 
     pub(crate) fn linearized_text(
         &self,
-        language: &TargetLanguage,
+        language: &impl Language,
         effects: &[Effect<'a>],
         files: &FileRegistry<'a>,
         memo: &mut HashMap<CodeRange, Option<String>>,
@@ -910,7 +910,7 @@ impl<'a> ResolvedPattern<'a> {
         &mut self,
         binding: &Binding<'a>,
         is_first: bool,
-        language: &TargetLanguage,
+        language: &impl Language,
     ) -> Result<()> {
         let ResolvedPattern::Snippets(ref mut snippets) = self else {
             return Ok(());

--- a/crates/core/src/pattern/state.rs
+++ b/crates/core/src/pattern/state.rs
@@ -8,7 +8,7 @@ use crate::problem::{Effect, FileOwner};
 use anyhow::{anyhow, bail, Result};
 use grit_util::CodeRange;
 use im::{vector, Vector};
-use marzano_language::target_language::TargetLanguage;
+use marzano_language::language::Language;
 use marzano_util::analysis_logs::AnalysisLogs;
 use marzano_util::position::Range;
 use marzano_util::position::VariableMatch;
@@ -79,7 +79,7 @@ fn get_top_level_effect_ranges<'a>(
     effects: &[Effect<'a>],
     memo: &HashMap<CodeRange, Option<String>>,
     range: &CodeRange,
-    language: &TargetLanguage,
+    language: &impl Language,
     logs: &mut AnalysisLogs,
 ) -> Result<Vec<EffectRange<'a>>> {
     let mut effects: Vec<EffectRange> = effects
@@ -124,7 +124,7 @@ pub(crate) fn get_top_level_effects<'a>(
     effects: &[Effect<'a>],
     memo: &HashMap<CodeRange, Option<String>>,
     range: &CodeRange,
-    language: &TargetLanguage,
+    language: &impl Language,
     logs: &mut AnalysisLogs,
 ) -> Result<Vec<Effect<'a>>> {
     let top_level = get_top_level_effect_ranges(effects, memo, range, language, logs)?;
@@ -223,7 +223,7 @@ impl<'a, Q: QueryContext> State<'a, Q> {
 
     pub(crate) fn bindings_history_to_ranges(
         &self,
-        lang: &TargetLanguage,
+        lang: &impl Language,
         current_name: Option<&str>,
     ) -> (Vec<VariableMatch>, Vec<Range>, bool) {
         let mut matches = vec![];

--- a/crates/core/src/smart_insert.rs
+++ b/crates/core/src/smart_insert.rs
@@ -1,6 +1,6 @@
 use crate::binding::Binding;
 use grit_util::AstNode;
-use marzano_language::{language::Language, target_language::TargetLanguage};
+use marzano_language::language::Language;
 use marzano_util::node_with_source::NodeWithSource;
 
 impl<'a> Binding<'a> {
@@ -9,7 +9,7 @@ impl<'a> Binding<'a> {
         &self,
         text: &str,
         is_first: bool,
-        language: &TargetLanguage,
+        language: &impl Language,
     ) -> Option<String> {
         match self {
             Self::List(node, field_id) => {
@@ -49,7 +49,7 @@ fn calculate_padding(
     children: &[NodeWithSource],
     insert: &str,
     is_first: bool,
-    language: &TargetLanguage,
+    language: &impl Language,
 ) -> Option<String> {
     let named_children: Vec<_> = children
         .iter()

--- a/crates/core/src/text_unparser.rs
+++ b/crates/core/src/text_unparser.rs
@@ -4,7 +4,7 @@ use crate::problem::Effect;
 use anyhow::Result;
 use grit_util::CodeRange;
 use im::Vector;
-use marzano_language::target_language::TargetLanguage;
+use marzano_language::language::Language;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::HashMap;
 use std::ops::Range;
@@ -23,7 +23,7 @@ pub(crate) fn apply_effects<'a>(
     files: &FileRegistry<'a>,
     the_filename: &Path,
     new_filename: &mut PathBuf,
-    language: &TargetLanguage,
+    language: &impl Language,
     current_name: Option<&str>,
     logs: &mut AnalysisLogs,
 ) -> Result<(String, Option<Vec<Range<usize>>>)> {

--- a/crates/core/src/tree_sitter_serde.rs
+++ b/crates/core/src/tree_sitter_serde.rs
@@ -1,7 +1,6 @@
 use marzano_language::{
     grit_ts_node::GRIT_NODE_TYPES,
     language::{Field, Language},
-    target_language::TargetLanguage,
 };
 use serde_json::{json, Value};
 use tree_sitter::Node;
@@ -9,10 +8,12 @@ use tree_sitter::Node;
 /**
  * Converts a tree-sitter node to a Serde JSON value.
  */
+// Todo language should not be an optional
+// node types should be it's own trait that Language implements
 pub fn tree_sitter_node_to_json(
     node: &Node,
     source: &str,
-    language: Option<&TargetLanguage>,
+    language: Option<&impl Language>,
 ) -> serde_json::Value {
     let sort_id = node.kind_id();
     let node_types = if let Some(language) = language {

--- a/crates/language/src/css.rs
+++ b/crates/language/src/css.rs
@@ -101,6 +101,10 @@ impl Language for Css {
             default_parse_file(self.get_ts_language(), name, body, logs, new)
         }
     }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("/* {} */\n", text)
+    }
 }
 
 #[cfg(test)]

--- a/crates/language/src/hcl.rs
+++ b/crates/language/src/hcl.rs
@@ -66,6 +66,10 @@ impl Language for Hcl {
     fn is_comment(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("# {}\n", text)
+    }
 }
 
 #[cfg(test)]

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -60,4 +60,8 @@ impl Language for Html {
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
     }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("<!-- {} -->\n", text)
+    }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -339,6 +339,14 @@ pub trait Language {
     ) -> Result<Option<Tree>> {
         default_parse_file(self.get_ts_language(), name, body, logs, new)
     }
+
+    fn should_pad_snippet(&self) -> bool {
+        false
+    }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("// {}\n", text)
+    }
 }
 
 pub(crate) fn default_parse_file(

--- a/crates/language/src/markdown_block.rs
+++ b/crates/language/src/markdown_block.rs
@@ -62,6 +62,10 @@ impl Language for MarkdownBlock {
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
     }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("<!-- {} -->\n", text)
+    }
 }
 
 #[cfg(test)]

--- a/crates/language/src/markdown_inline.rs
+++ b/crates/language/src/markdown_inline.rs
@@ -62,6 +62,10 @@ impl Language for MarkdownInline {
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
     }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("<!-- {} -->\n", text)
+    }
 }
 
 #[cfg(test)]

--- a/crates/language/src/php.rs
+++ b/crates/language/src/php.rs
@@ -2,11 +2,11 @@ use regex::Regex;
 use std::sync::OnceLock;
 
 use crate::{
-    language::{
-        fields_for_nodes, Field, Language, SortId, TSLanguage
-    }, xscript_util::{
-        php_like_exact_variable_regex, php_like_metavariable_bracket_regex, php_like_metavariable_prefix, php_like_metavariable_regex, PHP_CODE_SNIPPETS
-    }
+    language::{fields_for_nodes, Field, Language, SortId, TSLanguage},
+    xscript_util::{
+        php_like_exact_variable_regex, php_like_metavariable_bracket_regex,
+        php_like_metavariable_prefix, php_like_metavariable_regex, PHP_CODE_SNIPPETS,
+    },
 };
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/php-node-types.json");
@@ -86,6 +86,10 @@ impl Language for Php {
 
     fn exact_variable_regex(&self) -> &'static Regex {
         php_like_exact_variable_regex()
+    }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("<!-- {} -->\n", text)
     }
 }
 

--- a/crates/language/src/python.rs
+++ b/crates/language/src/python.rs
@@ -88,6 +88,14 @@ impl Language for Python {
             replacements.push(Replacement::new(n.range(), ""));
         }
     }
+
+    fn should_pad_snippet(&self) -> bool {
+        true
+    }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("# {}\n", text)
+    }
 }
 
 #[cfg(test)]

--- a/crates/language/src/ruby.rs
+++ b/crates/language/src/ruby.rs
@@ -64,4 +64,8 @@ impl Language for Ruby {
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
     }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("# {}\n", text)
+    }
 }

--- a/crates/language/src/sql.rs
+++ b/crates/language/src/sql.rs
@@ -72,4 +72,8 @@ impl Language for Sql {
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
     }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("-- {}\n", text)
+    }
 }

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -12,8 +12,8 @@ use crate::{
     language::{Field, FieldId, Language, SortId},
     markdown_block::MarkdownBlock,
     markdown_inline::MarkdownInline,
-    php_only::PhpOnly,
     php::Php,
+    php_only::PhpOnly,
     python::Python,
     ruby::Ruby,
     rust::Rust,
@@ -237,7 +237,7 @@ impl PatternLanguage {
                 Some("html") => Some(Self::Php),
                 Some("only") => Some(Self::PhpOnly),
                 _ => Some(Self::Php),
-            }
+            },
             "universal" => Some(Self::Universal),
             _ => None,
         }
@@ -594,33 +594,6 @@ impl TargetLanguage {
         }
     }
 
-    pub fn should_pad_snippet(&self) -> bool {
-        match self {
-            TargetLanguage::JavaScript(_) => false,
-            TargetLanguage::TypeScript(_) => false,
-            TargetLanguage::Tsx(_) => false,
-            TargetLanguage::Html(_) => false,
-            TargetLanguage::Css(_) => false,
-            TargetLanguage::Json(_) => false,
-            TargetLanguage::Java(_) => false,
-            TargetLanguage::CSharp(_) => false,
-            TargetLanguage::Python(_) => true,
-            TargetLanguage::MarkdownBlock(_) => false,
-            TargetLanguage::MarkdownInline(_) => false,
-            TargetLanguage::Go(_) => false,
-            TargetLanguage::Rust(_) => false,
-            TargetLanguage::Ruby(_) => false,
-            TargetLanguage::Solidity(_) => false,
-            TargetLanguage::Hcl(_) => false,
-            TargetLanguage::Yaml(_) => true,
-            TargetLanguage::Sql(_) => false,
-            TargetLanguage::Vue(_) => false,
-            TargetLanguage::Toml(_) => false,
-            TargetLanguage::Php(_) => false,
-            TargetLanguage::PhpOnly(_) => false,
-        }
-    }
-
     pub fn get_default_extension(&self) -> &'static str {
         self.to_module_language().get_default_extension().unwrap()
     }
@@ -631,33 +604,6 @@ impl TargetLanguage {
 
     pub fn match_extension(&self, ext: &str) -> bool {
         self.to_module_language().match_extension(ext)
-    }
-
-    pub fn make_single_line_comment(&self, text: &str) -> String {
-        match self {
-            TargetLanguage::CSharp(_)
-            | TargetLanguage::Go(_)
-            | TargetLanguage::Java(_)
-            | TargetLanguage::JavaScript(_)
-            | TargetLanguage::Json(_)
-            | TargetLanguage::Rust(_)
-            | TargetLanguage::Solidity(_)
-            | TargetLanguage::Tsx(_)
-            | TargetLanguage::PhpOnly(_)
-            | TargetLanguage::TypeScript(_) => format!("// {}\n", text),
-            TargetLanguage::Python(_)
-            | TargetLanguage::Hcl(_)
-            | TargetLanguage::Ruby(_)
-            | TargetLanguage::Toml(_)
-            | TargetLanguage::Yaml(_) => format!("# {}\n", text),
-            TargetLanguage::Html(_)
-            | TargetLanguage::Php(_)
-            | TargetLanguage::Vue(_)
-            | TargetLanguage::MarkdownBlock(_)
-            | TargetLanguage::MarkdownInline(_) => format!("<!-- {} -->\n", text),
-            TargetLanguage::Css(_) => format!("/* {} */\n", text),
-            TargetLanguage::Sql(_) => format!("-- {}\n", text),
-        }
     }
 
     pub fn extract_single_line_comment(&self, text: &str) -> Option<String> {

--- a/crates/language/src/toml.rs
+++ b/crates/language/src/toml.rs
@@ -59,6 +59,10 @@ impl Language for Toml {
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
     }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("# {}\n", text)
+    }
 }
 
 #[cfg(test)]

--- a/crates/language/src/vue.rs
+++ b/crates/language/src/vue.rs
@@ -63,6 +63,10 @@ impl Language for Vue {
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
     }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("<!-- {} -->\n", text)
+    }
 }
 
 fn is_lang_attribute(node: &Node, text: &[u8], name_array: Option<&[&str]>) -> bool {

--- a/crates/language/src/yaml.rs
+++ b/crates/language/src/yaml.rs
@@ -108,6 +108,14 @@ impl Language for Yaml {
             None
         }
     }
+
+    fn should_pad_snippet(&self) -> bool {
+        true
+    }
+
+    fn make_single_line_comment(&self, text: &str) -> String {
+        format!("# {}\n", text)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
we will want to soon get rid of the target language struct to make it easier for other people to make use of their own custom parsers, this moves us in that direction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added methods for generating single-line comments in multiple programming languages including CSS, HCL, HTML, Markdown, PHP, Python, Ruby, SQL, TOML, Vue, and YAML.

- **Refactor**
  - Unified language handling by replacing `TargetLanguage` with a more generic `Language` trait across various modules, enhancing flexibility in language implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->