### PR TITLE
fix: not all comments have sort comment

### DIFF
--- a/crates/core/src/equivalence.rs
+++ b/crates/core/src/equivalence.rs
@@ -1,13 +1,14 @@
 use crate::binding::Binding;
 use grit_util::AstNode;
 use itertools::{EitherOrBoth, Itertools};
+use marzano_language::language::Language;
 use marzano_util::node_with_source::NodeWithSource;
 
 impl<'a> Binding<'a> {
     /// Checks whether two bindings are equivalent.
     ///
     /// Bindings are considered equivalent if they refer to the same thing.
-    pub fn is_equivalent_to(&self, other: &'a Binding) -> bool {
+    pub fn is_equivalent_to(&self, other: &'a Binding, language: &impl Language) -> bool {
         // covers Node, and List with one element
         if let (Some(s1), Some(s2)) = (self.singleton(), other.singleton()) {
             return are_equivalent(&s1, &s2);
@@ -18,7 +19,7 @@ impl<'a> Binding<'a> {
             Self::Node(node1) => match other {
                 Self::Node(node2) => are_equivalent(node1, node2),
                 Self::String(str, range) => {
-                    str[range.start_byte as usize..range.end_byte as usize] == self.text()
+                    str[range.start_byte as usize..range.end_byte as usize] == self.text(language)
                 }
                 Self::FileName(_) | Self::List(..) | Self::Empty(..) | Self::ConstantRef(_) => {
                     false
@@ -51,7 +52,7 @@ impl<'a> Binding<'a> {
             },
             Self::ConstantRef(c1) => other.as_constant().map_or(false, |c2| *c1 == c2),
             Self::String(s1, range) => {
-                s1[range.start_byte as usize..range.end_byte as usize] == other.text()
+                s1[range.start_byte as usize..range.end_byte as usize] == other.text(language)
             }
             Self::FileName(s1) => other.as_filename().map_or(false, |s2| *s1 == s2),
         }

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Result};
+use marzano_language::language::Language;
 use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
 
 use crate::{
@@ -9,13 +10,14 @@ use crate::{
 pub fn debug<Q: QueryContext>(
     analysis_logs: &mut AnalysisLogs,
     state: &State<'_, Q>,
+    lang: &impl Language,
     message: &str,
 ) -> Result<()> {
     let mut builder = AnalysisLogBuilder::default();
     builder.level(501_u16);
     builder.message(message);
 
-    if let Ok(file) = get_file_name(state) {
+    if let Ok(file) = get_file_name(state, lang) {
         builder.file(file);
     }
 

--- a/crates/core/src/pattern/accessor.rs
+++ b/crates/core/src/pattern/accessor.rs
@@ -6,8 +6,12 @@ use super::{
     state::State,
     variable::Variable,
 };
-use crate::{binding::Constant, context::QueryContext};
+use crate::{
+    binding::Constant,
+    context::{ExecContext, QueryContext},
+};
 use anyhow::{bail, Result};
+use marzano_language::language::Language;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::borrow::Cow;
 
@@ -34,20 +38,21 @@ impl<Q: QueryContext> Accessor<Q> {
         Self { map, key }
     }
 
-    fn get_key<'a>(&'a self, state: &State<'a, Q>) -> Result<Cow<'a, str>> {
+    fn get_key<'a>(&'a self, state: &State<'a, Q>, lang: &impl Language) -> Result<Cow<'a, str>> {
         match &self.key {
             AccessorKey::String(s) => Ok(Cow::Borrowed(s)),
-            AccessorKey::Variable(v) => v.text(state),
+            AccessorKey::Variable(v) => v.text(state, lang),
         }
     }
 
     pub(crate) fn get<'a, 'b>(
         &'a self,
         state: &'b State<'a, Q>,
+        lang: &impl Language,
     ) -> Result<Option<PatternOrResolved<'a, 'b, Q>>> {
-        let key = self.get_key(state)?;
+        let key = self.get_key(state, lang)?;
         match &self.map {
-            AccessorMap::Container(c) => match c.get_pattern_or_resolved(state)? {
+            AccessorMap::Container(c) => match c.get_pattern_or_resolved(state, lang)? {
                 None => Ok(None),
                 Some(PatternOrResolved::Pattern(Pattern::Map(m))) => {
                     Ok(m.get(&key).map(PatternOrResolved::Pattern))
@@ -64,10 +69,11 @@ impl<Q: QueryContext> Accessor<Q> {
     pub(crate) fn get_mut<'a, 'b>(
         &'a self,
         state: &'b mut State<'a, Q>,
+        lang: &impl Language,
     ) -> Result<Option<PatternOrResolvedMut<'a, 'b, Q>>> {
-        let key = self.get_key(state)?;
+        let key = self.get_key(state, lang)?;
         match &self.map {
-            AccessorMap::Container(c) => match c.get_pattern_or_resolved_mut(state)? {
+            AccessorMap::Container(c) => match c.get_pattern_or_resolved_mut(state, lang)? {
                 None => Ok(None),
                 Some(PatternOrResolvedMut::Pattern(Pattern::Map(m))) => {
                     Ok(m.get(&key).map(PatternOrResolvedMut::Pattern))
@@ -84,12 +90,13 @@ impl<Q: QueryContext> Accessor<Q> {
     pub(crate) fn set_resolved<'a>(
         &'a self,
         state: &mut State<'a, Q>,
+        lang: &impl Language,
         value: ResolvedPattern<'a>,
     ) -> Result<Option<ResolvedPattern<'a>>> {
         match &self.map {
             AccessorMap::Container(c) => {
-                let key = self.get_key(state)?;
-                match c.get_pattern_or_resolved_mut(state)? {
+                let key = self.get_key(state, lang)?;
+                match c.get_pattern_or_resolved_mut(state, lang)? {
                     None => Ok(None),
                     Some(PatternOrResolvedMut::Resolved(ResolvedPattern::Map(m))) => {
                         Ok(m.insert(key.to_string(), value))
@@ -116,12 +123,12 @@ impl<Q: QueryContext> Matcher<Q> for Accessor<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        match self.get(state)? {
+        match self.get(state, context.language())? {
             Some(PatternOrResolved::Resolved(r)) => {
-                execute_resolved_with_binding(r, binding, state)
+                execute_resolved_with_binding(r, binding, state, context.language())
             }
             Some(PatternOrResolved::ResolvedBinding(r)) => {
-                execute_resolved_with_binding(&r, binding, state)
+                execute_resolved_with_binding(&r, binding, state, context.language())
             }
             Some(PatternOrResolved::Pattern(p)) => p.execute(binding, state, context, logs),
             None => Ok(
@@ -136,15 +143,16 @@ pub(crate) fn execute_resolved_with_binding<'a, Q: QueryContext>(
     r: &ResolvedPattern<'a>,
     binding: &ResolvedPattern<'a>,
     state: &State<'a, Q>,
+    lang: &impl Language,
 ) -> Result<bool> {
     if let ResolvedPattern::Binding(r) = r {
         if let ResolvedPattern::Binding(b) = binding {
             if let (Some(r), Some(b)) = (r.last(), b.last()) {
-                return Ok(r.is_equivalent_to(b));
+                return Ok(r.is_equivalent_to(b, lang));
             } else {
                 bail!("Resolved pattern missing binding")
             }
         }
     }
-    Ok(r.text(&state.files)? == binding.text(&state.files)?)
+    Ok(r.text(&state.files, lang)? == binding.text(&state.files, lang)?)
 }

--- a/crates/core/src/pattern/add.rs
+++ b/crates/core/src/pattern/add.rs
@@ -3,7 +3,10 @@ use super::{
     resolved_pattern::ResolvedPattern,
     state::State,
 };
-use crate::{binding::Constant, context::QueryContext};
+use crate::{
+    binding::Constant,
+    context::{ExecContext, QueryContext},
+};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -55,7 +58,7 @@ impl<Q: QueryContext> Matcher<Q> for Add<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let binding_text = binding.text(&state.files)?;
+        let binding_text = binding.text(&state.files, context.language())?;
         let binding_int = binding_text.parse::<f64>()?;
         let target = self.evaluate(state, context, logs)?;
         Ok(binding_int == target)

--- a/crates/core/src/pattern/after.rs
+++ b/crates/core/src/pattern/after.rs
@@ -3,7 +3,12 @@ use super::{
     resolved_pattern::{pattern_to_binding, ResolvedPattern},
     State,
 };
-use crate::{binding::Constant, context::QueryContext, errors::debug, resolve};
+use crate::{
+    binding::Constant,
+    context::{ExecContext, QueryContext},
+    errors::debug,
+    resolve,
+};
 use anyhow::{bail, Result};
 use core::fmt::Debug;
 use grit_util::AstNode;
@@ -36,6 +41,7 @@ impl<Q: QueryContext> After<Q> {
             debug(
                 logs,
                 state,
+                context.language(),
                 "no node after current node, treating as undefined",
             )?;
             Ok(ResolvedPattern::Constant(Constant::Undefined))

--- a/crates/core/src/pattern/assignment.rs
+++ b/crates/core/src/pattern/assignment.rs
@@ -5,7 +5,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::context::QueryContext;
+use crate::context::{ExecContext, QueryContext};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -36,7 +36,8 @@ impl<Q: QueryContext> Matcher<Q> for Assignment<Q> {
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
         let resolved = ResolvedPattern::from_pattern(&self.pattern, state, context, logs)?;
-        self.container.set_resolved(state, resolved)?;
+        self.container
+            .set_resolved(state, context.language(), resolved)?;
         Ok(true)
     }
 }
@@ -50,7 +51,8 @@ impl<Q: QueryContext> Evaluator<Q> for Assignment<Q> {
     ) -> Result<FuncEvaluation> {
         let resolved: ResolvedPattern<'_> =
             ResolvedPattern::from_pattern(&self.pattern, state, context, logs)?;
-        self.container.set_resolved(state, resolved)?;
+        self.container
+            .set_resolved(state, context.language(), resolved)?;
         Ok(FuncEvaluation {
             predicator: true,
             ret_val: None,

--- a/crates/core/src/pattern/before.rs
+++ b/crates/core/src/pattern/before.rs
@@ -3,7 +3,12 @@ use super::{
     resolved_pattern::{pattern_to_binding, ResolvedPattern},
     State,
 };
-use crate::{binding::Constant, context::QueryContext, errors::debug, resolve};
+use crate::{
+    binding::Constant,
+    context::{ExecContext, QueryContext},
+    errors::debug,
+    resolve,
+};
 use anyhow::{bail, Result};
 use grit_util::AstNode;
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -35,6 +40,7 @@ impl<Q: QueryContext> Before<Q> {
             debug(
                 logs,
                 state,
+                context.language(),
                 "no node before current node, treating as undefined",
             )?;
             Ok(ResolvedPattern::Constant(Constant::Undefined))

--- a/crates/core/src/pattern/boolean_constant.rs
+++ b/crates/core/src/pattern/boolean_constant.rs
@@ -3,7 +3,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     state::State,
 };
-use crate::context::QueryContext;
+use crate::context::{ExecContext, QueryContext};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -29,11 +29,11 @@ impl<Q: QueryContext> Matcher<Q> for BooleanConstant {
         &'a self,
         binding: &ResolvedPattern<'a>,
         state: &mut State<'a, Q>,
-        _context: &'a Q::ExecContext<'a>,
+        context: &'a Q::ExecContext<'a>,
         _logs: &mut AnalysisLogs,
     ) -> Result<bool> {
         binding
-            .is_truthy(state)
+            .is_truthy(state, context.language())
             .map(|truthiness| truthiness == self.value)
     }
 }

--- a/crates/core/src/pattern/built_in_functions.rs
+++ b/crates/core/src/pattern/built_in_functions.rs
@@ -189,9 +189,9 @@ fn resolve_path_fn<'a>(
 ) -> Result<ResolvedPattern<'a>> {
     let args = patterns_to_resolved(args, state, context, logs)?;
 
-    let current_file = get_absolute_file_name(state)?;
+    let current_file = get_absolute_file_name(state, context.language())?;
     let target_path = match &args[0] {
-        Some(resolved_pattern) => resolved_pattern.text(&state.files)?,
+        Some(resolved_pattern) => resolved_pattern.text(&state.files, context.language())?,
         None => return Err(anyhow!("No path argument provided for resolve function")),
     };
 
@@ -217,7 +217,7 @@ fn capitalize_fn<'a>(
     let args = patterns_to_resolved(args, state, context, logs)?;
 
     let s = match &args[0] {
-        Some(resolved_pattern) => resolved_pattern.text(&state.files)?,
+        Some(resolved_pattern) => resolved_pattern.text(&state.files, context.language())?,
         None => return Err(anyhow!("No argument provided for capitalize function")),
     };
     Ok(ResolvedPattern::from_string(capitalize(&s)))
@@ -232,7 +232,7 @@ fn lowercase_fn<'a>(
     let args = patterns_to_resolved(args, state, context, logs)?;
 
     let s = match &args[0] {
-        Some(resolved_pattern) => resolved_pattern.text(&state.files)?,
+        Some(resolved_pattern) => resolved_pattern.text(&state.files, context.language())?,
         None => return Err(anyhow!("lowercase takes 1 argument")),
     };
     Ok(ResolvedPattern::from_string(s.to_lowercase()))
@@ -247,7 +247,7 @@ fn uppercase_fn<'a>(
     let args = patterns_to_resolved(args, state, context, logs)?;
 
     let s = match &args[0] {
-        Some(resolved_pattern) => resolved_pattern.text(&state.files)?,
+        Some(resolved_pattern) => resolved_pattern.text(&state.files, context.language())?,
         None => return Err(anyhow!("uppercase takes 1 argument")),
     };
     Ok(ResolvedPattern::from_string(s.to_uppercase()))
@@ -262,7 +262,7 @@ fn text_fn<'a>(
     let args = patterns_to_resolved(args, state, context, logs)?;
 
     let s = match args.first() {
-        Some(Some(resolved_pattern)) => resolved_pattern.text(&state.files)?,
+        Some(Some(resolved_pattern)) => resolved_pattern.text(&state.files, context.language())?,
         _ => return Err(anyhow!("text takes 1 argument")),
     };
     Ok(ResolvedPattern::from_string(s.to_string()))
@@ -277,12 +277,12 @@ fn trim_fn<'a>(
     let args = patterns_to_resolved(args, state, context, logs)?;
 
     let trim_chars = match &args[1] {
-        Some(resolved_pattern) => resolved_pattern.text(&state.files)?,
+        Some(resolved_pattern) => resolved_pattern.text(&state.files, context.language())?,
         None => return Err(anyhow!("trim takes 2 arguments: string and trim_chars")),
     };
 
     let s = match &args[0] {
-        Some(resolved_pattern) => resolved_pattern.text(&state.files)?,
+        Some(resolved_pattern) => resolved_pattern.text(&state.files, context.language())?,
         None => return Err(anyhow!("trim takes 2 arguments: string and trim_chars")),
     };
 
@@ -301,12 +301,12 @@ fn split_fn<'a>(
     let args = patterns_to_resolved(args, state, context, logs)?;
 
     let string = if let Some(string) = &args[0] {
-        string.text(&state.files)?
+        string.text(&state.files, context.language())?
     } else {
         bail!("split requires parameter string")
     };
     let separator = if let Some(separator) = &args[1] {
-        separator.text(&state.files)?
+        separator.text(&state.files, context.language())?
     } else {
         bail!("split requires parameter separator")
     };
@@ -327,8 +327,8 @@ fn random_fn<'a>(
 
     match args.as_slice() {
         [Some(start), Some(end)] => {
-            let start = start.text(&state.files)?;
-            let end = end.text(&state.files)?;
+            let start = start.text(&state.files, context.language())?;
+            let end = end.text(&state.files, context.language())?;
             let start = start.parse::<i64>().unwrap();
             let end = end.parse::<i64>().unwrap();
             // Inclusive range
@@ -359,7 +359,7 @@ fn join_fn<'a>(
 
     let separator = &args[1];
     let separator = match separator {
-        Some(resolved_pattern) => resolved_pattern.text(&state.files)?,
+        Some(resolved_pattern) => resolved_pattern.text(&state.files, context.language())?,
         None => return Err(anyhow!("trim takes 2 arguments: list and separator")),
     };
 
@@ -484,14 +484,14 @@ fn length_fn<'a>(
                 let length = if let Some(list_items) = resolved_pattern.list_items() {
                     list_items.count()
                 } else {
-                    resolved_pattern.text().len()
+                    resolved_pattern.text(context.language()).len()
                 };
                 Ok(ResolvedPattern::Constant(Constant::Integer(length as i64)))
             }
             None => Err(anyhow!("length argument must be a list or string")),
         },
         Some(resolved_pattern) => {
-            if let Ok(text) = resolved_pattern.text(&state.files) {
+            if let Ok(text) = resolved_pattern.text(&state.files, context.language()) {
                 let length = text.len();
                 Ok(ResolvedPattern::Constant(Constant::Integer(length as i64)))
             } else {

--- a/crates/core/src/pattern/code_snippet.rs
+++ b/crates/core/src/pattern/code_snippet.rs
@@ -4,7 +4,10 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{context::QueryContext, resolve};
+use crate::{
+    context::{ExecContext, QueryContext},
+    resolve,
+};
 use anyhow::Result;
 use core::fmt::Debug;
 use marzano_language::language::SortId;
@@ -54,7 +57,7 @@ impl<Q: QueryContext> Matcher<Q> for CodeSnippet<Q> {
             | resolved @ ResolvedPattern::File(_)
             | resolved @ ResolvedPattern::Files(_)
             | resolved @ ResolvedPattern::Constant(_) => {
-                return Ok(resolved.text(&state.files)?.trim() == self.source)
+                return Ok(resolved.text(&state.files, context.language())?.trim() == self.source)
             }
         };
 

--- a/crates/core/src/pattern/container.rs
+++ b/crates/core/src/pattern/container.rs
@@ -5,6 +5,7 @@ use super::{
     resolved_pattern::ResolvedPattern, state::State, variable::Variable,
 };
 use anyhow::Result;
+use marzano_language::language::Language;
 
 /// A `Container` represents anything which "contains" a reference to a Pattern.
 ///
@@ -37,6 +38,7 @@ impl<Q: QueryContext> Container<Q> {
     pub(crate) fn set_resolved<'a>(
         &'a self,
         state: &mut State<'a, Q>,
+        lang: &impl Language,
         value: ResolvedPattern<'a>,
     ) -> Result<Option<ResolvedPattern<'a>>> {
         match self {
@@ -44,35 +46,37 @@ impl<Q: QueryContext> Container<Q> {
                 let var = state.trace_var(v);
                 let content = &mut state.bindings[var.scope].back_mut().unwrap()[var.index];
                 match content.pattern {
-                    Some(Pattern::Accessor(a)) => a.set_resolved(state, value),
-                    Some(Pattern::ListIndex(l)) => l.set_resolved(state, value),
+                    Some(Pattern::Accessor(a)) => a.set_resolved(state, lang, value),
+                    Some(Pattern::ListIndex(l)) => l.set_resolved(state, lang, value),
                     None | Some(_) => Ok(content.set_value(value)),
                 }
             }
-            Container::Accessor(a) => a.set_resolved(state, value),
-            Container::ListIndex(l) => l.set_resolved(state, value),
+            Container::Accessor(a) => a.set_resolved(state, lang, value),
+            Container::ListIndex(l) => l.set_resolved(state, lang, value),
         }
     }
 
     pub(crate) fn get_pattern_or_resolved<'a, 'b>(
         &'a self,
         state: &'b State<'a, Q>,
+        lang: &impl Language,
     ) -> Result<Option<PatternOrResolved<'a, 'b, Q>>> {
         match self {
             Container::Variable(v) => v.get_pattern_or_resolved(state),
-            Container::Accessor(a) => a.get(state),
-            Container::ListIndex(a) => a.get(state),
+            Container::Accessor(a) => a.get(state, lang),
+            Container::ListIndex(a) => a.get(state, lang),
         }
     }
 
     pub(crate) fn get_pattern_or_resolved_mut<'a, 'b>(
         &'a self,
         state: &'b mut State<'a, Q>,
+        lang: &impl Language,
     ) -> Result<Option<PatternOrResolvedMut<'a, 'b, Q>>> {
         match self {
             Container::Variable(v) => v.get_pattern_or_resolved_mut(state),
-            Container::Accessor(a) => a.get_mut(state),
-            Container::ListIndex(l) => l.get_mut(state),
+            Container::Accessor(a) => a.get_mut(state, lang),
+            Container::ListIndex(l) => l.get_mut(state, lang),
         }
     }
 }

--- a/crates/core/src/pattern/divide.rs
+++ b/crates/core/src/pattern/divide.rs
@@ -3,7 +3,10 @@ use super::{
     resolved_pattern::ResolvedPattern,
     state::State,
 };
-use crate::{binding::Constant, context::QueryContext};
+use crate::{
+    binding::Constant,
+    context::{ExecContext, QueryContext},
+};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -55,7 +58,7 @@ impl<Q: QueryContext> Matcher<Q> for Divide<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let binding_text = binding.text(&state.files)?;
+        let binding_text = binding.text(&state.files, context.language())?;
         let binding_int = binding_text.parse::<f64>()?;
         let target = self.evaluate(state, context, logs)?;
         Ok(binding_int == target)

--- a/crates/core/src/pattern/dynamic_snippet.rs
+++ b/crates/core/src/pattern/dynamic_snippet.rs
@@ -8,7 +8,7 @@ use super::{
     variable::Variable,
     State,
 };
-use crate::context::QueryContext;
+use crate::context::{ExecContext, QueryContext};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -48,7 +48,7 @@ impl<Q: QueryContext> DynamicPattern<Q> {
         logs: &mut AnalysisLogs,
     ) -> Result<String> {
         let resolved = ResolvedPattern::from_dynamic_pattern(self, state, context, logs)?;
-        Ok(resolved.text(&state.files)?.to_string())
+        Ok(resolved.text(&state.files, context.language())?.to_string())
     }
 }
 
@@ -66,7 +66,7 @@ impl<Q: QueryContext> Matcher<Q> for DynamicPattern<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        if binding.text(&state.files)? == self.text(state, context, logs)? {
+        if binding.text(&state.files, context.language())? == self.text(state, context, logs)? {
             Ok(true)
         } else {
             Ok(false)

--- a/crates/core/src/pattern/equal.rs
+++ b/crates/core/src/pattern/equal.rs
@@ -4,7 +4,7 @@ use super::{
     variable::Variable,
     State,
 };
-use crate::context::QueryContext;
+use crate::context::{ExecContext, QueryContext};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -33,7 +33,7 @@ impl<Q: QueryContext> Evaluator<Q> for Equal<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<FuncEvaluation> {
-        let lhs_text = self.var.text(state)?;
+        let lhs_text = self.var.text(state, context.language())?;
         let rhs_text = self.pattern.text(state, context, logs)?;
         Ok(FuncEvaluation {
             predicator: lhs_text == rhs_text,

--- a/crates/core/src/pattern/float_constant.rs
+++ b/crates/core/src/pattern/float_constant.rs
@@ -3,7 +3,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     state::State,
 };
-use crate::context::QueryContext;
+use crate::context::{ExecContext, QueryContext};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -29,10 +29,10 @@ impl<Q: QueryContext> Matcher<Q> for FloatConstant {
         &'a self,
         binding: &ResolvedPattern<'a>,
         state: &mut State<'a, Q>,
-        _context: &'a Q::ExecContext<'a>,
+        context: &'a Q::ExecContext<'a>,
         _logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let text = binding.text(&state.files)?;
+        let text = binding.text(&state.files, context.language())?;
         let parsed_double = text.parse::<f64>()?;
         Ok(parsed_double == self.value)
     }

--- a/crates/core/src/pattern/function_definition.rs
+++ b/crates/core/src/pattern/function_definition.rs
@@ -13,7 +13,10 @@ use super::{
     target_arch = "wasm32"
 ))]
 use crate::context::ExecContext;
-use crate::{binding::Constant, context::QueryContext};
+use crate::{
+    binding::Constant,
+    context::{ExecContext, QueryContext},
+};
 use anyhow::{bail, Result};
 #[cfg(feature = "external_functions")]
 use marzano_externals::function::ExternalFunction;
@@ -126,7 +129,7 @@ impl<Q: QueryContext> FunctionDefinition<Q> for ForeignFunctionDefinition {
 
         for r in resolved.iter() {
             match r {
-                Some(r) => match r.text(&state.files) {
+                Some(r) => match r.text(&state.files, context.language()) {
                     Ok(t) => cow_resolved.push(t),
                     Err(e) => bail!("failed to get text from resolved pattern: {}", e),
                 },

--- a/crates/core/src/pattern/function_definition.rs
+++ b/crates/core/src/pattern/function_definition.rs
@@ -6,13 +6,6 @@ use super::{
     state::State,
     variable::Variable,
 };
-#[cfg(all(
-    feature = "network_requests_external",
-    feature = "external_functions_ffi",
-    not(feature = "network_requests"),
-    target_arch = "wasm32"
-))]
-use crate::context::ExecContext;
 use crate::{
     binding::Constant,
     context::{ExecContext, QueryContext},

--- a/crates/core/src/pattern/includes.rs
+++ b/crates/core/src/pattern/includes.rs
@@ -3,7 +3,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::context::QueryContext;
+use crate::context::{ExecContext, QueryContext};
 use anyhow::{Context as _, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -111,10 +111,10 @@ fn execute<'a, Q: QueryContext>(
         | Pattern::Like(_) => {
             let resolved = ResolvedPattern::from_pattern(pattern, state, context, logs)
                 .context("includes can only be used with patterns that can be resolved")?;
-            let substring = resolved.text(&state.files).context(
+            let substring = resolved.text(&state.files, context.language()).context(
                 "includes can only be used with patterns that can be resolved to a string",
             )?;
-            let string = binding.text(&state.files).context(
+            let string = binding.text(&state.files, context.language()).context(
                 "includes can only be used with patterns that can be resolved to a string",
             )?;
             if string.contains(&*substring) {

--- a/crates/core/src/pattern/int_constant.rs
+++ b/crates/core/src/pattern/int_constant.rs
@@ -3,7 +3,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     state::State,
 };
-use crate::context::QueryContext;
+use crate::context::{ExecContext, QueryContext};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -29,10 +29,10 @@ impl<Q: QueryContext> Matcher<Q> for IntConstant {
         &'a self,
         binding: &ResolvedPattern<'a>,
         state: &mut State<'a, Q>,
-        _context: &'a Q::ExecContext<'a>,
+        context: &'a Q::ExecContext<'a>,
         _logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let text = binding.text(&state.files)?;
+        let text = binding.text(&state.files, context.language())?;
         let parsed_int = text.parse::<i64>()?;
         Ok(parsed_int == self.value)
     }

--- a/crates/core/src/pattern/match.rs
+++ b/crates/core/src/pattern/match.rs
@@ -5,7 +5,10 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{context::QueryContext, errors::debug};
+use crate::{
+    context::{ExecContext, QueryContext},
+    errors::debug,
+};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -56,7 +59,7 @@ impl<Q: QueryContext> Evaluator<Q> for Match<Q> {
                                     "Attempted to match against undefined variable {}",
                                     state.get_name(&var)
                                 );
-                                debug(logs, state, message.as_str())?;
+                                debug(logs, state, context.language(), message.as_str())?;
                             }
                             res
                         }
@@ -68,7 +71,7 @@ impl<Q: QueryContext> Evaluator<Q> for Match<Q> {
                                 "Attempted to match against undefined variable {}",
                                 state.get_name(&var)
                             );
-                            debug(logs, state, message.as_str())?;
+                            debug(logs, state, context.language(), message.as_str())?;
                         }
                         res
                     }

--- a/crates/core/src/pattern/modulo.rs
+++ b/crates/core/src/pattern/modulo.rs
@@ -3,7 +3,10 @@ use super::{
     resolved_pattern::ResolvedPattern,
     state::State,
 };
-use crate::{binding::Constant, context::QueryContext};
+use crate::{
+    binding::Constant,
+    context::{ExecContext, QueryContext},
+};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -57,7 +60,7 @@ impl<Q: QueryContext> Matcher<Q> for Modulo<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let binding_text = binding.text(&state.files)?;
+        let binding_text = binding.text(&state.files, context.language())?;
         let binding_int = binding_text.parse::<i64>()?;
         let target = self.evaluate(state, context, logs)?;
         Ok(binding_int == target)

--- a/crates/core/src/pattern/multiply.rs
+++ b/crates/core/src/pattern/multiply.rs
@@ -3,7 +3,10 @@ use super::{
     resolved_pattern::ResolvedPattern,
     state::State,
 };
-use crate::{binding::Constant, context::QueryContext};
+use crate::{
+    binding::Constant,
+    context::{ExecContext, QueryContext},
+};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -55,7 +58,7 @@ impl<Q: QueryContext> Matcher<Q> for Multiply<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let binding_text = binding.text(&state.files)?;
+        let binding_text = binding.text(&state.files, context.language())?;
         let binding_int = binding_text.parse::<f64>()?;
         let target = self.evaluate(state, context, logs)?;
         Ok(binding_int == target)

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -49,7 +49,7 @@ use super::{
     within::Within,
     State,
 };
-use crate::context::QueryContext;
+use crate::context::{ExecContext, QueryContext};
 use anyhow::{bail, Result};
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -143,7 +143,7 @@ impl<Q: QueryContext> Pattern<Q> {
         logs: &mut AnalysisLogs,
     ) -> Result<String> {
         Ok(ResolvedPattern::from_pattern(self, state, context, logs)?
-            .text(&state.files)?
+            .text(&state.files, context.language())?
             .to_string())
     }
 
@@ -153,7 +153,8 @@ impl<Q: QueryContext> Pattern<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<f64> {
-        ResolvedPattern::from_pattern(self, state, context, logs)?.float(&state.files)
+        ResolvedPattern::from_pattern(self, state, context, logs)?
+            .float(&state.files, context.language())
     }
 }
 
@@ -229,7 +230,7 @@ impl<Q: QueryContext> Matcher<Q> for Pattern<Q> {
             state.bindings[GLOBAL_VARS_SCOPE_INDEX].back_mut().unwrap()[FILENAME_INDEX].value =
                 Some(file.name(&state.files));
             state.bindings[GLOBAL_VARS_SCOPE_INDEX].back_mut().unwrap()[ABSOLUTE_PATH_INDEX]
-                .value = Some(file.absolute_path(&state.files)?);
+                .value = Some(file.absolute_path(&state.files, context.language())?);
             state.bindings[GLOBAL_VARS_SCOPE_INDEX].back_mut().unwrap()[PROGRAM_INDEX].value =
                 Some(file.binding(&state.files));
         }

--- a/crates/core/src/pattern/range.rs
+++ b/crates/core/src/pattern/range.rs
@@ -3,7 +3,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     state::State,
 };
-use crate::context::QueryContext;
+use crate::context::{ExecContext, QueryContext};
 use anyhow::{anyhow, Result};
 use marzano_util::analysis_logs::AnalysisLogs;
 use marzano_util::position::UtilRange;
@@ -69,10 +69,10 @@ impl<Q: QueryContext> Matcher<Q> for Range {
         &'a self,
         binding: &ResolvedPattern<'a>,
         _state: &mut State<'a, Q>,
-        _context: &'a Q::ExecContext<'a>,
+        context: &'a Q::ExecContext<'a>,
         _logs: &mut AnalysisLogs,
     ) -> anyhow::Result<bool> {
-        if let Some(range) = binding.position() {
+        if let Some(range) = binding.position(context.language()) {
             if let Some(start) = &self.start {
                 if start.line > range.start.line {
                     return Ok(false);

--- a/crates/core/src/pattern/state.rs
+++ b/crates/core/src/pattern/state.rs
@@ -87,7 +87,7 @@ fn get_top_level_effect_ranges<'a>(
         .filter(|effect| {
             let binding = &effect.binding;
             if let Some(src) = binding.source() {
-                if let Some(binding_range) = binding.code_range() {
+                if let Some(binding_range) = binding.code_range(language) {
                     range.applies_to(src) && !matches!(memo.get(&binding_range), Some(None))
                 } else {
                     let _ = binding.log_empty_field_rewrite_error(language, logs);
@@ -100,7 +100,7 @@ fn get_top_level_effect_ranges<'a>(
         .map(|effect| {
             let binding = &effect.binding;
             let ts_range = binding
-                .position()
+                .position(language)
                 .ok_or_else(|| anyhow!("binding has no position"))?;
             let end_byte = ts_range.end_byte;
             let start_byte = ts_range.start_byte;
@@ -243,7 +243,7 @@ impl<'a, Q: QueryContext> State<'a, Q> {
                                 suppressed_count += 1;
                                 continue;
                             }
-                            if let Some(match_position) = binding.position() {
+                            if let Some(match_position) = binding.position(lang) {
                                 // TODO, this check only needs to be done at the global scope right?
                                 if name == MATCH_VAR {
                                     // apply_match = true;

--- a/crates/core/src/pattern/step.rs
+++ b/crates/core/src/pattern/step.rs
@@ -184,11 +184,15 @@ impl<Q: QueryContext> Matcher<Q> for Step<Q> {
                 if let ResolvedPattern::File(file) = f {
                     let name: PathBuf = file
                         .name(&state.files)
-                        .text(&state.files)
+                        .text(&state.files, context.language())
                         .unwrap()
                         .as_ref()
                         .into();
-                    let body = file.body(&state.files).text(&state.files).unwrap().into();
+                    let body = file
+                        .body(&state.files)
+                        .text(&state.files, context.language())
+                        .unwrap()
+                        .into();
                     let owned_file =
                         FileOwner::new(name.clone(), body, None, true, context.language(), logs)?
                             .ok_or_else(|| {

--- a/crates/core/src/pattern/string_constant.rs
+++ b/crates/core/src/pattern/string_constant.rs
@@ -3,7 +3,10 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{binding::Binding, context::QueryContext};
+use crate::{
+    binding::Binding,
+    context::{ExecContext, QueryContext},
+};
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use grit_util::AstNode;
@@ -34,10 +37,10 @@ impl<Q: QueryContext> Matcher<Q> for StringConstant {
         &'a self,
         binding: &ResolvedPattern<'a>,
         state: &mut State<'a, Q>,
-        _context: &'a Q::ExecContext<'a>,
+        context: &'a Q::ExecContext<'a>,
         _logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let text = binding.text(&state.files)?;
+        let text = binding.text(&state.files, context.language())?;
         if text == self.text {
             Ok(true)
         } else {

--- a/crates/core/src/pattern/subtract.rs
+++ b/crates/core/src/pattern/subtract.rs
@@ -3,7 +3,10 @@ use super::{
     resolved_pattern::ResolvedPattern,
     state::State,
 };
-use crate::{binding::Constant, context::QueryContext};
+use crate::{
+    binding::Constant,
+    context::{ExecContext, QueryContext},
+};
 use anyhow::Result;
 use marzano_util::analysis_logs::AnalysisLogs;
 
@@ -55,7 +58,7 @@ impl<Q: QueryContext> Matcher<Q> for Subtract<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let binding_text = binding.text(&state.files)?;
+        let binding_text = binding.text(&state.files, context.language())?;
         let binding_int = binding_text.parse::<f64>()?;
         let target = self.evaluate(state, context, logs)?;
         Ok(binding_int == target)

--- a/crates/core/src/pattern/variable_content.rs
+++ b/crates/core/src/pattern/variable_content.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use marzano_language::language::Language;
 use std::borrow::Cow;
 
 use crate::{context::QueryContext, pattern::patterns::Pattern};
@@ -29,9 +30,9 @@ impl<'a, Q: QueryContext> VariableContent<'a, Q> {
 
     // should we return an option instead of a Result?
     // should we trace pattern calls here? - currently only used by variable which already traces
-    pub fn text(&self, state: &State<'a, Q>) -> Result<Cow<'a, str>> {
+    pub fn text(&self, state: &State<'a, Q>, language: &impl Language) -> Result<Cow<'a, str>> {
         if let Some(value) = &self.value {
-            value.text(&state.files)
+            value.text(&state.files, language)
         } else {
             Err(anyhow!("no value for variable {}", self.name))
         }

--- a/crates/language/src/csharp.rs
+++ b/crates/language/src/csharp.rs
@@ -22,6 +22,7 @@ fn language() -> TSLanguage {
 pub struct CSharp {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 
@@ -30,9 +31,11 @@ impl CSharp {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -60,5 +63,9 @@ impl Language for CSharp {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 }

--- a/crates/language/src/go.rs
+++ b/crates/language/src/go.rs
@@ -21,6 +21,7 @@ fn language() -> TSLanguage {
 pub struct Go {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 
@@ -29,9 +30,11 @@ impl Go {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -64,6 +67,10 @@ impl Language for Go {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 }
 

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -22,6 +22,7 @@ fn language() -> TSLanguage {
 pub struct Html {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 
@@ -30,9 +31,11 @@ impl Html {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -59,6 +62,10 @@ impl Language for Html {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/java.rs
+++ b/crates/language/src/java.rs
@@ -73,7 +73,7 @@ impl Language for Java {
     }
 
     fn is_comment(&self, id: SortId) -> bool {
-        self.comment_sorts.iter().any(|sort| sort == &id)
+        self.comment_sorts.contains(&id)
     }
 }
 

--- a/crates/language/src/json.rs
+++ b/crates/language/src/json.rs
@@ -21,6 +21,7 @@ fn language() -> TSLanguage {
 pub struct Json {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 
@@ -29,9 +30,11 @@ impl Json {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -58,6 +61,10 @@ impl Language for Json {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -242,9 +242,7 @@ pub trait Language {
         &EXACT_REPLACED_VARIABLE_REGEX
     }
 
-    fn is_comment(&self, _id: SortId) -> bool {
-        false
-    }
+    fn is_comment(&self, _id: SortId) -> bool;
 
     fn is_comment_wrapper(&self, _node: &tree_sitter::Node) -> bool {
         false

--- a/crates/language/src/markdown_block.rs
+++ b/crates/language/src/markdown_block.rs
@@ -63,6 +63,10 @@ impl Language for MarkdownBlock {
         self.metavariable_sort
     }
 
+    fn is_comment(&self, _id: SortId) -> bool {
+        false
+    }
+
     fn make_single_line_comment(&self, text: &str) -> String {
         format!("<!-- {} -->\n", text)
     }

--- a/crates/language/src/markdown_inline.rs
+++ b/crates/language/src/markdown_inline.rs
@@ -63,6 +63,10 @@ impl Language for MarkdownInline {
         self.metavariable_sort
     }
 
+    fn is_comment(&self, _id: SortId) -> bool {
+        false
+    }
+
     fn make_single_line_comment(&self, text: &str) -> String {
         format!("<!-- {} -->\n", text)
     }

--- a/crates/language/src/php.rs
+++ b/crates/language/src/php.rs
@@ -29,6 +29,7 @@ fn language() -> TSLanguage {
 pub struct Php {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 // use std::io::Write;
@@ -37,9 +38,11 @@ impl Php {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -70,6 +73,10 @@ impl Language for Php {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 
     fn metavariable_prefix(&self) -> &'static str {

--- a/crates/language/src/php_only.rs
+++ b/crates/language/src/php_only.rs
@@ -1,16 +1,16 @@
-use std::sync::OnceLock;
 use regex::Regex;
-
+use std::sync::OnceLock;
 
 use crate::{
-    language::{
-        fields_for_nodes, Field, Language, SortId, TSLanguage
-    }, xscript_util::{
-        php_like_exact_variable_regex, php_like_metavariable_bracket_regex, php_like_metavariable_prefix, php_like_metavariable_regex, PHP_ONLY_CODE_SNIPPETS
-    }
+    language::{fields_for_nodes, Field, Language, SortId, TSLanguage},
+    xscript_util::{
+        php_like_exact_variable_regex, php_like_metavariable_bracket_regex,
+        php_like_metavariable_prefix, php_like_metavariable_regex, PHP_ONLY_CODE_SNIPPETS,
+    },
 };
 
-static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/php_only-node-types.json");
+static NODE_TYPES_STRING: &str =
+    include_str!("../../../resources/node-types/php_only-node-types.json");
 
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
 static LANGUAGE: OnceLock<TSLanguage> = OnceLock::new();
@@ -30,6 +30,7 @@ fn language() -> TSLanguage {
 pub struct PhpOnly {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 // use std::io::Write;
@@ -38,9 +39,11 @@ impl PhpOnly {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -71,6 +74,10 @@ impl Language for PhpOnly {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 
     fn metavariable_prefix(&self) -> &'static str {

--- a/crates/language/src/ruby.rs
+++ b/crates/language/src/ruby.rs
@@ -22,6 +22,7 @@ fn language() -> TSLanguage {
 pub struct Ruby {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 
@@ -30,9 +31,11 @@ impl Ruby {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -63,6 +66,10 @@ impl Language for Ruby {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/sql.rs
+++ b/crates/language/src/sql.rs
@@ -21,6 +21,7 @@ fn language() -> TSLanguage {
 pub struct Sql {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 
@@ -29,9 +30,11 @@ impl Sql {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -71,6 +74,10 @@ impl Language for Sql {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/toml.rs
+++ b/crates/language/src/toml.rs
@@ -21,6 +21,7 @@ fn language() -> TSLanguage {
 pub struct Toml {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 
@@ -29,9 +30,11 @@ impl Toml {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -58,6 +61,10 @@ impl Language for Toml {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/vue.rs
+++ b/crates/language/src/vue.rs
@@ -25,6 +25,7 @@ fn language() -> TSLanguage {
 pub struct Vue {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     language: &'static TSLanguage,
 }
 
@@ -33,9 +34,11 @@ impl Vue {
         let language = LANGUAGE.get_or_init(|| lang.unwrap_or_else(language));
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             language,
         }
     }
@@ -62,6 +65,10 @@ impl Language for Vue {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/yaml.rs
+++ b/crates/language/src/yaml.rs
@@ -25,6 +25,7 @@ fn built_in_language() -> TSLanguage {
 pub struct Yaml {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
+    comment_sort: SortId,
     equivalent_leaf_nodes: &'static [Vec<LeafNormalizer>],
     language: &'static TSLanguage,
 }
@@ -46,9 +47,11 @@ impl Yaml {
             ]]
         });
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
+        let comment_sort = language.id_for_node_kind("comment", true);
         Self {
             node_types,
             metavariable_sort,
+            comment_sort,
             equivalent_leaf_nodes,
             language,
         }
@@ -80,6 +83,10 @@ impl Language for Yaml {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+
+    fn is_comment(&self, id: SortId) -> bool {
+        id == self.comment_sort
     }
 
     fn get_equivalence_class(


### PR DESCRIPTION
use the is_comment utility to check if a node is a comment, as not all comments have the kind "comment"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced language-specific handling across various functionalities, improving accuracy in text processing and pattern matching based on the language context.

- **Bug Fixes**
  - Corrected language parameter integrations to ensure consistent behavior in functions dealing with text and code positions across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->