### PR TITLE
chore: give php its own util file

### DIFF
--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -12,6 +12,7 @@ pub mod language;
 pub mod markdown_block;
 pub mod markdown_inline;
 pub mod php;
+mod php_like;
 pub mod php_only;
 pub mod python;
 pub mod ruby;

--- a/crates/language/src/php.rs
+++ b/crates/language/src/php.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 
 use crate::{
     language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage},
-    xscript_util::{
+    php_like::{
         php_like_exact_variable_regex, php_like_metavariable_bracket_regex,
         php_like_metavariable_prefix, php_like_metavariable_regex, PHP_CODE_SNIPPETS,
     },

--- a/crates/language/src/php_like.rs
+++ b/crates/language/src/php_like.rs
@@ -1,0 +1,52 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref PHP_LIKE_EXACT_VARIABLE_REGEX: Regex = Regex::new(r"^\^([A-Za-z_][A-Za-z0-9_]*)$")
+        .expect("Failed to compile PHP_LIKE_EXACT_VARIABLE_REGEX");
+    static ref PHP_LIKE_VARIABLE_REGEX: Regex = Regex::new(r"\^(\.\.\.|[A-Za-z_][A-Za-z0-9_]*)")
+        .expect("Failed to compile PHP_LIKE_VARIABLE_REGEX");
+    static ref PHP_LIKE_BRACKET_VAR_REGEX: Regex = Regex::new(r"\^\[([A-Za-z_][A-Za-z0-9_]*)\]")
+        .expect("Failed to compile PHP_LIKE_BRACKET_VAR_REGEX");
+    pub static ref PHP_ONLY_CODE_SNIPPETS: Vec<(&'static str, &'static str)> = vec![
+        ("", ""),
+        ("", ";"),
+        ("$", ";"),
+        ("class GRIT_CLASS {", "}"),
+        ("class GRIT_CLASS { ", " function GRIT_FN(); }"),
+        (" GRIT_FN(", ") { }"),
+        ("$GRIT_VAR = ", ";"),
+        ("$GRIT_VAR = ", ""),
+        ("[", "];"),
+        ("", "{}"),
+    ];
+    pub static ref PHP_CODE_SNIPPETS: Vec<(&'static str, &'static str)> = {
+        let mut php_tag_modifications: Vec<(&'static str, &'static str)> = PHP_ONLY_CODE_SNIPPETS
+            .clone()
+            .into_iter()
+            .map(|(s1, s2)| {
+                let owned_str1 = Box::leak(Box::new(format!("<?php {}", s1))) as &'static str;
+                let owned_str2 = Box::leak(Box::new(format!("{} ?>", s2))) as &'static str;
+                (owned_str1, owned_str2)
+            })
+            .collect();
+        php_tag_modifications.extend(vec![("", "")]);
+        php_tag_modifications
+    };
+}
+
+pub(crate) fn php_like_metavariable_regex() -> &'static Regex {
+    &PHP_LIKE_VARIABLE_REGEX
+}
+
+pub(crate) fn php_like_metavariable_bracket_regex() -> &'static Regex {
+    &PHP_LIKE_BRACKET_VAR_REGEX
+}
+
+pub(crate) fn php_like_exact_variable_regex() -> &'static Regex {
+    &PHP_LIKE_EXACT_VARIABLE_REGEX
+}
+
+pub(crate) fn php_like_metavariable_prefix() -> &'static str {
+    "^"
+}

--- a/crates/language/src/php_only.rs
+++ b/crates/language/src/php_only.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 
 use crate::{
     language::{fields_for_nodes, Field, Language, NodeTypes, SortId, TSLanguage},
-    xscript_util::{
+    php_like::{
         php_like_exact_variable_regex, php_like_metavariable_bracket_regex,
         php_like_metavariable_prefix, php_like_metavariable_regex, PHP_ONLY_CODE_SNIPPETS,
     },

--- a/crates/language/src/xscript_util.rs
+++ b/crates/language/src/xscript_util.rs
@@ -4,10 +4,8 @@ use crate::{
 };
 use anyhow::anyhow;
 use grit_util::AstNode;
-use regex::Regex;
 use marzano_util::node_with_source::NodeWithSource;
 use tree_sitter::{Parser, Tree};
-use lazy_static::lazy_static;
 
 static STATEMENT_NODE_NAMES: &[&str] = &[
     "break_statement",
@@ -158,56 +156,6 @@ pub(crate) fn jslike_check_replacements(
             }
         }
     }
-}
-
-lazy_static! {
-    static ref PHP_LIKE_EXACT_VARIABLE_REGEX: Regex =
-        Regex::new(r"^\^([A-Za-z_][A-Za-z0-9_]*)$").expect("Failed to compile PHP_LIKE_EXACT_VARIABLE_REGEX");
-    static ref PHP_LIKE_VARIABLE_REGEX: Regex =
-        Regex::new(r"\^(\.\.\.|[A-Za-z_][A-Za-z0-9_]*)").expect("Failed to compile PHP_LIKE_VARIABLE_REGEX");
-    static ref PHP_LIKE_BRACKET_VAR_REGEX: Regex =
-        Regex::new(r"\^\[([A-Za-z_][A-Za-z0-9_]*)\]").expect("Failed to compile PHP_LIKE_BRACKET_VAR_REGEX");
-    pub static ref PHP_ONLY_CODE_SNIPPETS: Vec<(&'static str, &'static str)> = vec![
-        ("", ""),
-        ("", ";"),
-        ("$", ";"),
-        ("class GRIT_CLASS {", "}"),
-        ("class GRIT_CLASS { ", " function GRIT_FN(); }"),
-        (" GRIT_FN(", ") { }"),
-        ("$GRIT_VAR = ", ";"),
-        ("$GRIT_VAR = ", ""),
-        ("[", "];"),
-        ("", "{}"),
-    ];
-    pub static ref PHP_CODE_SNIPPETS: Vec<(&'static str, &'static str)> = {
-        let mut php_tag_modifications:Vec<(&'static str, &'static str)> = PHP_ONLY_CODE_SNIPPETS.
-            clone().
-            into_iter().
-            map(|(s1, s2)| {
-                let owned_str1 = Box::leak(Box::new(format!("<?php {}", s1))) as &'static str;
-                let owned_str2 = Box::leak(Box::new(format!("{} ?>", s2))) as &'static str;
-                (owned_str1, owned_str2)
-            }).collect();
-        php_tag_modifications.extend(vec![("", "")]);
-        php_tag_modifications
-    };
-    
-}
-
-pub(crate) fn php_like_metavariable_regex() -> &'static Regex {
-    &PHP_LIKE_VARIABLE_REGEX
-}
-
-pub(crate) fn php_like_metavariable_bracket_regex() -> &'static Regex {
-    &PHP_LIKE_BRACKET_VAR_REGEX
-}
-
-pub(crate) fn php_like_exact_variable_regex() -> &'static Regex {
-    &PHP_LIKE_EXACT_VARIABLE_REGEX
-}
-
-pub(crate) fn php_like_metavariable_prefix() -> &'static str {
-    "^"
 }
 
 #[cfg(test)]


### PR DESCRIPTION
moves the php utilities into their own file instead of reusing the javascript like utilities file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new PHP-like syntax module, enhancing the capability to define and utilize regular expressions and code snippets that resemble PHP syntax.

- **Refactor**
	- Renamed modules and updated import paths to align with new PHP-like functionality.

- **Chores**
	- Removed outdated regex code and functions from a previous module to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->