### PR TITLE
chore: simplify comment api in language crate

### DIFF
--- a/crates/core/src/ast_node.rs
+++ b/crates/core/src/ast_node.rs
@@ -72,7 +72,7 @@ impl Matcher<MarzanoQueryContext> for ASTNode {
         if self.args.is_empty() {
             return Ok(true);
         }
-        if context.language().is_comment(self.sort) {
+        if context.language().is_comment_sort(self.sort) {
             let content = context.language().comment_text(&node, source);
             let content = resolve!(content);
 

--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -595,7 +595,7 @@ fn get_range_nodes_for_list<'a>(
 
     let mut leading_comment = first_node.clone();
     while let Some(comment) = leading_comment.previous_sibling() {
-        if language.is_comment(comment.node.kind_id()) {
+        if language.is_comment_node(&comment) {
             leading_comment = comment;
         } else {
             break;
@@ -603,7 +603,7 @@ fn get_range_nodes_for_list<'a>(
     }
     let mut trailing_comment = end_node;
     while let Some(comment) = trailing_comment.next_sibling() {
-        if language.is_comment(comment.node.kind_id()) {
+        if language.is_comment_node(&comment) {
             trailing_comment = comment;
         } else {
             break;

--- a/crates/core/src/pattern_compiler/ast_node_compiler.rs
+++ b/crates/core/src/pattern_compiler/ast_node_compiler.rs
@@ -26,7 +26,7 @@ impl AstNodeCompiler {
         is_rhs: bool,
     ) -> Result<ASTNode> {
         let mut args = Vec::new();
-        if context.compilation.lang.is_comment(sort) {
+        if context.compilation.lang.is_comment_sort(sort) {
             match named_args.len().cmp(&1) {
                 Ordering::Equal => {
                     let (name, node) = named_args.remove(0);

--- a/crates/core/src/suppress.rs
+++ b/crates/core/src/suppress.rs
@@ -14,7 +14,7 @@ impl<'a> Binding<'a> {
         let target_range = node.node.range();
         for n in node.children().chain(node.ancestors()) {
             for c in n.children() {
-                if !(lang.is_comment(c.node.kind_id()) || lang.is_comment_wrapper(&c.node)) {
+                if !(lang.is_comment_node(&c)) {
                     continue;
                 }
                 if is_suppress_comment(&c, &target_range, current_name, lang) {
@@ -81,8 +81,7 @@ fn comment_applies_to_range(
         return false;
     };
     while let Some(next) = applicable.next_named_node() {
-        if !lang.is_comment(applicable.node.kind_id())
-            && !lang.is_comment_wrapper(&applicable.node)
+        if !lang.is_comment_node(&applicable)
             // Some languages have significant whitespace; continue until we find a non-whitespace non-comment node
             && !applicable.text().trim().is_empty()
         {

--- a/crates/language/src/csharp.rs
+++ b/crates/language/src/csharp.rs
@@ -67,7 +67,7 @@ impl Language for CSharp {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 }

--- a/crates/language/src/css.rs
+++ b/crates/language/src/css.rs
@@ -77,7 +77,7 @@ impl Language for Css {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/go.rs
+++ b/crates/language/src/go.rs
@@ -71,7 +71,7 @@ impl Language for Go {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 }

--- a/crates/language/src/hcl.rs
+++ b/crates/language/src/hcl.rs
@@ -65,7 +65,7 @@ impl Language for Hcl {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -66,7 +66,7 @@ impl Language for Html {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/java.rs
+++ b/crates/language/src/java.rs
@@ -74,7 +74,7 @@ impl Language for Java {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         self.comment_sorts.contains(&id)
     }
 }

--- a/crates/language/src/javascript.rs
+++ b/crates/language/src/javascript.rs
@@ -4,7 +4,7 @@ use crate::{
         Replacement, SortId, TSLanguage,
     },
     xscript_util::{
-        self, js_like_get_statement_sorts, js_optional_empty_field_compilation,
+        self, js_like_get_statement_sorts, js_like_is_comment, js_optional_empty_field_compilation,
         js_skip_snippet_compilation_sorts, jslike_check_replacements,
     },
 };
@@ -37,6 +37,7 @@ pub struct JavaScript {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
     comment_sort: SortId,
+    jsx_sort: SortId,
     statement_sorts: &'static [SortId],
     language: &'static TSLanguage,
     skip_snippet_compilation_sorts: &'static Vec<(SortId, FieldId)>,
@@ -49,6 +50,7 @@ impl JavaScript {
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
         let comment_sort = language.id_for_node_kind("comment", true);
+        let jsx_sort = language.id_for_node_kind("jsx_expression", true);
 
         let statement_sorts = STATEMENT_SORTS.get_or_init(|| js_like_get_statement_sorts(language));
 
@@ -64,6 +66,7 @@ impl JavaScript {
             node_types,
             metavariable_sort,
             comment_sort,
+            jsx_sort,
             statement_sorts,
             language,
             skip_snippet_compilation_sorts,
@@ -131,8 +134,12 @@ impl Language for JavaScript {
         ]
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
+    }
+
+    fn is_comment_node(&self, node: &NodeWithSource) -> bool {
+        js_like_is_comment(node, self.comment_sort, self.jsx_sort)
     }
 
     fn is_statement(&self, id: SortId) -> bool {

--- a/crates/language/src/json.rs
+++ b/crates/language/src/json.rs
@@ -65,7 +65,7 @@ impl Language for Json {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -246,10 +246,15 @@ pub trait Language: NodeTypes {
         &EXACT_REPLACED_VARIABLE_REGEX
     }
 
-    fn is_comment(&self, _id: SortId) -> bool;
+    // checks if the sort is the languages comment sort
+    fn is_comment_sort(&self, _id: SortId) -> bool;
 
-    fn is_comment_wrapper(&self, _node: &tree_sitter::Node) -> bool {
-        false
+    // checks if a node is a comment. distinct from the above
+    // in that sometimes a node is a comment but doesn't have
+    // a comment sort for example when parsing javascript,
+    // comments embedded in jsx dont have the comment sort
+    fn is_comment_node(&self, node: &NodeWithSource) -> bool {
+        self.is_comment_sort(node.node.kind_id())
     }
 
     fn is_statement(&self, _id: SortId) -> bool {

--- a/crates/language/src/markdown_block.rs
+++ b/crates/language/src/markdown_block.rs
@@ -65,7 +65,7 @@ impl Language for MarkdownBlock {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, _id: SortId) -> bool {
+    fn is_comment_sort(&self, _id: SortId) -> bool {
         false
     }
 

--- a/crates/language/src/markdown_inline.rs
+++ b/crates/language/src/markdown_inline.rs
@@ -65,7 +65,7 @@ impl Language for MarkdownInline {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, _id: SortId) -> bool {
+    fn is_comment_sort(&self, _id: SortId) -> bool {
         false
     }
 

--- a/crates/language/src/php.rs
+++ b/crates/language/src/php.rs
@@ -77,7 +77,7 @@ impl Language for Php {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/php_only.rs
+++ b/crates/language/src/php_only.rs
@@ -78,7 +78,7 @@ impl Language for PhpOnly {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/python.rs
+++ b/crates/language/src/python.rs
@@ -79,7 +79,7 @@ impl Language for Python {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/ruby.rs
+++ b/crates/language/src/ruby.rs
@@ -70,7 +70,7 @@ impl Language for Ruby {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/rust.rs
+++ b/crates/language/src/rust.rs
@@ -124,7 +124,7 @@ impl Language for Rust {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         self.comment_sorts.contains(&id)
     }
 }

--- a/crates/language/src/solidity.rs
+++ b/crates/language/src/solidity.rs
@@ -70,7 +70,7 @@ impl Language for Solidity {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 }

--- a/crates/language/src/sql.rs
+++ b/crates/language/src/sql.rs
@@ -78,7 +78,7 @@ impl Language for Sql {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/toml.rs
+++ b/crates/language/src/toml.rs
@@ -65,7 +65,7 @@ impl Language for Toml {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/tsx.rs
+++ b/crates/language/src/tsx.rs
@@ -6,11 +6,12 @@ use crate::{
         Replacement, SortId, TSLanguage,
     },
     xscript_util::{
-        self, js_like_optional_empty_field_compilation, js_like_skip_snippet_compilation_sorts,
+        self, js_like_is_comment, js_like_optional_empty_field_compilation,
+        js_like_skip_snippet_compilation_sorts,
     },
 };
 use marzano_util::{node_with_source::NodeWithSource, position::Range};
-use tree_sitter::{Node, Parser};
+use tree_sitter::Parser;
 use xscript_util::{js_like_get_statement_sorts, jslike_check_replacements};
 
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/tsx-node-types.json");
@@ -36,6 +37,7 @@ pub struct Tsx {
     node_types: &'static [Vec<Field>],
     metavariable_sort: SortId,
     comment_sort: SortId,
+    jsx_sort: SortId,
     statement_sorts: &'static [SortId],
     language: &'static TSLanguage,
     skip_snippet_compilation_sorts: &'static Vec<(SortId, FieldId)>,
@@ -48,6 +50,7 @@ impl Tsx {
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
         let comment_sort = language.id_for_node_kind("comment", true);
+        let jsx_sort = language.id_for_node_kind("jsx_expression", true);
         let skip_snippet_compilation_sorts = SKIP_SNIPPET_COMPILATION_SORTS.get_or_init(|| {
             kind_and_field_id_for_names(language, js_like_skip_snippet_compilation_sorts())
         });
@@ -62,6 +65,7 @@ impl Tsx {
             node_types,
             metavariable_sort,
             comment_sort,
+            jsx_sort,
             statement_sorts,
             language,
             skip_snippet_compilation_sorts,
@@ -131,17 +135,12 @@ impl Language for Tsx {
         ]
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 
-    fn is_comment_wrapper(&self, node: &Node) -> bool {
-        node.kind() == "jsx_expression"
-            && node.named_child_count() == 1
-            && node
-                .named_child(0)
-                .map(|c| self.is_comment(c.kind_id()))
-                .is_some_and(|b| b)
+    fn is_comment_node(&self, node: &NodeWithSource) -> bool {
+        js_like_is_comment(node, self.comment_sort, self.jsx_sort)
     }
 
     fn is_statement(&self, id: SortId) -> bool {

--- a/crates/language/src/typescript.rs
+++ b/crates/language/src/typescript.rs
@@ -9,9 +9,10 @@ use crate::xscript_util::{
     self, js_like_get_statement_sorts, js_like_optional_empty_field_compilation,
     js_like_skip_snippet_compilation_sorts, jslike_check_replacements,
 };
+
 use marzano_util::node_with_source::NodeWithSource;
 use marzano_util::position::Range;
-use tree_sitter::{Node, Parser};
+use tree_sitter::Parser;
 
 static NODE_TYPES_STRING: &str =
     include_str!("../../../resources/node-types/typescript-node-types.json");
@@ -133,17 +134,8 @@ impl Language for TypeScript {
         ]
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
-    }
-
-    fn is_comment_wrapper(&self, node: &Node) -> bool {
-        node.kind() == "jsx_expression"
-            && node.named_child_count() == 1
-            && node
-                .named_child(0)
-                .map(|c| self.is_comment(c.kind_id()))
-                .is_some_and(|b| b)
     }
 
     fn is_statement(&self, id: SortId) -> bool {

--- a/crates/language/src/vue.rs
+++ b/crates/language/src/vue.rs
@@ -69,7 +69,7 @@ impl Language for Vue {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 

--- a/crates/language/src/xscript_util.rs
+++ b/crates/language/src/xscript_util.rs
@@ -4,10 +4,11 @@ use crate::{
 };
 use anyhow::anyhow;
 use grit_util::AstNode;
-use regex::Regex;
-use marzano_util::node_with_source::NodeWithSource;
-use tree_sitter::{Parser, Tree};
 use lazy_static::lazy_static;
+
+use marzano_util::node_with_source::NodeWithSource;
+use regex::Regex;
+use tree_sitter::{Parser, Tree};
 
 static STATEMENT_NODE_NAMES: &[&str] = &[
     "break_statement",
@@ -117,6 +118,22 @@ pub(crate) fn parse_file(
     }
 }
 
+pub(crate) fn js_like_is_comment(
+    node: &NodeWithSource,
+    comment_sort: SortId,
+    jsx_sort: SortId,
+) -> bool {
+    let id = node.node.kind_id();
+    id == comment_sort
+        || (id == jsx_sort
+            && node.node.named_child_count() == 1
+            && node
+                .node
+                .named_child(0)
+                .map(|c| c.kind_id() == comment_sort)
+                .is_some_and(|b| b))
+}
+
 pub(crate) fn jslike_check_replacements(
     n: NodeWithSource<'_>,
     replacement_ranges: &mut Vec<Replacement>,
@@ -161,12 +178,12 @@ pub(crate) fn jslike_check_replacements(
 }
 
 lazy_static! {
-    static ref PHP_LIKE_EXACT_VARIABLE_REGEX: Regex =
-        Regex::new(r"^\^([A-Za-z_][A-Za-z0-9_]*)$").expect("Failed to compile PHP_LIKE_EXACT_VARIABLE_REGEX");
-    static ref PHP_LIKE_VARIABLE_REGEX: Regex =
-        Regex::new(r"\^(\.\.\.|[A-Za-z_][A-Za-z0-9_]*)").expect("Failed to compile PHP_LIKE_VARIABLE_REGEX");
-    static ref PHP_LIKE_BRACKET_VAR_REGEX: Regex =
-        Regex::new(r"\^\[([A-Za-z_][A-Za-z0-9_]*)\]").expect("Failed to compile PHP_LIKE_BRACKET_VAR_REGEX");
+    static ref PHP_LIKE_EXACT_VARIABLE_REGEX: Regex = Regex::new(r"^\^([A-Za-z_][A-Za-z0-9_]*)$")
+        .expect("Failed to compile PHP_LIKE_EXACT_VARIABLE_REGEX");
+    static ref PHP_LIKE_VARIABLE_REGEX: Regex = Regex::new(r"\^(\.\.\.|[A-Za-z_][A-Za-z0-9_]*)")
+        .expect("Failed to compile PHP_LIKE_VARIABLE_REGEX");
+    static ref PHP_LIKE_BRACKET_VAR_REGEX: Regex = Regex::new(r"\^\[([A-Za-z_][A-Za-z0-9_]*)\]")
+        .expect("Failed to compile PHP_LIKE_BRACKET_VAR_REGEX");
     pub static ref PHP_ONLY_CODE_SNIPPETS: Vec<(&'static str, &'static str)> = vec![
         ("", ""),
         ("", ";"),
@@ -180,18 +197,18 @@ lazy_static! {
         ("", "{}"),
     ];
     pub static ref PHP_CODE_SNIPPETS: Vec<(&'static str, &'static str)> = {
-        let mut php_tag_modifications:Vec<(&'static str, &'static str)> = PHP_ONLY_CODE_SNIPPETS.
-            clone().
-            into_iter().
-            map(|(s1, s2)| {
+        let mut php_tag_modifications: Vec<(&'static str, &'static str)> = PHP_ONLY_CODE_SNIPPETS
+            .clone()
+            .into_iter()
+            .map(|(s1, s2)| {
                 let owned_str1 = Box::leak(Box::new(format!("<?php {}", s1))) as &'static str;
                 let owned_str2 = Box::leak(Box::new(format!("{} ?>", s2))) as &'static str;
                 (owned_str1, owned_str2)
-            }).collect();
+            })
+            .collect();
         php_tag_modifications.extend(vec![("", "")]);
         php_tag_modifications
     };
-    
 }
 
 pub(crate) fn php_like_metavariable_regex() -> &'static Regex {

--- a/crates/language/src/yaml.rs
+++ b/crates/language/src/yaml.rs
@@ -87,7 +87,7 @@ impl Language for Yaml {
         self.metavariable_sort
     }
 
-    fn is_comment(&self, id: SortId) -> bool {
+    fn is_comment_sort(&self, id: SortId) -> bool {
         id == self.comment_sort
     }
 


### PR DESCRIPTION
replace `is_comment_wrapper` with `is_comment_node` as that is what it does, and has it also return true if the sort of the node is a comment simplifying it's usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced comment identification across various programming languages to improve accuracy and context sensitivity.
  - Added handling for JSX expressions in JavaScript and TypeScript modules.

- **Refactor**
  - Updated function names and refactored logic for better clarity and maintainability in comment-related functionalities.
  - Simplified and unified methods for checking comment nodes across different language implementations.

- **Bug Fixes**
  - Corrected the logic flow in the `Matcher` implementation and various language modules to ensure consistent behavior when identifying comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->