### PR TITLE
chore: no direct `ResolvedPattern` variant usages

### DIFF
--- a/crates/core/src/pattern/accumulate.rs
+++ b/crates/core/src/pattern/accumulate.rs
@@ -67,26 +67,8 @@ impl<Q: QueryContext> Matcher<Q> for Accumulate<Q> {
             } else {
                 Cow::Borrowed(context_node)
             };
-            let bindings = match resolved.as_ref() {
-                ResolvedPattern::Binding(b) => b,
-                ResolvedPattern::Constant(_) => {
-                    bail!("variable on left hand side of insert side-conditions cannot be bound to a constant")
-                }
-                ResolvedPattern::File(_) => {
-                    bail!("variable on left hand side of insert side-conditions cannot be bound to a file, try rewriting the content, or name instead")
-                }
-                ResolvedPattern::Files(_) => {
-                    bail!("variable on left hand side of insert side-conditions cannot be bound to a files node")
-                }
-                ResolvedPattern::List(_) => {
-                    bail!("variable on left hand side of insert side-conditions cannot be bound to a list pattern")
-                }
-                ResolvedPattern::Map(_) => {
-                    bail!("variable on left hand side of insert side-conditions cannot be bound to a map pattern")
-                }
-                ResolvedPattern::Snippets(_) => {
-                    bail!("variable on left hand side of insert side-conditions cannot be bound to snippets")
-                }
+            let Some(bindings) = resolved.get_bindings() else {
+                bail!("variable on left hand side of insert side-conditions can onlybe bound to bindings")
             };
             let dynamic_right = match &self.dynamic_right {
                 Some(r) => r,
@@ -96,10 +78,9 @@ impl<Q: QueryContext> Matcher<Q> for Accumulate<Q> {
                     )
                 }
             };
-            let mut replacement: ResolvedPattern<'_> =
+            let mut replacement =
                 ResolvedPattern::from_dynamic_pattern(dynamic_right, state, context, logs)?;
             let effects: Result<Vec<Effect>> = bindings
-                .iter()
                 .map(|b| {
                     let is_first = !state.effects.iter().any(|e| e.binding == *b);
                     replacement.normalize_insert(b, is_first, context.language())?;

--- a/crates/core/src/pattern/add.rs
+++ b/crates/core/src/pattern/add.rs
@@ -28,7 +28,7 @@ impl<Q: QueryContext> Add<Q> {
         logs: &mut AnalysisLogs,
     ) -> Result<ResolvedPattern<'a>> {
         let res = self.evaluate(state, context, logs)?;
-        Ok(ResolvedPattern::Constant(Constant::Float(res)))
+        Ok(ResolvedPattern::from_constant(Constant::Float(res)))
     }
 
     fn evaluate<'a>(

--- a/crates/core/src/pattern/ast_node.rs
+++ b/crates/core/src/pattern/ast_node.rs
@@ -35,9 +35,7 @@ impl Matcher<Q> for ASTNode {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let binding = if let ResolvedPattern::Binding(binding) = binding {
-            resolve!(binding.last())
-        } else {
+        let Some(binding) = binding.get_last_binding() else {
             return Ok(false);
         };
         let Some(node) = binding.singleton() else {
@@ -71,7 +69,7 @@ impl Matcher<Q> for ASTNode {
 
             let res = if *is_list {
                 pattern.execute(
-                    &ResolvedPattern::from_list(
+                    &ResolvedPattern::from_list_binding(
                         NodeWithSource::new(node.clone(), source),
                         *field_id,
                     ),

--- a/crates/core/src/pattern/code_snippet.rs
+++ b/crates/core/src/pattern/code_snippet.rs
@@ -4,10 +4,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{
-    context::{ExecContext, QueryContext},
-    resolve,
-};
+use crate::context::{ExecContext, QueryContext};
 use anyhow::Result;
 use core::fmt::Debug;
 use marzano_language::language::SortId;
@@ -44,21 +41,13 @@ impl<Q: QueryContext> Matcher<Q> for CodeSnippet<Q> {
     // wrong, but whatever for now
     fn execute<'a>(
         &'a self,
-        resolved_pattern: &ResolvedPattern<'a>,
+        resolved: &ResolvedPattern<'a>,
         state: &mut State<'a, Q>,
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let binding = match resolved_pattern {
-            ResolvedPattern::Binding(binding) => resolve!(binding.last()),
-            resolved @ ResolvedPattern::Snippets(_)
-            | resolved @ ResolvedPattern::List(_)
-            | resolved @ ResolvedPattern::Map(_)
-            | resolved @ ResolvedPattern::File(_)
-            | resolved @ ResolvedPattern::Files(_)
-            | resolved @ ResolvedPattern::Constant(_) => {
-                return Ok(resolved.text(&state.files, context.language())?.trim() == self.source)
-            }
+        let Some(binding) = resolved.get_last_binding() else {
+            return Ok(resolved.text(&state.files, context.language())?.trim() == self.source);
         };
 
         let Some(node) = binding.singleton() else {
@@ -70,7 +59,7 @@ impl<Q: QueryContext> Matcher<Q> for CodeSnippet<Q> {
             .iter()
             .find(|(id, _)| *id == node.node.kind_id())
         {
-            pattern.execute(resolved_pattern, state, context, logs)
+            pattern.execute(resolved, state, context, logs)
         } else {
             Ok(false)
         }

--- a/crates/core/src/pattern/container.rs
+++ b/crates/core/src/pattern/container.rs
@@ -40,7 +40,7 @@ impl<Q: QueryContext> Container<Q> {
         state: &mut State<'a, Q>,
         lang: &impl Language,
         value: ResolvedPattern<'a>,
-    ) -> Result<Option<ResolvedPattern<'a>>> {
+    ) -> Result<bool> {
         match self {
             Container::Variable(v) => {
                 let var = state.trace_var(v);
@@ -48,7 +48,10 @@ impl<Q: QueryContext> Container<Q> {
                 match content.pattern {
                     Some(Pattern::Accessor(a)) => a.set_resolved(state, lang, value),
                     Some(Pattern::ListIndex(l)) => l.set_resolved(state, lang, value),
-                    None | Some(_) => Ok(content.set_value(value)),
+                    None | Some(_) => {
+                        content.set_value(value);
+                        Ok(true)
+                    }
                 }
             }
             Container::Accessor(a) => a.set_resolved(state, lang, value),

--- a/crates/core/src/pattern/contains.rs
+++ b/crates/core/src/pattern/contains.rs
@@ -3,10 +3,9 @@ use super::{
     resolved_pattern::{LazyBuiltIn, ResolvedPattern, ResolvedSnippet},
     Node, State,
 };
-use crate::{context::QueryContext, resolve};
+use crate::context::QueryContext;
 use anyhow::Result;
 use core::fmt::Debug;
-use im::vector;
 use marzano_util::{analysis_logs::AnalysisLogs, node_with_source::NodeWithSource};
 
 #[derive(Debug, Clone)]
@@ -42,7 +41,7 @@ fn execute_until<'a, Q: QueryContext>(
     let mut still_computing = true;
     while still_computing {
         let node = cursor.node();
-        let node_lhs = ResolvedPattern::from_node(NodeWithSource::new(node, src));
+        let node_lhs = ResolvedPattern::from_node_binding(NodeWithSource::new(node, src));
 
         let state = cur_state.clone();
         if the_contained.execute(&node_lhs, &mut cur_state, context, logs)? {
@@ -90,54 +89,28 @@ impl<Q: QueryContext> Matcher<Q> for Contains<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        match resolved_pattern {
-            ResolvedPattern::Binding(bindings) => {
-                let binding = resolve!(bindings.last());
-                if let Some(node) = binding.as_node() {
-                    execute_until(
-                        init_state,
-                        &node.node,
-                        node.source,
+        if let Some(binding) = resolved_pattern.get_last_binding() {
+            if let Some(node) = binding.as_node() {
+                execute_until(
+                    init_state,
+                    &node.node,
+                    node.source,
+                    context,
+                    logs,
+                    &self.contains,
+                    &self.until,
+                )
+            } else if let Some(items) = binding.list_items() {
+                let mut cur_state = init_state.clone();
+                let mut did_match = false;
+                for item in items {
+                    let state = cur_state.clone();
+                    if self.execute(
+                        &ResolvedPattern::from_node_binding(item),
+                        &mut cur_state,
                         context,
                         logs,
-                        &self.contains,
-                        &self.until,
-                    )
-                } else if let Some(list_items) = binding.list_items() {
-                    let mut did_match = false;
-                    let mut cur_state = init_state.clone();
-                    for item in list_items {
-                        let state = cur_state.clone();
-                        if self.execute(
-                            &ResolvedPattern::from_node(item),
-                            &mut cur_state,
-                            context,
-                            logs,
-                        )? {
-                            did_match = true;
-                        } else {
-                            cur_state = state;
-                        }
-                    }
-
-                    if did_match {
-                        *init_state = cur_state;
-                    }
-                    Ok(did_match)
-                } else if let Some(_c) = binding.as_constant() {
-                    // this seems like an infinite loop, todo return false?
-                    self.contains
-                        .execute(resolved_pattern, init_state, context, logs)
-                } else {
-                    Ok(false)
-                }
-            }
-            ResolvedPattern::List(elements) => {
-                let mut cur_state = init_state.clone();
-                let mut did_match = false;
-                for element in elements {
-                    let state = cur_state.clone();
-                    if self.execute(element, &mut cur_state, context, logs)? {
+                    )? {
                         did_match = true;
                     } else {
                         cur_state = state;
@@ -148,100 +121,118 @@ impl<Q: QueryContext> Matcher<Q> for Contains<Q> {
                 }
                 *init_state = cur_state;
                 Ok(true)
+            } else if let Some(_c) = binding.as_constant() {
+                // this seems like an infinite loop, todo return false?
+                self.contains
+                    .execute(resolved_pattern, init_state, context, logs)
+            } else {
+                Ok(false)
             }
-            ResolvedPattern::File(file) => {
-                let mut cur_state = init_state.clone();
-                let mut did_match = false;
-                let prev_state = cur_state.clone();
-                if self
-                    .contains
-                    .execute(resolved_pattern, &mut cur_state, context, logs)?
-                {
+        } else if let Some(items) = resolved_pattern.get_list_items() {
+            let mut cur_state = init_state.clone();
+            let mut did_match = false;
+            for item in items {
+                let state = cur_state.clone();
+                if self.execute(item, &mut cur_state, context, logs)? {
                     did_match = true;
                 } else {
-                    cur_state = prev_state;
+                    cur_state = state;
                 }
-                let prev_state = cur_state.clone();
-                if self.contains.execute(
-                    &file.name(&cur_state.files),
-                    &mut cur_state,
-                    context,
-                    logs,
-                )? {
-                    did_match = true;
-                } else {
-                    cur_state = prev_state;
-                }
-                let prev_state = cur_state.clone();
-                if self.execute(
-                    &file.binding(&cur_state.files),
-                    &mut cur_state,
-                    context,
-                    logs,
-                )? {
-                    did_match = true;
-                } else {
-                    cur_state = prev_state;
-                }
-                if !did_match {
-                    return Ok(false);
-                }
-                *init_state = cur_state;
-                Ok(true)
             }
-            ResolvedPattern::Files(files) => {
-                let mut cur_state = init_state.clone();
-                let mut did_match = false;
-                let prev_state = cur_state.clone();
-                if self
-                    .contains
-                    .execute(resolved_pattern, &mut cur_state, context, logs)?
-                {
-                    did_match = true;
-                } else {
-                    cur_state = prev_state;
-                }
-                let prev_state = cur_state.clone();
-                if self.execute(files, &mut cur_state, context, logs)? {
-                    did_match = true;
-                } else {
-                    cur_state = prev_state;
-                }
-                if !did_match {
-                    return Ok(false);
-                }
-                *init_state = cur_state;
-                Ok(true)
+            if !did_match {
+                return Ok(false);
             }
-            ResolvedPattern::Snippets(snippets) => {
-                let mut cur_state = init_state.clone();
-                let mut did_match = false;
-                for snippet in snippets {
-                    let state = cur_state.clone();
-                    let resolved = match snippet {
-                        ResolvedSnippet::Text(_) => {
-                            ResolvedPattern::Snippets(vector![snippet.to_owned()])
-                        }
-                        ResolvedSnippet::Binding(b) => {
-                            ResolvedPattern::Binding(vector![b.to_owned()])
-                        }
-                        ResolvedSnippet::LazyFn(l) => match &**l {
-                            LazyBuiltIn::Join(j) => ResolvedPattern::List(j.list.clone()),
-                        },
-                    };
-                    if self.execute(&resolved, &mut cur_state, context, logs)? {
-                        did_match = true;
-                    } else {
-                        cur_state = state;
+            *init_state = cur_state;
+            Ok(true)
+        } else if let Some(file) = resolved_pattern.get_file() {
+            let mut cur_state = init_state.clone();
+            let mut did_match = false;
+            let prev_state = cur_state.clone();
+            if self
+                .contains
+                .execute(resolved_pattern, &mut cur_state, context, logs)?
+            {
+                did_match = true;
+            } else {
+                cur_state = prev_state;
+            }
+            let prev_state = cur_state.clone();
+            if self
+                .contains
+                .execute(&file.name(&cur_state.files), &mut cur_state, context, logs)?
+            {
+                did_match = true;
+            } else {
+                cur_state = prev_state;
+            }
+            let prev_state = cur_state.clone();
+            if self.execute(
+                &file.binding(&cur_state.files),
+                &mut cur_state,
+                context,
+                logs,
+            )? {
+                did_match = true;
+            } else {
+                cur_state = prev_state;
+            }
+            if !did_match {
+                return Ok(false);
+            }
+            *init_state = cur_state;
+            Ok(true)
+        } else if let Some(files) = resolved_pattern.get_files() {
+            let mut cur_state = init_state.clone();
+            let mut did_match = false;
+            let prev_state = cur_state.clone();
+            if self
+                .contains
+                .execute(resolved_pattern, &mut cur_state, context, logs)?
+            {
+                did_match = true;
+            } else {
+                cur_state = prev_state;
+            }
+            let prev_state = cur_state.clone();
+            if self.execute(files, &mut cur_state, context, logs)? {
+                did_match = true;
+            } else {
+                cur_state = prev_state;
+            }
+            if !did_match {
+                return Ok(false);
+            }
+            *init_state = cur_state;
+            Ok(true)
+        } else if let Some(snippets) = resolved_pattern.get_snippets() {
+            let mut cur_state = init_state.clone();
+            let mut did_match = false;
+            for snippet in snippets {
+                let state = cur_state.clone();
+                let resolved = match snippet {
+                    ResolvedSnippet::Text(_) => {
+                        ResolvedPattern::from_resolved_snippet(snippet.to_owned())
                     }
+                    ResolvedSnippet::Binding(b) => ResolvedPattern::from_binding(b.to_owned()),
+                    ResolvedSnippet::LazyFn(l) => match &**l {
+                        LazyBuiltIn::Join(j) => {
+                            ResolvedPattern::from_list_parts(j.list.iter().cloned())
+                        }
+                    },
+                };
+                if self.execute(&resolved, &mut cur_state, context, logs)? {
+                    did_match = true;
+                } else {
+                    cur_state = state;
                 }
-                if !did_match {
-                    return Ok(false);
-                }
-                *init_state = cur_state;
-                Ok(true)
             }
-            ResolvedPattern::Map(_) | ResolvedPattern::Constant(_) => Ok(false),
+            if !did_match {
+                return Ok(false);
+            }
+            *init_state = cur_state;
+            Ok(true)
+        } else {
+            return Ok(false);
         }
     }
 }

--- a/crates/core/src/pattern/divide.rs
+++ b/crates/core/src/pattern/divide.rs
@@ -28,7 +28,7 @@ impl<Q: QueryContext> Divide<Q> {
         logs: &mut AnalysisLogs,
     ) -> Result<ResolvedPattern<'a>> {
         let res = self.evaluate(state, context, logs)?;
-        Ok(ResolvedPattern::Constant(Constant::Float(res)))
+        Ok(ResolvedPattern::from_constant(Constant::Float(res)))
     }
 
     fn evaluate<'a>(

--- a/crates/core/src/pattern/every.rs
+++ b/crates/core/src/pattern/every.rs
@@ -3,9 +3,8 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{context::QueryContext, resolve};
+use crate::{binding::Constant, context::QueryContext};
 use anyhow::Result;
-use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
 
 #[derive(Debug, Clone)]
@@ -35,50 +34,34 @@ impl<Q: QueryContext> Matcher<Q> for Every<Q> {
     ) -> Result<bool> {
         // might be necessary to clone init state at the top,
         // but more performant to not, so leaving out for now.
-        match binding {
-            ResolvedPattern::Binding(bindings) => {
-                let binding = resolve!(bindings.last());
-                let Some(list_items) = binding.list_items() else {
+        if let Some(items) = binding.get_list_binding_items() {
+            let pattern = &self.pattern;
+            for item in items {
+                if !pattern.execute(&item, init_state, context, logs)? {
                     return Ok(false);
-                };
-
-                for item in list_items {
-                    if !self.pattern.execute(
-                        &ResolvedPattern::from_node(item),
-                        init_state,
-                        context,
-                        logs,
-                    )? {
-                        return Ok(false);
-                    }
                 }
-                Ok(true)
             }
-            ResolvedPattern::List(elements) => {
-                let pattern = &self.pattern;
-                for element in elements {
-                    if !pattern.execute(element, init_state, context, logs)? {
-                        return Ok(false);
-                    }
+            Ok(true)
+        } else if let Some(items) = binding.get_list_items() {
+            let pattern = &self.pattern;
+            for item in items {
+                if !pattern.execute(item, init_state, context, logs)? {
+                    return Ok(false);
                 }
-                Ok(true)
             }
-            ResolvedPattern::Map(map) => {
-                let pattern = &self.pattern;
-                for (key, value) in map {
-                    let key =
-                        ResolvedPattern::Constant(crate::binding::Constant::String(key.clone()));
-                    let resolved = ResolvedPattern::List(vector![key, value.clone()]);
-                    if !pattern.execute(&resolved, init_state, context, logs)? {
-                        return Ok(false);
-                    }
+            Ok(true)
+        } else if let Some(map) = binding.get_map() {
+            let pattern = &self.pattern;
+            for (key, value) in map {
+                let key = ResolvedPattern::from_constant(Constant::String(key.clone()));
+                let resolved = ResolvedPattern::from_list_parts([key, value.clone()].into_iter());
+                if !pattern.execute(&resolved, init_state, context, logs)? {
+                    return Ok(false);
                 }
-                Ok(true)
             }
-            ResolvedPattern::Snippets(_)
-            | ResolvedPattern::File(_)
-            | ResolvedPattern::Files(_)
-            | ResolvedPattern::Constant(_) => Ok(false),
+            Ok(true)
+        } else {
+            Ok(false)
         }
     }
 }

--- a/crates/core/src/pattern/file_pattern.rs
+++ b/crates/core/src/pattern/file_pattern.rs
@@ -27,28 +27,23 @@ impl<Q: QueryContext> Matcher<Q> for FilePattern<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        match resolved_pattern {
-            ResolvedPattern::File(file) => {
-                if !self
-                    .name
-                    .execute(&file.name(&state.files), state, context, logs)?
-                {
-                    return Ok(false);
-                }
-                if !self
-                    .body
-                    .execute(&file.binding(&state.files), state, context, logs)?
-                {
-                    return Ok(false);
-                }
-                Ok(true)
-            }
-            ResolvedPattern::Binding(_)
-            | ResolvedPattern::Snippets(_)
-            | ResolvedPattern::List(_)
-            | ResolvedPattern::Map(_)
-            | ResolvedPattern::Files(_)
-            | ResolvedPattern::Constant(_) => Ok(false),
+        let Some(file) = resolved_pattern.get_file() else {
+            return Ok(false);
+        };
+
+        if !self
+            .name
+            .execute(&file.name(&state.files), state, context, logs)?
+        {
+            return Ok(false);
         }
+        if !self
+            .body
+            .execute(&file.binding(&state.files), state, context, logs)?
+        {
+            return Ok(false);
+        }
+
+        Ok(true)
     }
 }

--- a/crates/core/src/pattern/function_definition.rs
+++ b/crates/core/src/pattern/function_definition.rs
@@ -111,6 +111,8 @@ impl<Q: QueryContext> FunctionDefinition<Q> for ForeignFunctionDefinition {
         args: &'a [Option<Pattern<Q>>],
         logs: &mut AnalysisLogs,
     ) -> Result<FuncEvaluation> {
+        use super::resolved_pattern::ResolvedPattern;
+
         let param_names = self
             .params
             .iter()
@@ -159,9 +161,7 @@ impl<Q: QueryContext> FunctionDefinition<Q> for ForeignFunctionDefinition {
 
         Ok(FuncEvaluation {
             predicator: true,
-            ret_val: Some(crate::pattern::resolved_pattern::ResolvedPattern::Constant(
-                Constant::String(string),
-            )),
+            ret_val: Some(ResolvedPattern::from_constant(Constant::String(string))),
         })
     }
 }

--- a/crates/core/src/pattern/list.rs
+++ b/crates/core/src/pattern/list.rs
@@ -40,29 +40,14 @@ impl<Q: QueryContext> Matcher<Q> for List<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        match binding {
-            ResolvedPattern::Binding(v) => {
-                let Some(list_items) = v.last().and_then(|b| b.list_items()) else {
-                    return Ok(false);
-                };
-
-                let children: Vec<Cow<ResolvedPattern>> = list_items
-                    .map(ResolvedPattern::from_node)
-                    .map(Cow::Owned)
-                    .collect();
-
-                execute_assoc(&self.patterns, &children, state, context, logs)
-            }
-            ResolvedPattern::List(patterns) => {
-                let patterns: Vec<Cow<ResolvedPattern<'_>>> =
-                    patterns.into_iter().map(Cow::Borrowed).collect();
-                execute_assoc(&self.patterns, &patterns, state, context, logs)
-            }
-            ResolvedPattern::Snippets(_)
-            | ResolvedPattern::File(_)
-            | ResolvedPattern::Files(_)
-            | ResolvedPattern::Map(_)
-            | ResolvedPattern::Constant(_) => Ok(false),
+        if let Some(items) = binding.get_list_binding_items() {
+            let patterns: Vec<_> = items.map(Cow::Owned).collect();
+            execute_assoc(&self.patterns, &patterns, state, context, logs)
+        } else if let Some(items) = binding.get_list_items() {
+            let patterns: Vec<_> = items.map(Cow::Borrowed).collect();
+            execute_assoc(&self.patterns, &patterns, state, context, logs)
+        } else {
+            Ok(false)
         }
     }
 }

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -7,7 +7,7 @@ use super::{
     state::State,
 };
 use crate::{
-    binding::{Binding, Constant},
+    binding::Binding,
     context::{ExecContext, QueryContext},
     resolve_opt,
 };
@@ -66,21 +66,24 @@ impl<Q: QueryContext> ListIndex<Q> {
                 Some(PatternOrResolved::Pattern(Pattern::List(l))) => {
                     Ok(l.get(index).map(PatternOrResolved::Pattern))
                 }
-                Some(PatternOrResolved::Resolved(ResolvedPattern::Binding(b))) => {
-                    let mut list_items = b
-                        .last()
-                        .and_then(Binding::list_items)
-                        .ok_or_else(|| anyhow!("left side of a listIndex must be a list"))?;
-
-                    let len = list_items.clone().count();
-                    let index = resolve_opt!(to_unsigned(index, len));
-                    return Ok(list_items.nth(index).map(|n| {
-                        PatternOrResolved::ResolvedBinding(ResolvedPattern::from_node(n))
-                    }));
-                }
-                Some(PatternOrResolved::Resolved(ResolvedPattern::List(l))) => {
-                    let index = resolve_opt!(to_unsigned(index, l.len()));
-                    Ok(l.get(index).map(PatternOrResolved::Resolved))
+                Some(PatternOrResolved::Resolved(resolved)) => {
+                    if resolved.is_list() {
+                        Ok(resolved
+                            .get_list_item_at(index)
+                            .map(PatternOrResolved::Resolved))
+                    } else if let Some(mut items) =
+                        resolved.get_last_binding().and_then(Binding::list_items)
+                    {
+                        let len = items.clone().count();
+                        let index = resolve_opt!(to_unsigned(index, len));
+                        Ok(items.nth(index).map(|n| {
+                            PatternOrResolved::ResolvedBinding(ResolvedPattern::from_node_binding(
+                                n,
+                            ))
+                        }))
+                    } else {
+                        bail!("left side of a listIndex must be a list")
+                    }
                 }
                 Some(s) => bail!("left side of a listIndex must be a list but got {:?}", s),
             },
@@ -100,21 +103,20 @@ impl<Q: QueryContext> ListIndex<Q> {
                 Some(PatternOrResolvedMut::Pattern(Pattern::List(l))) => {
                     Ok(l.get(index).map(PatternOrResolvedMut::Pattern))
                 }
-                Some(PatternOrResolvedMut::Resolved(ResolvedPattern::Binding(b))) => {
-                    let mut list_items = b
-                        .last()
-                        .and_then(Binding::list_items)
-                        .ok_or_else(|| anyhow!("left side of a listIndex must be a list"))?;
-
-                    let len = list_items.clone().count();
-                    let index = resolve_opt!(to_unsigned(index, len));
-                    Ok(list_items
-                        .nth(index)
-                        .map(|_| PatternOrResolvedMut::_ResolvedBinding))
-                }
-                Some(PatternOrResolvedMut::Resolved(ResolvedPattern::List(l))) => {
-                    let index = resolve_opt!(to_unsigned(index, l.len()));
-                    Ok(l.get_mut(index).map(PatternOrResolvedMut::Resolved))
+                Some(PatternOrResolvedMut::Resolved(resolved)) => {
+                    if let Some(mut items) = resolved.get_list_binding_items() {
+                        let len = items.clone().count();
+                        let index = resolve_opt!(to_unsigned(index, len));
+                        Ok(items
+                            .nth(index)
+                            .map(|_| PatternOrResolvedMut::_ResolvedBinding))
+                    } else if resolved.is_list() {
+                        Ok(resolved
+                            .get_list_item_at_mut(index)
+                            .map(PatternOrResolvedMut::Resolved))
+                    } else {
+                        bail!("left side of a listIndex must be a list")
+                    }
                 }
                 Some(s) => bail!("left side of a listIndex must be a list but got {:?}", s),
             },
@@ -127,14 +129,13 @@ impl<Q: QueryContext> ListIndex<Q> {
         state: &mut State<'a, Q>,
         lang: &impl Language,
         value: ResolvedPattern<'a>,
-    ) -> Result<Option<ResolvedPattern<'a>>> {
+    ) -> Result<bool> {
         let index = self.get_index(state, lang)?;
         match &self.list {
             ListOrContainer::Container(c) => match c.get_pattern_or_resolved_mut(state, lang)? {
-                None => Ok(None),
-                Some(PatternOrResolvedMut::Resolved(ResolvedPattern::List(l))) => {
-                    let index = resolve_opt!(to_unsigned(index, l.len()));
-                    Ok(Some(l.set(index, value)))
+                None => Ok(false),
+                Some(PatternOrResolvedMut::Resolved(resolved)) => {
+                    resolved.set_list_item_at_mut(index, value)
                 }
                 Some(_) => bail!("accessor can only mutate a resolved list"),
             },
@@ -175,10 +176,7 @@ impl<Q: QueryContext> Matcher<Q> for ListIndex<Q> {
                 execute_resolved_with_binding(&r, binding, state, context.language())
             }
             Some(PatternOrResolved::Pattern(p)) => p.execute(binding, state, context, logs),
-            None => Ok(
-                matches!(binding, ResolvedPattern::Constant(Constant::Boolean(false)))
-                    || binding.matches_undefined(),
-            ),
+            None => Ok(binding.matches_false_or_undefined()),
         }
     }
 }

--- a/crates/core/src/pattern/log.rs
+++ b/crates/core/src/pattern/log.rs
@@ -67,7 +67,7 @@ impl<Q: QueryContext> Log<Q> {
                 })
                 .unwrap_or(Ok("Variable has no source".to_string()))?;
             log_builder.source(src);
-            let node: Option<&Binding> = value.and_then(|v| v.get_binding());
+            let node: Option<&Binding> = value.and_then(|v| v.get_last_binding());
             // todo add support for other types of bindings
             if let Some(node) = node {
                 if let Some(range) = node.position(context.language()) {

--- a/crates/core/src/pattern/map.rs
+++ b/crates/core/src/pattern/map.rs
@@ -37,24 +37,24 @@ impl<Q: QueryContext> Matcher<Q> for GritMap<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        if let ResolvedPattern::Map(map) = binding {
-            for element in map.iter() {
-                if let Some(pattern) = self.elements.get(element.0) {
-                    if !pattern.execute(element.1, state, context, logs)? {
-                        return Ok(false);
-                    }
-                } else {
+        let Some(map) = binding.get_map() else {
+            return Ok(false);
+        };
+
+        for element in map.iter() {
+            if let Some(pattern) = self.elements.get(element.0) {
+                if !pattern.execute(element.1, state, context, logs)? {
                     return Ok(false);
                 }
+            } else {
+                return Ok(false);
             }
-            for element in self.elements.iter() {
-                if !map.contains_key(element.0) {
-                    return Ok(false);
-                }
-            }
-            Ok(true)
-        } else {
-            Ok(false)
         }
+        for element in self.elements.iter() {
+            if !map.contains_key(element.0) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 }

--- a/crates/core/src/pattern/modulo.rs
+++ b/crates/core/src/pattern/modulo.rs
@@ -28,7 +28,7 @@ impl<Q: QueryContext> Modulo<Q> {
         logs: &mut AnalysisLogs,
     ) -> Result<ResolvedPattern<'a>> {
         let res = self.evaluate(state, context, logs)?;
-        Ok(ResolvedPattern::Constant(Constant::Integer(res)))
+        Ok(ResolvedPattern::from_constant(Constant::Integer(res)))
     }
 
     fn evaluate<'a>(

--- a/crates/core/src/pattern/multiply.rs
+++ b/crates/core/src/pattern/multiply.rs
@@ -28,7 +28,7 @@ impl<Q: QueryContext> Multiply<Q> {
         logs: &mut AnalysisLogs,
     ) -> Result<ResolvedPattern<'a>> {
         let res = self.evaluate(state, context, logs)?;
-        Ok(ResolvedPattern::Constant(Constant::Float(res)))
+        Ok(ResolvedPattern::from_constant(Constant::Float(res)))
     }
 
     fn evaluate<'a>(

--- a/crates/core/src/pattern/or.rs
+++ b/crates/core/src/pattern/or.rs
@@ -6,7 +6,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{binding::Binding, context::QueryContext};
+use crate::context::QueryContext;
 use anyhow::Result;
 use core::fmt::Debug;
 use marzano_util::analysis_logs::AnalysisLogs;
@@ -32,16 +32,15 @@ impl<Q: QueryContext> PatternName for Or<Q> {
 impl<Q: QueryContext> Matcher<Q> for Or<Q> {
     fn execute<'a>(
         &'a self,
-        binding: &ResolvedPattern<'a>,
+        resolved: &ResolvedPattern<'a>,
         init_state: &mut State<'a, Q>,
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        if let ResolvedPattern::Binding(binding_vector) = &binding {
+        if let Some(binding) = resolved.get_last_binding() {
             for p in self.patterns.iter() {
                 // filter out pattern which cannot match because of a mismatched node type
-                if let (Some(binding_node), Pattern::AstNode(node_pattern)) =
-                    (binding_vector.last().and_then(Binding::as_node), p)
+                if let (Some(binding_node), Pattern::AstNode(node_pattern)) = (binding.as_node(), p)
                 {
                     // Safety: This is safe as long as `MarzanoProblemContext` is the
                     // only implementation of `ProblemContext`.
@@ -50,7 +49,7 @@ impl<Q: QueryContext> Matcher<Q> for Or<Q> {
                     }
                 }
                 let mut state = init_state.clone();
-                let res = p.execute(binding, &mut state, context, logs)?;
+                let res = p.execute(resolved, &mut state, context, logs)?;
                 if res {
                     *init_state = state;
                     return Ok(true);
@@ -59,7 +58,7 @@ impl<Q: QueryContext> Matcher<Q> for Or<Q> {
         } else {
             for p in self.patterns.iter() {
                 let mut state = init_state.clone();
-                let res = p.execute(binding, &mut state, context, logs)?;
+                let res = p.execute(resolved, &mut state, context, logs)?;
                 if res {
                     *init_state = state;
                     return Ok(true);

--- a/crates/core/src/pattern/patterns.rs
+++ b/crates/core/src/pattern/patterns.rs
@@ -226,7 +226,7 @@ impl<Q: QueryContext> Matcher<Q> for Pattern<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        if let ResolvedPattern::File(file) = &binding {
+        if let Some(file) = binding.get_file() {
             state.bindings[GLOBAL_VARS_SCOPE_INDEX].back_mut().unwrap()[FILENAME_INDEX].value =
                 Some(file.name(&state.files));
             state.bindings[GLOBAL_VARS_SCOPE_INDEX].back_mut().unwrap()[ABSOLUTE_PATH_INDEX]

--- a/crates/core/src/pattern/regex.rs
+++ b/crates/core/src/pattern/regex.rs
@@ -90,23 +90,16 @@ impl<Q: QueryContext> RegexPattern<Q> {
                     continue;
                 }
             } else {
-                let res = if let ResolvedPattern::Binding(binding) = binding {
-                    if let Some(binding) = binding.last() {
-                        if let (Some(mut position), Some(source)) =
-                            (binding.position(context.language()), binding.source())
-                        {
-                            // this moves the byte-range out of sync with
-                            // the row-col range, maybe we should just
-                            // have a Range<usize> for String bindings?
-                            position.end_byte = position.start_byte + range.end as u32;
-                            position.start_byte += range.start as u32;
-                            ResolvedPattern::from_range(position, source)
-                        } else {
-                            ResolvedPattern::from_string(value.to_string())
-                        }
-                    } else {
-                        bail!("binding has no binding")
-                    }
+                let res = if let Some((Some(mut position), Some(source))) = binding
+                    .get_last_binding()
+                    .map(|binding| (binding.position(context.language()), binding.source()))
+                {
+                    // this moves the byte-range out of sync with
+                    // the row-col range, maybe we should just
+                    // have a Range<usize> for String bindings?
+                    position.end_byte = position.start_byte + range.end as u32;
+                    position.start_byte += range.start as u32;
+                    ResolvedPattern::from_range_binding(position, source)
                 } else {
                     ResolvedPattern::from_string(value.to_string())
                 };

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -3,7 +3,7 @@ use super::{
     code_snippet::CodeSnippet,
     dynamic_snippet::{DynamicPattern, DynamicSnippet, DynamicSnippetPart},
     functions::GritCall,
-    list_index::ListIndex,
+    list_index::{to_unsigned, ListIndex},
     paths::absolutize,
     patterns::Pattern,
     state::{FilePtr, FileRegistry, State},
@@ -58,7 +58,7 @@ impl<'a> File<'a> {
     pub(crate) fn name(&self, files: &FileRegistry<'a>) -> ResolvedPattern<'a> {
         match self {
             File::Resolved(resolved) => resolved.name.clone(),
-            File::Ptr(ptr) => ResolvedPattern::from_path(&files.get_file(*ptr).name),
+            File::Ptr(ptr) => ResolvedPattern::from_path_binding(&files.get_file(*ptr).name),
         }
     }
 
@@ -73,7 +73,7 @@ impl<'a> File<'a> {
                 let absolute_path = absolutize(name.as_ref())?;
                 Ok(ResolvedPattern::Constant(Constant::String(absolute_path)))
             }
-            File::Ptr(ptr) => Ok(ResolvedPattern::from_path(
+            File::Ptr(ptr) => Ok(ResolvedPattern::from_path_binding(
                 &files.get_file(*ptr).absolute_path,
             )),
         }
@@ -85,7 +85,7 @@ impl<'a> File<'a> {
             File::Ptr(ptr) => {
                 let file = &files.get_file(*ptr);
                 let range = file.tree.root_node().range().into();
-                ResolvedPattern::from_range(range, &file.source)
+                ResolvedPattern::from_range_binding(range, &file.source)
             }
         }
     }
@@ -96,7 +96,7 @@ impl<'a> File<'a> {
             File::Ptr(ptr) => {
                 let file = &files.get_file(*ptr);
                 let node = file.tree.root_node();
-                ResolvedPattern::from_node(NodeWithSource::new(node, &file.source))
+                ResolvedPattern::from_node_binding(NodeWithSource::new(node, &file.source))
             }
         }
     }
@@ -109,15 +109,14 @@ pub struct JoinFn<'a> {
 }
 
 impl<'a> JoinFn<'a> {
-    pub(crate) fn from_resolved(list: Vector<ResolvedPattern<'a>>, separator: String) -> Self {
-        Self { list, separator }
-    }
-
-    pub(crate) fn from_list_binding(binding: &'_ Binding<'a>, separator: String) -> Option<Self> {
-        binding.list_items().map(|list_items| Self {
-            list: list_items.map(ResolvedPattern::from_node).collect(),
+    pub(crate) fn from_patterns(
+        patterns: impl Iterator<Item = ResolvedPattern<'a>>,
+        separator: String,
+    ) -> Self {
+        Self {
+            list: patterns.collect(),
             separator,
-        })
+        }
     }
 
     fn linearized_text(
@@ -299,12 +298,12 @@ impl<'a> ResolvedSnippet<'a> {
 impl<'a> ResolvedPattern<'a> {
     pub fn extend(
         &mut self,
-        mut with: ResolvedPattern<'a>,
+        mut with: Self,
         effects: &mut Vector<Effect<'a>>,
         language: &impl Language,
     ) -> Result<()> {
         match self {
-            ResolvedPattern::Binding(bindings) => {
+            Self::Binding(bindings) => {
                 let new_effects: Result<Vec<Effect>> = bindings
                     .iter()
                     .map(|b| {
@@ -321,30 +320,30 @@ impl<'a> ResolvedPattern<'a> {
                 effects.extend(new_effects);
                 Ok(())
             }
-            ResolvedPattern::Snippets(snippets) => {
+            Self::Snippets(snippets) => {
                 match with {
-                    ResolvedPattern::Snippets(with_snippets) => {
+                    Self::Snippets(with_snippets) => {
                         snippets.extend(with_snippets);
                     }
-                    ResolvedPattern::Binding(binding) => {
+                    Self::Binding(binding) => {
                         let binding = binding
                             .last()
                             .ok_or_else(|| anyhow!("cannot extend with empty binding"))?;
                         snippets.push_back(ResolvedSnippet::Binding(binding.clone()));
                     }
-                    ResolvedPattern::List(_) => {
+                    Self::List(_) => {
                         return Err(anyhow!("cannot extend ResolvedPattern::Snippet with List"))
                     }
-                    ResolvedPattern::File(_) => {
+                    Self::File(_) => {
                         return Err(anyhow!("cannot extend ResolvedPattern::Snippet with File"))
                     }
-                    ResolvedPattern::Files(_) => {
+                    Self::Files(_) => {
                         return Err(anyhow!("cannot extend ResolvedPattern::Snippet with Files"))
                     }
-                    ResolvedPattern::Map(_) => {
+                    Self::Map(_) => {
                         return Err(anyhow!("cannot extend ResolvedPattern::Snippet with Map"))
                     }
-                    ResolvedPattern::Constant(c) => {
+                    Self::Constant(c) => {
                         snippets.push_back(ResolvedSnippet::Text(c.to_string().into()));
                     }
                 }
@@ -353,15 +352,15 @@ impl<'a> ResolvedPattern<'a> {
             // do we want to auto flattern?
             // for now not since don't know what shape we want,
             // but probably will soon
-            ResolvedPattern::List(lst) => {
+            Self::List(lst) => {
                 lst.push_back(with);
                 Ok(())
             }
-            ResolvedPattern::File(_) => Err(anyhow!("cannot extend ResolvedPattern::File")),
-            ResolvedPattern::Files(_) => Err(anyhow!("cannot extend ResolvedPattern::Files")),
-            ResolvedPattern::Map(_) => Err(anyhow!("cannot extend ResolvedPattern::Map")),
-            ResolvedPattern::Constant(Constant::Integer(i)) => {
-                if let ResolvedPattern::Constant(Constant::Integer(j)) = with {
+            Self::File(_) => Err(anyhow!("cannot extend ResolvedPattern::File")),
+            Self::Files(_) => Err(anyhow!("cannot extend ResolvedPattern::Files")),
+            Self::Map(_) => Err(anyhow!("cannot extend ResolvedPattern::Map")),
+            Self::Constant(Constant::Integer(i)) => {
+                if let Self::Constant(Constant::Integer(j)) = with {
                     *i += j;
                     Ok(())
                 } else {
@@ -370,8 +369,8 @@ impl<'a> ResolvedPattern<'a> {
                     ))
                 }
             }
-            ResolvedPattern::Constant(Constant::Float(x)) => {
-                if let ResolvedPattern::Constant(Constant::Float(y)) = with {
+            Self::Constant(Constant::Float(x)) => {
+                if let Self::Constant(Constant::Float(y)) = with {
                     *x += y;
                     Ok(())
                 } else {
@@ -380,12 +379,12 @@ impl<'a> ResolvedPattern<'a> {
                     ))
                 }
             }
-            ResolvedPattern::Constant(_) => Err(anyhow!("cannot extend ResolvedPattern::Constant")),
+            Self::Constant(_) => Err(anyhow!("cannot extend ResolvedPattern::Constant")),
         }
     }
 
     pub(crate) fn position(&self, language: &impl Language) -> Option<Range> {
-        if let ResolvedPattern::Binding(binding) = self {
+        if let Self::Binding(binding) = self {
             if let Some(binding) = binding.last() {
                 return binding.position(language);
             }
@@ -398,30 +397,46 @@ impl<'a> ResolvedPattern<'a> {
     }
 
     pub(crate) fn undefined() -> Self {
-        Self::Constant(Constant::Undefined)
+        Self::from_constant(Constant::Undefined)
     }
 
-    pub fn from_constant(constant: &'a Constant) -> Self {
+    pub fn from_constant(constant: Constant) -> Self {
+        Self::Constant(constant)
+    }
+
+    pub fn from_constant_binding(constant: &'a Constant) -> Self {
         Self::from_binding(Binding::from_constant(constant))
     }
 
-    pub(crate) fn from_node(node: NodeWithSource<'a>) -> Self {
+    pub(crate) fn from_file_pointer(file: FilePtr) -> Self {
+        Self::File(File::Ptr(file))
+    }
+
+    pub(crate) fn from_files(files: Self) -> Self {
+        Self::Files(Box::new(files))
+    }
+
+    pub(crate) fn from_node_binding(node: NodeWithSource<'a>) -> Self {
         Self::from_binding(Binding::from_node(node))
     }
 
-    pub(crate) fn from_list(node: NodeWithSource<'a>, field_id: FieldId) -> Self {
+    pub(crate) fn from_list_parts(parts: impl Iterator<Item = ResolvedPattern<'a>>) -> Self {
+        Self::List(parts.collect())
+    }
+
+    pub(crate) fn from_list_binding(node: NodeWithSource<'a>, field_id: FieldId) -> Self {
         Self::from_binding(Binding::List(node, field_id))
     }
 
-    pub(crate) fn empty_field(node: NodeWithSource<'a>, field_id: FieldId) -> Self {
+    pub(crate) fn from_empty_binding(node: NodeWithSource<'a>, field_id: FieldId) -> Self {
         Self::from_binding(Binding::Empty(node, field_id))
     }
 
-    pub(crate) fn from_path(path: &'a Path) -> Self {
+    pub(crate) fn from_path_binding(path: &'a Path) -> Self {
         Self::from_binding(Binding::from_path(path))
     }
 
-    pub(crate) fn from_range(range: Range, src: &'a str) -> Self {
+    pub(crate) fn from_range_binding(range: Range, src: &'a str) -> Self {
         Self::from_binding(Binding::from_range(range, src))
     }
 
@@ -435,8 +450,8 @@ impl<'a> ResolvedPattern<'a> {
 
     fn to_snippets(&self) -> Result<Vector<ResolvedSnippet<'a>>> {
         match self {
-            ResolvedPattern::Snippets(snippets) => Ok(snippets.clone()),
-            ResolvedPattern::Binding(bindings) => Ok(vector![ResolvedSnippet::from_binding(
+            Self::Snippets(snippets) => Ok(snippets.clone()),
+            Self::Binding(bindings) => Ok(vector![ResolvedSnippet::from_binding(
                 bindings
                     .last()
                     .ok_or_else(|| {
@@ -444,7 +459,7 @@ impl<'a> ResolvedPattern<'a> {
                     })?
                     .to_owned(),
             )]),
-            ResolvedPattern::List(elements) => {
+            Self::List(elements) => {
                 // merge separated by space
                 let mut snippets = Vec::new();
                 for pattern in elements {
@@ -454,7 +469,7 @@ impl<'a> ResolvedPattern<'a> {
                 snippets.pop();
                 Ok(snippets.into())
             }
-            ResolvedPattern::Map(map) => {
+            Self::Map(map) => {
                 let mut snippets = Vec::new();
                 snippets.push(ResolvedSnippet::Text("{".into()));
                 for (key, value) in map {
@@ -466,24 +481,142 @@ impl<'a> ResolvedPattern<'a> {
                 snippets.push(ResolvedSnippet::Text("}".into()));
                 Ok(snippets.into())
             }
-            ResolvedPattern::File(_) => Err(anyhow!(
+            Self::File(_) => Err(anyhow!(
                 "cannot convert ResolvedPattern::File to ResolvedSnippet"
             )),
-            ResolvedPattern::Files(_) => Err(anyhow!(
+            Self::Files(_) => Err(anyhow!(
                 "cannot convert ResolvedPattern::Files to ResolvedSnippet"
             )),
-            ResolvedPattern::Constant(c) => {
-                Ok(vector![ResolvedSnippet::Text(c.to_string().into(),)])
-            }
+            Self::Constant(c) => Ok(vector![ResolvedSnippet::Text(c.to_string().into(),)]),
         }
     }
 
-    pub fn get_binding(&self) -> Option<&Binding> {
-        if let ResolvedPattern::Binding(bindings) = self {
+    pub fn get_bindings(&self) -> Option<impl Iterator<Item = &Binding<'a>>> {
+        if let Self::Binding(bindings) = self {
+            Some(bindings.iter())
+        } else {
+            None
+        }
+    }
+
+    pub fn get_file(&self) -> Option<&File<'a>> {
+        if let Self::File(file) = self {
+            Some(file)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_file_pointers(&self) -> Option<Vec<FilePtr>> {
+        match self {
+            Self::Binding(_) => None,
+            Self::Snippets(_) => None,
+            Self::List(_) => handle_files(self),
+            Self::Map(_) => None,
+            Self::File(file) => extract_file_pointer(file).map(|f| vec![f]),
+            Self::Files(files) => handle_files(files),
+            Self::Constant(_) => None,
+        }
+    }
+
+    pub fn get_files(&self) -> Option<&Self> {
+        if let Self::Files(files) = self {
+            Some(files)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_last_binding(&self) -> Option<&Binding<'a>> {
+        if let Self::Binding(bindings) = self {
             bindings.last()
         } else {
             None
         }
+    }
+
+    pub fn get_list_item_at(&self, index: isize) -> Option<&Self> {
+        if let Self::List(items) = self {
+            to_unsigned(index, items.len()).and_then(|index| items.get(index))
+        } else {
+            None
+        }
+    }
+
+    pub fn get_list_item_at_mut(&mut self, index: isize) -> Option<&mut Self> {
+        if let Self::List(items) = self {
+            to_unsigned(index, items.len()).and_then(|index| items.get_mut(index))
+        } else {
+            None
+        }
+    }
+
+    pub fn get_list_items(&self) -> Option<impl Iterator<Item = &Self>> {
+        if let Self::List(items) = self {
+            Some(items.iter())
+        } else {
+            None
+        }
+    }
+
+    pub fn get_list_binding_items(&self) -> Option<impl Iterator<Item = Self> + Clone> {
+        self.get_last_binding()
+            .and_then(Binding::list_items)
+            .map(|items| items.map(ResolvedPattern::from_node_binding))
+    }
+
+    pub fn get_map(&self) -> Option<&BTreeMap<String, Self>> {
+        if let Self::Map(map) = self {
+            Some(map)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_map_mut(&mut self) -> Option<&mut BTreeMap<String, Self>> {
+        if let Self::Map(map) = self {
+            Some(map)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_snippets(&self) -> Option<impl Iterator<Item = &ResolvedSnippet<'a>>> {
+        if let Self::Snippets(snippets) = self {
+            Some(snippets.iter())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_binding(&self) -> bool {
+        matches!(self, Self::Binding(_))
+    }
+
+    pub fn is_list(&self) -> bool {
+        matches!(self, Self::List(_))
+    }
+
+    pub fn push_binding(&mut self, binding: Binding<'a>) -> Result<()> {
+        let Self::Binding(bindings) = self else {
+            bail!("can only push to bindings");
+        };
+
+        bindings.push_back(binding);
+        Ok(())
+    }
+
+    pub fn set_list_item_at_mut(&mut self, index: isize, value: Self) -> Result<bool> {
+        let Self::List(items) = self else {
+            bail!("can only set items on a list")
+        };
+
+        let Some(index) = to_unsigned(index, items.len()) else {
+            return Ok(false);
+        };
+
+        items.insert(index, value);
+        Ok(true)
     }
 
     pub fn from_dynamic_snippet<Q: QueryContext>(
@@ -570,11 +703,11 @@ impl<'a> ResolvedPattern<'a> {
     ) -> Result<Self> {
         match accessor.get(state, context.language())? {
             Some(PatternOrResolved::Pattern(pattern)) => {
-                ResolvedPattern::from_pattern(pattern, state, context, logs)
+                Self::from_pattern(pattern, state, context, logs)
             }
             Some(PatternOrResolved::ResolvedBinding(resolved)) => Ok(resolved),
             Some(PatternOrResolved::Resolved(resolved)) => Ok(resolved.clone()),
-            None => Ok(ResolvedPattern::from_constant(&Constant::Undefined)),
+            None => Ok(Self::from_constant_binding(&Constant::Undefined)),
         }
     }
 
@@ -586,11 +719,11 @@ impl<'a> ResolvedPattern<'a> {
     ) -> Result<Self> {
         match index.get(state, context.language())? {
             Some(PatternOrResolved::Pattern(pattern)) => {
-                ResolvedPattern::from_pattern(pattern, state, context, logs)
+                Self::from_pattern(pattern, state, context, logs)
             }
             Some(PatternOrResolved::ResolvedBinding(resolved)) => Ok(resolved),
             Some(PatternOrResolved::Resolved(resolved)) => Ok(resolved.clone()),
-            None => Ok(ResolvedPattern::from_constant(&Constant::Undefined)),
+            None => Ok(Self::from_constant_binding(&Constant::Undefined)),
         }
     }
 
@@ -612,15 +745,9 @@ impl<'a> ResolvedPattern<'a> {
             Pattern::StringConstant(string) => Ok(Self::Snippets(vector![ResolvedSnippet::Text(
                 (&string.text).into(),
             )])),
-            Pattern::IntConstant(int) => {
-                Ok(ResolvedPattern::Constant(Constant::Integer(int.value)))
-            }
-            Pattern::FloatConstant(double) => {
-                Ok(ResolvedPattern::Constant(Constant::Float(double.value)))
-            }
-            Pattern::BooleanConstant(bool) => {
-                Ok(ResolvedPattern::Constant(Constant::Boolean(bool.value)))
-            }
+            Pattern::IntConstant(int) => Ok(Self::Constant(Constant::Integer(int.value))),
+            Pattern::FloatConstant(double) => Ok(Self::Constant(Constant::Float(double.value))),
+            Pattern::BooleanConstant(bool) => Ok(Self::Constant(Constant::Boolean(bool.value))),
             Pattern::Variable(var) => {
                 let content = &state.bindings[var.scope].last().unwrap()[var.index];
                 let name = &content.name;
@@ -658,15 +785,16 @@ impl<'a> ResolvedPattern<'a> {
             Pattern::File(file_pattern) => {
                 let name = &file_pattern.name;
                 let body = &file_pattern.body;
-                let name = ResolvedPattern::from_pattern(name, state, context, logs)?;
+                let name = Self::from_pattern(name, state, context, logs)?;
                 let name = name.text(&state.files, context.language())?;
-                let name = ResolvedPattern::Constant(Constant::String(name.to_string()));
-                let body = ResolvedPattern::from_pattern(body, state, context, logs)?;
+                let name = Self::Constant(Constant::String(name.to_string()));
+                let body = Self::from_pattern(body, state, context, logs)?;
                 // todo: replace GENERATED_SOURCE with a computed source once linearization and
                 // on-the-fly rewrites are in place
-                Ok(ResolvedPattern::File(File::Resolved(Box::new(
-                    ResolvedFile { name, body },
-                ))))
+                Ok(Self::File(File::Resolved(Box::new(ResolvedFile {
+                    name,
+                    body,
+                }))))
             }
             Pattern::Add(add_pattern) => add_pattern.call(state, context, logs),
             Pattern::Subtract(subtract_pattern) => subtract_pattern.call(state, context, logs),
@@ -725,7 +853,7 @@ impl<'a> ResolvedPattern<'a> {
         match self {
             // if whitespace is significant we need to distribute indentations
             // across lines within the snippet
-            ResolvedPattern::Snippets(snippets) => {
+            Self::Snippets(snippets) => {
                 if should_pad_snippet {
                     let mut res = String::new();
                     let mut padding = 0;
@@ -754,7 +882,7 @@ impl<'a> ResolvedPattern<'a> {
                 }
             }
             // we may have to distribute indentations as we did for snippets above
-            ResolvedPattern::List(list) => Ok(list
+            Self::List(list) => Ok(list
                 .iter()
                 .map(|pattern| {
                     pattern.linearized_text(
@@ -769,7 +897,7 @@ impl<'a> ResolvedPattern<'a> {
                 .collect::<Result<Vec<_>>>()?
                 .join(",")
                 .into()),
-            ResolvedPattern::Map(map) => Ok(("{".to_string()
+            Self::Map(map) => Ok(("{".to_string()
                 + &map
                     .iter()
                     .map(|(key, value)| {
@@ -796,7 +924,7 @@ impl<'a> ResolvedPattern<'a> {
                 + "}")
                 .into()),
             // might have to handle differently for ResolvedPattern::List containing indent followed by binding
-            ResolvedPattern::Binding(binding) => Ok(binding
+            Self::Binding(binding) => Ok(binding
                 .last()
                 .ok_or_else(|| anyhow!("cannot grab text of resolved_pattern with no binding"))?
                 .linearized_text(
@@ -807,7 +935,7 @@ impl<'a> ResolvedPattern<'a> {
                     should_pad_snippet.then_some(0),
                     logs,
                 )?),
-            ResolvedPattern::File(file) => Ok(format!(
+            Self::File(file) => Ok(format!(
                 "{}:\n{}",
                 file.name(files)
                     .linearized_text(language, effects, files, memo, false, logs)?,
@@ -822,23 +950,23 @@ impl<'a> ResolvedPattern<'a> {
             )
             .into()),
             // unsure if this is correct, taken from text
-            ResolvedPattern::Files(_files) => {
+            Self::Files(_files) => {
                 bail!("cannot linearize files pattern, not implemented yet");
             }
             // unsure if this is correct, taken from text
-            ResolvedPattern::Constant(c) => Ok(c.to_string().into()),
+            Self::Constant(c) => Ok(c.to_string().into()),
         }
     }
 
     pub(crate) fn float(&self, state: &FileRegistry<'a>, language: &impl Language) -> Result<f64> {
         match self {
-            ResolvedPattern::Constant(c) => match c {
+            Self::Constant(c) => match c {
                 Constant::Float(d) => Ok(*d),
                 Constant::Integer(i) => Ok(*i as f64),
                 Constant::String(s) => Ok(s.parse::<f64>()?),
                 Constant::Boolean(_) | Constant::Undefined => Err(anyhow!("Cannot convert constant to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")),
             },
-            ResolvedPattern::Snippets(s) => {
+            Self::Snippets(s) => {
                 let text = s
                     .iter()
                     .map(|snippet| snippet.text(state, language))
@@ -848,7 +976,7 @@ impl<'a> ResolvedPattern<'a> {
                     anyhow!("Failed to convert snippet to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")
                 })
             }
-            ResolvedPattern::Binding(binding) => {
+            Self::Binding(binding) => {
                 let text = binding
                     .last()
                     .ok_or_else(|| anyhow!("cannot grab text of resolved_pattern with no binding"))?
@@ -857,42 +985,47 @@ impl<'a> ResolvedPattern<'a> {
                     anyhow!("Failed to convert binding to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")
                 })
             }
-            ResolvedPattern::List(_) | ResolvedPattern::Map(_) | ResolvedPattern::File(_) | ResolvedPattern::Files(_) => Err(anyhow!("Cannot convert type to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")),
+            Self::List(_) | Self::Map(_) | Self::File(_) | Self::Files(_) => Err(anyhow!("Cannot convert type to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")),
         }
     }
 
     pub(crate) fn matches_undefined(&self) -> bool {
         match self {
-            ResolvedPattern::Binding(b) => b
+            Self::Binding(b) => b
                 .last()
                 .and_then(Binding::as_constant)
                 .map_or(false, Constant::is_undefined),
-            ResolvedPattern::Constant(Constant::Undefined) => true,
-            ResolvedPattern::Constant(_)
-            | ResolvedPattern::Snippets(_)
-            | ResolvedPattern::List(_)
-            | ResolvedPattern::Map(_)
-            | ResolvedPattern::File(_)
-            | ResolvedPattern::Files(_) => false,
+            Self::Constant(Constant::Undefined) => true,
+            Self::Constant(_)
+            | Self::Snippets(_)
+            | Self::List(_)
+            | Self::Map(_)
+            | Self::File(_)
+            | Self::Files(_) => false,
         }
+    }
+
+    pub(crate) fn matches_false_or_undefined(&self) -> bool {
+        // should this match a binding to the constant `false` as well?
+        matches!(self, Self::Constant(Constant::Boolean(false))) || self.matches_undefined()
     }
 
     // should we instead return an Option?
     pub fn text(&self, state: &FileRegistry<'a>, language: &impl Language) -> Result<Cow<'a, str>> {
         match self {
-            ResolvedPattern::Snippets(snippets) => Ok(snippets
+            Self::Snippets(snippets) => Ok(snippets
                 .iter()
                 .map(|snippet| snippet.text(state, language))
                 .collect::<Result<Vec<_>>>()?
                 .join("")
                 .into()),
-            ResolvedPattern::List(list) => Ok(list
+            Self::List(list) => Ok(list
                 .iter()
                 .map(|pattern| pattern.text(state, language))
                 .collect::<Result<Vec<_>>>()?
                 .join(",")
                 .into()),
-            ResolvedPattern::Map(map) => Ok(("{".to_string()
+            Self::Map(map) => Ok(("{".to_string()
                 + &map
                     .iter()
                     .map(|(key, value)| {
@@ -908,19 +1041,19 @@ impl<'a> ResolvedPattern<'a> {
                     .join(", ")
                 + "}")
                 .into()),
-            ResolvedPattern::Binding(binding) => Ok(binding
+            Self::Binding(binding) => Ok(binding
                 .last()
                 .ok_or_else(|| anyhow!("cannot grab text of resolved_pattern with no binding"))?
                 .text(language)?
                 .into()),
-            ResolvedPattern::File(file) => Ok(format!(
+            Self::File(file) => Ok(format!(
                 "{}:\n{}",
                 file.name(state).text(state, language)?,
                 file.body(state).text(state, language)?
             )
             .into()),
-            ResolvedPattern::Files(files) => files.text(state, language),
-            ResolvedPattern::Constant(constant) => Ok(constant.to_string().into()),
+            Self::Files(files) => files.text(state, language),
+            Self::Constant(constant) => Ok(constant.to_string().into()),
         }
     }
 
@@ -930,7 +1063,7 @@ impl<'a> ResolvedPattern<'a> {
         is_first: bool,
         language: &impl Language,
     ) -> Result<()> {
-        let ResolvedPattern::Snippets(ref mut snippets) = self else {
+        let Self::Snippets(ref mut snippets) = self else {
             return Ok(());
         };
         let Some(ResolvedSnippet::Text(text)) = snippets.front() else {
@@ -1002,6 +1135,20 @@ pub fn patterns_to_resolved<'a, Q: QueryContext>(
             None => Ok(None),
         })
         .collect::<Result<Vec<_>>>()
+}
+
+fn extract_file_pointer(file: &File) -> Option<FilePtr> {
+    match file {
+        File::Resolved(_) => None,
+        File::Ptr(ptr) => Some(*ptr),
+    }
+}
+
+fn handle_files(files_list: &ResolvedPattern) -> Option<Vec<FilePtr>> {
+    let files = files_list.get_list_items()?;
+    files
+        .map(|r| r.get_file().and_then(extract_file_pointer))
+        .collect()
 }
 
 /*

--- a/crates/core/src/pattern/rewrite.rs
+++ b/crates/core/src/pattern/rewrite.rs
@@ -75,30 +75,12 @@ impl<Q: QueryContext> Rewrite<Q> {
                 }
             }
         };
-        let bindings = match resolved.as_ref() {
-            ResolvedPattern::Binding(b) => b,
-            ResolvedPattern::Constant(_) => {
-                bail!("variable on left hand side of rewrite side-conditions cannot be bound to a constant")
-            }
-            ResolvedPattern::File(_) => {
-                bail!("variable on left hand side of rewrite side-conditions cannot be bound to a file, try rewriting the content, or name instead")
-            }
-            ResolvedPattern::Files(_) => {
-                bail!("variable on left hand side of rewrite side-conditions cannot be bound to a files node")
-            }
-            ResolvedPattern::List(_) => {
-                bail!("variable on left hand side of rewrite side-conditions cannot be bound to a list pattern")
-            }
-            ResolvedPattern::Map(_) => {
-                bail!("variable on left hand side of rewrite side-conditions cannot be bound to a map pattern")
-            }
-            ResolvedPattern::Snippets(_) => {
-                bail!("variable on left hand side of rewrite side-conditions cannot be bound to snippets")
-            }
+        let Some(bindings) = resolved.get_bindings() else {
+            bail!("variable on left hand side of rewrite side-conditions can only be bound to bindings")
         };
         let replacement: ResolvedPattern<'_> =
             ResolvedPattern::from_dynamic_pattern(&self.right, state, context, logs)?;
-        let effects = bindings.iter().map(|b| Effect {
+        let effects = bindings.map(|b| Effect {
             binding: b.clone(),
             pattern: replacement.clone(),
             kind: EffectKind::Rewrite,

--- a/crates/core/src/pattern/some.rs
+++ b/crates/core/src/pattern/some.rs
@@ -3,9 +3,8 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{context::QueryContext, resolve};
+use crate::{binding::Constant, context::QueryContext};
 use anyhow::Result;
-use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
 
 #[derive(Debug, Clone)]
@@ -33,68 +32,50 @@ impl<Q: QueryContext> Matcher<Q> for Some<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        match binding {
-            ResolvedPattern::Binding(bindings) => {
-                let binding = resolve!(bindings.last());
-                let Some(list_items) = binding.list_items() else {
-                    return Ok(false);
-                };
-
-                let mut did_match = false;
-                let mut cur_state = init_state.clone();
-                for item in list_items {
-                    let state = cur_state.clone();
-                    if self.pattern.execute(
-                        &ResolvedPattern::from_node(item),
-                        &mut cur_state,
-                        context,
-                        logs,
-                    )? {
-                        did_match = true;
-                    } else {
-                        cur_state = state;
-                    }
+        if let Some(items) = binding.get_list_binding_items() {
+            let mut did_match = false;
+            let mut cur_state = init_state.clone();
+            for item in items {
+                let state = cur_state.clone();
+                if self.pattern.execute(&item, &mut cur_state, context, logs)? {
+                    did_match = true;
+                } else {
+                    cur_state = state;
                 }
-                *init_state = cur_state;
-                Ok(did_match)
             }
-            ResolvedPattern::List(elements) => {
-                let pattern = &self.pattern;
-                let mut cur_state = init_state.clone();
-                let mut did_match = false;
-                for element in elements {
-                    let state = cur_state.clone();
-                    if pattern.execute(element, &mut cur_state, context, logs)? {
-                        did_match = true;
-                    } else {
-                        cur_state = state;
-                    }
+            *init_state = cur_state;
+            Ok(did_match)
+        } else if let Some(items) = binding.get_list_items() {
+            let mut cur_state = init_state.clone();
+            let mut did_match = false;
+            for item in items {
+                let state = cur_state.clone();
+                if self.pattern.execute(item, &mut cur_state, context, logs)? {
+                    did_match = true;
+                } else {
+                    cur_state = state;
                 }
-                *init_state = cur_state;
-                Ok(did_match)
             }
-            ResolvedPattern::Map(map) => {
-                let pattern = &self.pattern;
-                let mut cur_state = init_state.clone();
-                let mut did_match = false;
-                for (key, value) in map {
-                    let state = cur_state.clone();
-                    let key =
-                        ResolvedPattern::Constant(crate::binding::Constant::String(key.clone()));
-                    let resolved = ResolvedPattern::List(vector![key, value.clone()]);
-                    if pattern.execute(&resolved, &mut cur_state, context, logs)? {
-                        did_match = true;
-                    } else {
-                        cur_state = state;
-                    }
+            *init_state = cur_state;
+            Ok(did_match)
+        } else if let Some(map) = binding.get_map() {
+            let pattern = &self.pattern;
+            let mut cur_state = init_state.clone();
+            let mut did_match = false;
+            for (key, value) in map {
+                let state = cur_state.clone();
+                let key = ResolvedPattern::from_constant(Constant::String(key.clone()));
+                let resolved = ResolvedPattern::from_list_parts([key, value.clone()].into_iter());
+                if pattern.execute(&resolved, &mut cur_state, context, logs)? {
+                    did_match = true;
+                } else {
+                    cur_state = state;
                 }
-                *init_state = cur_state;
-                Ok(did_match)
             }
-            ResolvedPattern::Snippets(_)
-            | ResolvedPattern::File(_)
-            | ResolvedPattern::Files(_)
-            | ResolvedPattern::Constant(_) => Ok(false),
+            *init_state = cur_state;
+            Ok(did_match)
+        } else {
+            Ok(false)
         }
     }
 }

--- a/crates/core/src/pattern/state.rs
+++ b/crates/core/src/pattern/state.rs
@@ -1,6 +1,5 @@
 use super::{
-    constants::MATCH_VAR, patterns::Pattern, resolved_pattern::ResolvedPattern, variable::Variable,
-    variable_content::VariableContent,
+    constants::MATCH_VAR, patterns::Pattern, variable::Variable, variable_content::VariableContent,
 };
 use crate::context::QueryContext;
 use crate::intervals::{earliest_deadline_sort, get_top_level_intervals_in_range, Interval};
@@ -236,8 +235,8 @@ impl<'a, Q: QueryContext> State<'a, Q> {
                 let mut bindings_count = 0;
                 let mut suppressed_count = 0;
                 for value in content.value_history.iter() {
-                    if let ResolvedPattern::Binding(bindings) = value {
-                        for binding in bindings.iter() {
+                    if let Some(bindings) = value.get_bindings() {
+                        for binding in bindings {
                             bindings_count += 1;
                             if binding.is_suppressed(lang, current_name) {
                                 suppressed_count += 1;

--- a/crates/core/src/pattern/string_constant.rs
+++ b/crates/core/src/pattern/string_constant.rs
@@ -84,10 +84,7 @@ impl<Q: QueryContext> Matcher<Q> for AstLeafNode {
         _context: &'a Q::ExecContext<'a>,
         _logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let ResolvedPattern::Binding(b) = binding else {
-            return Ok(false);
-        };
-        let Some(node) = b.last().and_then(Binding::singleton) else {
+        let Some(node) = binding.get_last_binding().and_then(Binding::singleton) else {
             return Ok(false);
         };
         if let Some(e) = &self.equivalence_class {

--- a/crates/core/src/pattern/subtract.rs
+++ b/crates/core/src/pattern/subtract.rs
@@ -28,7 +28,7 @@ impl<Q: QueryContext> Subtract<Q> {
         logs: &mut AnalysisLogs,
     ) -> Result<ResolvedPattern<'a>> {
         let res = self.evaluate(state, context, logs)?;
-        Ok(ResolvedPattern::Constant(Constant::Float(res)))
+        Ok(ResolvedPattern::from_constant(Constant::Float(res)))
     }
 
     fn evaluate<'a>(

--- a/crates/core/src/pattern/variable_content.rs
+++ b/crates/core/src/pattern/variable_content.rs
@@ -1,10 +1,8 @@
+use super::{resolved_pattern::ResolvedPattern, state::State, variable::Variable};
+use crate::{context::QueryContext, pattern::patterns::Pattern};
 use anyhow::{anyhow, Result};
 use marzano_language::language::Language;
 use std::borrow::Cow;
-
-use crate::{context::QueryContext, pattern::patterns::Pattern};
-
-use super::{resolved_pattern::ResolvedPattern, state::State, variable::Variable};
 
 #[derive(Debug, Clone)]
 pub struct VariableContent<'a, Q: QueryContext> {
@@ -38,7 +36,7 @@ impl<'a, Q: QueryContext> VariableContent<'a, Q> {
         }
     }
 
-    pub(crate) fn set_value(&mut self, value: ResolvedPattern<'a>) -> Option<ResolvedPattern<'a>> {
-        std::mem::replace(&mut self.value, Some(value))
+    pub(crate) fn set_value(&mut self, value: ResolvedPattern<'a>) {
+        self.value = Some(value);
     }
 }

--- a/crates/core/src/pattern/within.rs
+++ b/crates/core/src/pattern/within.rs
@@ -3,7 +3,7 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{context::QueryContext, resolve};
+use crate::{binding::Binding, context::QueryContext};
 use anyhow::Result;
 use core::fmt::Debug;
 use grit_util::AstNode;
@@ -47,19 +47,13 @@ impl<Q: QueryContext> Matcher<Q> for Within<Q> {
             cur_state = state;
         }
 
-        let binding = if let ResolvedPattern::Binding(binding) = binding {
-            resolve!(binding.last())
-        } else {
-            return Ok(did_match);
-        };
-
-        let Some(node) = binding.parent_node() else {
+        let Some(node) = binding.get_last_binding().and_then(Binding::parent_node) else {
             return Ok(did_match);
         };
         for n in node.ancestors() {
             let state = cur_state.clone();
             if self.pattern.execute(
-                &ResolvedPattern::from_node(n),
+                &ResolvedPattern::from_node_binding(n),
                 &mut cur_state,
                 context,
                 logs,

--- a/crates/core/src/snapshots/marzano_core__test__some_every_errors_on_invalid_rewrite.snap
+++ b/crates/core/src/snapshots/marzano_core__test__some_every_errors_on_invalid_rewrite.snap
@@ -1,12 +1,12 @@
 ---
-source: apps/marzano/core/src/test.rs
+source: crates/core/src/test.rs
 expression: results
 ---
 - __typename: DoneFile
   relativeFilePath: test-file.tsx
 - __typename: AnalysisLog
   level: 280
-  message: variable on left hand side of rewrite side-conditions cannot be bound to a constant
+  message: variable on left hand side of rewrite side-conditions can only be bound to bindings
   position:
     line: 1
     column: 1
@@ -15,4 +15,3 @@ expression: results
   range: ~
   syntaxTree: ~
   source: ~
-


### PR DESCRIPTION
While preparing to put `Binding` behind a trait, I realized `ResolvedPattern` will have to be put behind a trait as well. This cannot be done as long as all the variants get used directly all over the placed, so I added additional methods to make these accesses more abstract.

Then the conversion to traits should be doable in one or two PRs, and after this both `Binding` and `ResolvedPattern` should be fully abstract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved handling and efficiency of pattern matching and bindings across various modules.
  - Enhanced error handling and processing in built-in functions.
  - Streamlined logic for handling resolved patterns, improving code clarity and performance.
- **Bug Fixes**
  - Fixed inconsistencies in handling `ResolvedPattern` across different scenarios, ensuring more reliable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->