### PR TITLE
chore: add node types trait, make global const local

### DIFF
--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -2,8 +2,8 @@ use crate::problem::{FileOwner, InputRanges, Problem};
 use crate::{fs, tree_sitter_serde::tree_sitter_node_to_json};
 use anyhow::{bail, Result};
 use im::Vector;
+use marzano_language::grit_ts_node::grit_node_types;
 use marzano_language::language::Language;
-use marzano_language::tsx::Tsx;
 use marzano_util::analysis_logs::AnalysisLog as MarzanoAnalysisLog;
 use marzano_util::position::{Position, Range, VariableMatch};
 use serde::{Deserialize, Serialize};
@@ -247,8 +247,13 @@ pub struct PatternInfo {
 impl PatternInfo {
     pub fn from_compiled(compiled: Problem, source_file: String) -> Self {
         let node = compiled.tree.root_node();
-        let parsed_pattern =
-            to_string_pretty(&tree_sitter_node_to_json(&node, &source_file, None::<&Tsx>)).unwrap();
+        let grit_node_types = grit_node_types();
+        let parsed_pattern = to_string_pretty(&tree_sitter_node_to_json(
+            &node,
+            &source_file,
+            &grit_node_types,
+        ))
+        .unwrap();
         Self {
             messages: vec![],
             variables: compiled.compiled_vars(),
@@ -284,12 +289,8 @@ impl Match {
         tree: &Tree,
         language: &impl Language,
     ) -> Self {
-        let input_file_debug_text = to_string_pretty(&tree_sitter_node_to_json(
-            &tree.root_node(),
-            file,
-            Some(language),
-        ))
-        .unwrap();
+        let input_file_debug_text =
+            to_string_pretty(&tree_sitter_node_to_json(&tree.root_node(), file, language)).unwrap();
         Self {
             debug: input_file_debug_text,
             source_file: name.to_owned(),

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -18,12 +18,9 @@ pub fn parse_input_file(lang: &impl Language, input: &str, path: &Path) -> Resul
         .parse(input.as_bytes(), None)
         .context("Failed to parse input")?
         .context("Parsed tree is empty")?;
-    let input_file_debug_text = to_string_pretty(&tree_sitter_node_to_json(
-        &tree.root_node(),
-        input,
-        Some(lang),
-    ))
-    .context("Failed to convert tree to pretty JSON string")?;
+    let input_file_debug_text =
+        to_string_pretty(&tree_sitter_node_to_json(&tree.root_node(), input, lang))
+            .context("Failed to convert tree to pretty JSON string")?;
     Ok(InputFile {
         source_file: path.to_string_lossy().to_string(),
         syntax_tree: input_file_debug_text,

--- a/crates/core/src/pattern_compiler/ast_node_compiler.rs
+++ b/crates/core/src/pattern_compiler/ast_node_compiler.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::ast_node::ASTNode;
 use anyhow::{anyhow, Result};
 use itertools::Itertools;
-use marzano_language::language::{FieldId, Language, SortId};
+use marzano_language::language::{FieldId, Language, NodeTypes, SortId};
 use marzano_util::node_with_source::NodeWithSource;
 use std::cmp::Ordering;
 

--- a/crates/core/src/pattern_compiler/pattern_compiler.rs
+++ b/crates/core/src/pattern_compiler/pattern_compiler.rs
@@ -55,7 +55,7 @@ use crate::{ast_node::ASTNode, context::QueryContext};
 use anyhow::{anyhow, bail, Result};
 use grit_util::AstNode;
 use grit_util::{traverse, Order};
-use marzano_language::language::{Field, GritMetaValue, Language, SnippetNode};
+use marzano_language::language::{Field, GritMetaValue, Language, NodeTypes, SnippetNode};
 use marzano_util::{
     cursor_wrapper::CursorWrapper,
     node_with_source::NodeWithSource,

--- a/crates/core/src/tree_sitter_serde.rs
+++ b/crates/core/src/tree_sitter_serde.rs
@@ -1,7 +1,4 @@
-use marzano_language::{
-    grit_ts_node::GRIT_NODE_TYPES,
-    language::{Field, Language},
-};
+use marzano_language::language::{Field, NodeTypes};
 use serde_json::{json, Value};
 use tree_sitter::Node;
 
@@ -13,14 +10,10 @@ use tree_sitter::Node;
 pub fn tree_sitter_node_to_json(
     node: &Node,
     source: &str,
-    language: Option<&impl Language>,
+    language: &impl NodeTypes,
 ) -> serde_json::Value {
     let sort_id = node.kind_id();
-    let node_types = if let Some(language) = language {
-        language.node_types()
-    } else {
-        &GRIT_NODE_TYPES
-    };
+    let node_types = language.node_types();
     let empty: Vec<Field> = vec![];
     let node_fields = if node.is_error() {
         &empty

--- a/crates/language/src/csharp.rs
+++ b/crates/language/src/csharp.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str =
     include_str!("../../../resources/node-types/csharp-node-types.json");
@@ -41,6 +41,12 @@ impl CSharp {
     }
 }
 
+impl NodeTypes for CSharp {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for CSharp {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -52,10 +58,6 @@ impl Language for CSharp {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/css.rs
+++ b/crates/language/src/css.rs
@@ -1,7 +1,9 @@
 use std::sync::OnceLock;
 
 use crate::{
-    language::{default_parse_file, fields_for_nodes, Field, Language, SortId, TSLanguage},
+    language::{
+        default_parse_file, fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage,
+    },
     vue::get_vue_ranges,
 };
 use anyhow::anyhow;
@@ -49,6 +51,12 @@ impl Css {
     }
 }
 
+impl NodeTypes for Css {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Css {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -63,10 +71,6 @@ impl Language for Css {
             ("GRIT_BLOCK { ", " }"),
             ("GRIT_BLOCK { GRIT_PROPERTY: ", " }"),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/go.rs
+++ b/crates/language/src/go.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/go-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
@@ -40,6 +40,12 @@ impl Go {
     }
 }
 
+impl NodeTypes for Go {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Go {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -56,10 +62,6 @@ impl Language for Go {
             ("func GRIT_FUNC(GRIT_ARG *", ".GRIT_TYPE) {}"),
             ("func GRIT_FUNC(GRIT_ARG *GRIT_PACKAGE.", ") {}"),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/grit_ts_node.rs
+++ b/crates/language/src/grit_ts_node.rs
@@ -1,11 +1,26 @@
-use crate::language::{fields_for_nodes, Field, TSLanguage};
+use crate::language::{fields_for_nodes, Field, NodeTypes, TSLanguage};
 use lazy_static::lazy_static;
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/grit-node-types.json");
 
 lazy_static! {
-    pub static ref GRIT_NODE_TYPES: Vec<Vec<Field>> =
-        fields_for_nodes(&language(), NODE_TYPES_STRING);
+    static ref GRIT_NODE_TYPES: Vec<Vec<Field>> = fields_for_nodes(&language(), NODE_TYPES_STRING);
+}
+
+pub struct GritNodeTypes {
+    node_types: &'static [Vec<Field>],
+}
+
+impl NodeTypes for GritNodeTypes {
+    fn node_types(&self) -> &[Vec<Field>] {
+        &self.node_types
+    }
+}
+
+pub fn grit_node_types() -> GritNodeTypes {
+    GritNodeTypes {
+        node_types: &GRIT_NODE_TYPES,
+    }
 }
 
 #[cfg(not(feature = "builtin-parser"))]

--- a/crates/language/src/grit_ts_node.rs
+++ b/crates/language/src/grit_ts_node.rs
@@ -13,7 +13,7 @@ pub struct GritNodeTypes {
 
 impl NodeTypes for GritNodeTypes {
     fn node_types(&self) -> &[Vec<Field>] {
-        &self.node_types
+        self.node_types
     }
 }
 

--- a/crates/language/src/hcl.rs
+++ b/crates/language/src/hcl.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/hcl-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
@@ -43,6 +43,12 @@ impl Hcl {
     }
 }
 
+impl NodeTypes for Hcl {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Hcl {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -53,10 +59,6 @@ impl Language for Hcl {
     }
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", ""), ("GRIT_VAL = ", ""), ("GRIT_ID = { ", " }")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/html-node-types.json");
 
@@ -41,6 +41,12 @@ impl Html {
     }
 }
 
+impl NodeTypes for Html {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Html {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -51,10 +57,6 @@ impl Language for Html {
     }
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/java.rs
+++ b/crates/language/src/java.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/java-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
@@ -23,6 +23,12 @@ pub struct Java {
     metavariable_sort: SortId,
     comment_sorts: [SortId; 2],
     language: &'static TSLanguage,
+}
+
+impl NodeTypes for Java {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
 }
 
 impl Java {
@@ -62,10 +68,6 @@ impl Language for Java {
             ("class GRIT_CLASS { ", " GRIT_FUNCTION() {} }"),
             ("class GRIT_CLASS { GRIT_FN(", ") {} }"),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/javascript.rs
+++ b/crates/language/src/javascript.rs
@@ -1,7 +1,7 @@
 use crate::{
     language::{
-        fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, Replacement,
-        SortId, TSLanguage,
+        fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, NodeTypes,
+        Replacement, SortId, TSLanguage,
     },
     xscript_util::{
         self, js_like_get_statement_sorts, js_optional_empty_field_compilation,
@@ -75,6 +75,12 @@ impl JavaScript {
     }
 }
 
+impl NodeTypes for JavaScript {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for JavaScript {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -123,10 +129,6 @@ impl Language for JavaScript {
             ("import { ", " } from 'GRIT_PACKAGE'"),
             ("function GRIT_FN(GRIT_ARG", ") { }"),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn is_comment(&self, id: SortId) -> bool {

--- a/crates/language/src/json.rs
+++ b/crates/language/src/json.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/json-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
@@ -22,6 +22,12 @@ pub struct Json {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
     language: &'static TSLanguage,
+}
+
+impl NodeTypes for Json {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
 }
 
 impl Json {
@@ -50,10 +56,6 @@ impl Language for Json {
     }
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", ""), ("{ ", " }")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -171,8 +171,12 @@ pub(crate) fn kind_and_field_id_for_names(
         .collect()
 }
 
+pub trait NodeTypes {
+    fn node_types(&self) -> &[Vec<Field>];
+}
+
 #[enum_dispatch(TargetLanguage)]
-pub trait Language {
+pub trait Language: NodeTypes {
     /// tree sitter language to parse the source
     fn get_ts_language(&self) -> &TSLanguage;
 
@@ -304,8 +308,6 @@ pub trait Language {
             _metavariable_sort: self.metavariable_sort(),
         }
     }
-
-    fn node_types(&self) -> &[Vec<Field>];
 
     fn metavariable_sort(&self) -> SortId;
 

--- a/crates/language/src/markdown_block.rs
+++ b/crates/language/src/markdown_block.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str =
     include_str!("../../../resources/node-types/markdown-block-node-types.json");
@@ -24,6 +24,12 @@ pub struct MarkdownBlock {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
     language: &'static TSLanguage,
+}
+
+impl NodeTypes for MarkdownBlock {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
 }
 
 impl MarkdownBlock {
@@ -53,10 +59,6 @@ impl Language for MarkdownBlock {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/markdown_inline.rs
+++ b/crates/language/src/markdown_inline.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str =
     include_str!("../../../resources/node-types/markdown-inline-node-types.json");
@@ -42,6 +42,12 @@ impl MarkdownInline {
     }
 }
 
+impl NodeTypes for MarkdownInline {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for MarkdownInline {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -53,10 +59,6 @@ impl Language for MarkdownInline {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/php.rs
+++ b/crates/language/src/php.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::sync::OnceLock;
 
 use crate::{
-    language::{fields_for_nodes, Field, Language, SortId, TSLanguage},
+    language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage},
     xscript_util::{
         php_like_exact_variable_regex, php_like_metavariable_bracket_regex,
         php_like_metavariable_prefix, php_like_metavariable_regex, PHP_CODE_SNIPPETS,
@@ -48,6 +48,12 @@ impl Php {
     }
 }
 
+impl NodeTypes for Php {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Php {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -62,10 +68,6 @@ impl Language for Php {
     }
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &PHP_CODE_SNIPPETS
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/php_only.rs
+++ b/crates/language/src/php_only.rs
@@ -1,16 +1,16 @@
-use std::sync::OnceLock;
 use regex::Regex;
-
+use std::sync::OnceLock;
 
 use crate::{
-    language::{
-        fields_for_nodes, Field, Language, SortId, TSLanguage
-    }, xscript_util::{
-        php_like_exact_variable_regex, php_like_metavariable_bracket_regex, php_like_metavariable_prefix, php_like_metavariable_regex, PHP_ONLY_CODE_SNIPPETS
-    }
+    language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage},
+    xscript_util::{
+        php_like_exact_variable_regex, php_like_metavariable_bracket_regex,
+        php_like_metavariable_prefix, php_like_metavariable_regex, PHP_ONLY_CODE_SNIPPETS,
+    },
 };
 
-static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/php_only-node-types.json");
+static NODE_TYPES_STRING: &str =
+    include_str!("../../../resources/node-types/php_only-node-types.json");
 
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
 static LANGUAGE: OnceLock<TSLanguage> = OnceLock::new();
@@ -49,6 +49,12 @@ impl PhpOnly {
     }
 }
 
+impl NodeTypes for PhpOnly {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for PhpOnly {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -63,10 +69,6 @@ impl Language for PhpOnly {
     }
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &PHP_ONLY_CODE_SNIPPETS
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/python.rs
+++ b/crates/language/src/python.rs
@@ -1,4 +1,6 @@
-use crate::language::{fields_for_nodes, Field, Language, Replacement, SortId, TSLanguage};
+use crate::language::{
+    fields_for_nodes, Field, Language, NodeTypes, Replacement, SortId, TSLanguage,
+};
 use grit_util::AstNode;
 use marzano_util::node_with_source::NodeWithSource;
 use std::sync::OnceLock;
@@ -45,6 +47,12 @@ impl Python {
     }
 }
 
+impl NodeTypes for Python {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Python {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -65,10 +73,6 @@ impl Language for Python {
             ("", "\ndef GRIT_FUNCTION():\n    return;"),
             ("GRIT_FN(", ")"),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/ruby.rs
+++ b/crates/language/src/ruby.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/ruby-node-types.json");
 
@@ -41,6 +41,12 @@ impl Ruby {
     }
 }
 
+impl NodeTypes for Ruby {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Ruby {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -55,10 +61,6 @@ impl Language for Ruby {
     }
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/rust.rs
+++ b/crates/language/src/rust.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, FieldId, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, FieldId, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/rust-node-types.json");
 
@@ -80,6 +80,12 @@ impl Rust {
     }
 }
 
+impl NodeTypes for Rust {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Rust {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -106,10 +112,6 @@ impl Language for Rust {
             ("fn GRIT_FN(", ") {}"),
             ("fn GRIT_FN(GRIT_ARG:", ") { }"),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/solidity.rs
+++ b/crates/language/src/solidity.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str =
     include_str!("../../../resources/node-types/solidity-node-types.json");
@@ -44,6 +44,12 @@ impl Solidity {
     }
 }
 
+impl NodeTypes for Solidity {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Solidity {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -58,10 +64,6 @@ impl Language for Solidity {
             ("function GRIT_FUNCTION() { ", " }"),
             ("function GRIT_FUNCTION() { ", "; }"),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/sql.rs
+++ b/crates/language/src/sql.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/sql-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
@@ -40,6 +40,12 @@ impl Sql {
     }
 }
 
+impl NodeTypes for Sql {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Sql {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -63,10 +69,6 @@ impl Language for Sql {
                 ";",
             ),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -1,5 +1,5 @@
-use crate::language::Replacement;
 use crate::language::{GritMetaValue, LeafEquivalenceClass, SnippetTree, TSLanguage};
+use crate::language::{NodeTypes, Replacement};
 use crate::{
     csharp::CSharp,
     css::Css,
@@ -455,6 +455,35 @@ pub fn expand_paths(
 
     let final_walker = file_walker.standard_filters(true).hidden(false).build();
     Ok(final_walker)
+}
+
+impl NodeTypes for TargetLanguage {
+    fn node_types(&self) -> &[Vec<Field>] {
+        match self {
+            TargetLanguage::JavaScript(l) => l.node_types(),
+            TargetLanguage::TypeScript(l) => l.node_types(),
+            TargetLanguage::Tsx(l) => l.node_types(),
+            TargetLanguage::Html(l) => l.node_types(),
+            TargetLanguage::Css(l) => l.node_types(),
+            TargetLanguage::Json(l) => l.node_types(),
+            TargetLanguage::Java(l) => l.node_types(),
+            TargetLanguage::CSharp(l) => l.node_types(),
+            TargetLanguage::Python(l) => l.node_types(),
+            TargetLanguage::MarkdownBlock(l) => l.node_types(),
+            TargetLanguage::MarkdownInline(l) => l.node_types(),
+            TargetLanguage::Go(l) => l.node_types(),
+            TargetLanguage::Rust(l) => l.node_types(),
+            TargetLanguage::Ruby(l) => l.node_types(),
+            TargetLanguage::Solidity(l) => l.node_types(),
+            TargetLanguage::Hcl(l) => l.node_types(),
+            TargetLanguage::Yaml(l) => l.node_types(),
+            TargetLanguage::Vue(l) => l.node_types(),
+            TargetLanguage::Toml(l) => l.node_types(),
+            TargetLanguage::Sql(l) => l.node_types(),
+            TargetLanguage::Php(l) => l.node_types(),
+            TargetLanguage::PhpOnly(l) => l.node_types(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/language/src/toml.rs
+++ b/crates/language/src/toml.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/toml-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
@@ -40,6 +40,12 @@ impl Toml {
     }
 }
 
+impl NodeTypes for Toml {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Toml {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -50,10 +56,6 @@ impl Language for Toml {
     }
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/tsx.rs
+++ b/crates/language/src/tsx.rs
@@ -2,8 +2,8 @@ use std::{borrow::Cow, sync::OnceLock};
 
 use crate::{
     language::{
-        fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, Replacement,
-        SortId, TSLanguage,
+        fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, NodeTypes,
+        Replacement, SortId, TSLanguage,
     },
     xscript_util::{
         self, js_like_optional_empty_field_compilation, js_like_skip_snippet_compilation_sorts,
@@ -73,6 +73,12 @@ impl Tsx {
     }
 }
 
+impl NodeTypes for Tsx {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Tsx {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -123,10 +129,6 @@ impl Language for Tsx {
             ("function GRIT_FN(GRIT_ARG", ") { }"),
             ("GRIT_FN<{ ", " }>();"),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn is_comment(&self, id: SortId) -> bool {

--- a/crates/language/src/typescript.rs
+++ b/crates/language/src/typescript.rs
@@ -2,7 +2,8 @@ use std::borrow::Cow;
 use std::sync::OnceLock;
 
 use crate::language::{
-    fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, SortId, TSLanguage,
+    fields_for_nodes, kind_and_field_id_for_names, Field, FieldId, Language, NodeTypes, SortId,
+    TSLanguage,
 };
 use crate::xscript_util::{
     self, js_like_get_statement_sorts, js_like_optional_empty_field_compilation,
@@ -74,6 +75,12 @@ impl TypeScript {
     }
 }
 
+impl NodeTypes for TypeScript {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for TypeScript {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -124,10 +131,6 @@ impl Language for TypeScript {
             ("function GRIT_FN(GRIT_ARG", ") { }"),
             ("GRIT_FN<{ ", " }>();"),
         ]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn is_comment(&self, id: SortId) -> bool {

--- a/crates/language/src/vue.rs
+++ b/crates/language/src/vue.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::language::{fields_for_nodes, Field, Language, SortId, TSLanguage};
+use crate::language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/vue-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
@@ -44,6 +44,12 @@ impl Vue {
     }
 }
 
+impl NodeTypes for Vue {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Vue {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -54,10 +60,6 @@ impl Language for Vue {
     }
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/language/src/yaml.rs
+++ b/crates/language/src/yaml.rs
@@ -2,7 +2,7 @@ use std::{sync::OnceLock, vec};
 
 use crate::language::{
     fields_for_nodes, normalize_double_quote_string, normalize_identity, Field, Language,
-    LeafEquivalenceClass, LeafNormalizer, SortId, TSLanguage,
+    LeafEquivalenceClass, LeafNormalizer, NodeTypes, SortId, TSLanguage,
 };
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/yaml-node-types.json");
@@ -58,6 +58,12 @@ impl Yaml {
     }
 }
 
+impl NodeTypes for Yaml {
+    fn node_types(&self) -> &[Vec<Field>] {
+        self.node_types
+    }
+}
+
 impl Language for Yaml {
     fn get_ts_language(&self) -> &TSLanguage {
         self.language
@@ -72,10 +78,6 @@ impl Language for Yaml {
     }
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn node_types(&self) -> &[Vec<Field>] {
-        self.node_types
     }
 
     fn metavariable_sort(&self) -> SortId {

--- a/crates/wasm-bindings/src/match_pattern.rs
+++ b/crates/wasm-bindings/src/match_pattern.rs
@@ -78,7 +78,7 @@ pub async fn parse_input_files(
     let ParsedPattern { libs, tree, lang } =
         get_parsed_pattern(&pattern, lib_paths, lib_contents, parser).await?;
     let node = tree.root_node();
-    let parsed_pattern = tree_sitter_node_to_json(&node, &pattern, Some(&lang)).to_string();
+    let parsed_pattern = tree_sitter_node_to_json(&node, &pattern, &lang).to_string();
 
     let mut results: Vec<MatchResult> = Vec::new();
     for (path, content) in paths.into_iter().zip(contents) {
@@ -86,7 +86,7 @@ pub async fn parse_input_files(
         let mut parser = setup_language_parser((&lang).into()).await?;
         let tree = parser.parse(content.as_bytes(), None).unwrap().unwrap();
         let input_file_debug_text =
-            tree_sitter_node_to_json(&tree.root_node(), &content, Some(&lang)).to_string();
+            tree_sitter_node_to_json(&tree.root_node(), &content, &lang).to_string();
         let input_file = InputFile {
             source_file: path.to_string_lossy().to_string(),
             syntax_tree: input_file_debug_text,
@@ -106,7 +106,7 @@ pub async fn parse_input_files(
         None,
         parser,
         injected_builtins,
-        None
+        None,
     ) {
         Ok(c) => {
             let warning_logs = c
@@ -230,7 +230,7 @@ pub async fn match_pattern(
         None,
         parser,
         injected_builtins,
-        None
+        None,
     ) {
         Ok(c) => c,
         Err(e) => {


### PR DESCRIPTION
separate out the node types trait so we don't have to hack on defaults for `NodeTypes` that aren't `Languages`, make GRIT_NODE_TYPES global state private.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced language support and code parsing efficiency across multiple programming languages.
	- Improved JSON string generation for syntax trees, enhancing readability and performance.

- **Refactor**
	- Streamlined trait implementations and method assignments in language modules, focusing on node type management.
	- Optimized function calls and parameter handling in core parsing functionalities.

- **Documentation**
	- Updated method documentation inline with new trait implementations and structural changes in language modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->