### PR TITLE
chore: use cow to avoid unnecessary clones

### DIFF
--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -455,7 +455,7 @@ impl<'a> Binding<'a> {
             Self::Empty(_, _) => Ok("".into()),
             Self::Node(node) => Ok(node.text()?),
             Self::String(s, r) => Ok(s[r.start_byte as usize..r.end_byte as usize].into()),
-            Self::FileName(s) => Ok(s.to_string_lossy().into()),
+            Self::FileName(s) => Ok(s.to_string_lossy()),
             Self::List(node, _) => Ok(if let Some(pos) = self.position(language) {
                 node.source[pos.start_byte as usize..pos.end_byte as usize].into()
             } else {

--- a/crates/core/src/binding.rs
+++ b/crates/core/src/binding.rs
@@ -450,18 +450,18 @@ impl<'a> Binding<'a> {
         res
     }
 
-    pub fn text(&self, language: &impl Language) -> Result<String> {
+    pub fn text(&self, language: &impl Language) -> Result<Cow<str>> {
         match self {
-            Self::Empty(_, _) => Ok("".to_string()),
+            Self::Empty(_, _) => Ok("".into()),
             Self::Node(node) => Ok(node.text()?),
             Self::String(s, r) => Ok(s[r.start_byte as usize..r.end_byte as usize].into()),
             Self::FileName(s) => Ok(s.to_string_lossy().into()),
             Self::List(node, _) => Ok(if let Some(pos) = self.position(language) {
-                node.source[pos.start_byte as usize..pos.end_byte as usize].to_string()
+                node.source[pos.start_byte as usize..pos.end_byte as usize].into()
             } else {
-                "".to_string()
+                "".into()
             }),
-            Self::ConstantRef(c) => Ok(c.to_string()),
+            Self::ConstantRef(c) => Ok(c.to_string().into()),
         }
     }
 

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -247,7 +247,7 @@ impl<'a> ResolvedSnippet<'a> {
             ResolvedSnippet::Binding(binding) => {
                 // we are now taking the unmodified source code, and replacing the binding with the snippet
                 // we will want to apply effects next
-                Ok(binding.text(language)?.into())
+                binding.text(language).map(|c| c.into_owned().into())
             }
             ResolvedSnippet::LazyFn(lazy) => lazy.text(state, language),
         }
@@ -912,6 +912,7 @@ impl<'a> ResolvedPattern<'a> {
                 .last()
                 .ok_or_else(|| anyhow!("cannot grab text of resolved_pattern with no binding"))?
                 .text(language)?
+                .into_owned()
                 .into()),
             ResolvedPattern::File(file) => Ok(format!(
                 "{}:\n{}",

--- a/crates/core/src/pattern_compiler/foreign_language_compiler.rs
+++ b/crates/core/src/pattern_compiler/foreign_language_compiler.rs
@@ -14,6 +14,6 @@ impl NodeCompiler for ForeignLanguageCompiler {
         _context: &mut NodeCompilationContext,
         _is_rhs: bool,
     ) -> Result<Self::TargetPattern> {
-        node.text()?.as_str().try_into()
+        node.text()?.try_into()
     }
 }

--- a/crates/core/src/pattern_compiler/log_compiler.rs
+++ b/crates/core/src/pattern_compiler/log_compiler.rs
@@ -29,7 +29,7 @@ impl NodeCompiler for LogCompiler {
             .map(|n| {
                 let name = n.text()?;
                 let variable = VariableCompiler::from_node(&n, context)?;
-                Ok(VariableInfo::new(name, variable))
+                Ok(VariableInfo::new(name.to_string(), variable))
             })
             .map_or(Ok(None), |v: Result<VariableInfo>| v.map(Some))?;
 

--- a/crates/core/src/pattern_compiler/map_compiler.rs
+++ b/crates/core/src/pattern_compiler/map_compiler.rs
@@ -25,7 +25,8 @@ impl NodeCompiler for MapCompiler {
             let key = element
                 .child_by_field_name("key")
                 .ok_or_else(|| anyhow!("key not found in map element"))?
-                .text()?;
+                .text()?
+                .to_string();
             let value = element
                 .child_by_field_name("value")
                 .ok_or_else(|| anyhow!("value not found in map element"))?;

--- a/crates/grit-util/src/ast_node.rs
+++ b/crates/grit-util/src/ast_node.rs
@@ -1,4 +1,4 @@
-use std::str::Utf8Error;
+use std::{borrow::Cow, str::Utf8Error};
 
 use crate::CodeRange;
 
@@ -32,7 +32,7 @@ pub trait AstNode: std::fmt::Debug + Sized {
     fn previous_sibling(&self) -> Option<Self>;
 
     /// Returns the text representation of the node.
-    fn text(&self) -> Result<String, Utf8Error>;
+    fn text(&self) -> Result<Cow<str>, Utf8Error>;
 
     /// Returns the code range of the node.
     fn code_range(&self) -> CodeRange;

--- a/crates/language/src/xscript_util.rs
+++ b/crates/language/src/xscript_util.rs
@@ -146,7 +146,7 @@ pub(crate) fn jslike_check_replacements(
         }
     } else if n.node.is_error()
         && n.text()
-            .is_ok_and(|t| ["var", "let", "const"].contains(&t.as_str()))
+            .is_ok_and(|t| ["var", "let", "const"].contains(&t.as_ref()))
         || n.node.kind() == "empty_statement"
     {
         replacement_ranges.push(Replacement::new(n.range(), ""));

--- a/crates/util/src/node_with_source.rs
+++ b/crates/util/src/node_with_source.rs
@@ -1,4 +1,4 @@
-use std::{ptr, str::Utf8Error};
+use std::{borrow::Cow, ptr, str::Utf8Error};
 
 use crate::position::Range;
 
@@ -116,8 +116,8 @@ impl<'a> AstNode for NodeWithSource<'a> {
             .map(|sibling| Self::new(sibling, self.source))
     }
 
-    fn text(&self) -> Result<String, Utf8Error> {
-        Ok(self.node.utf8_text(self.source.as_bytes())?.to_string())
+    fn text(&self) -> Result<Cow<str>, Utf8Error> {
+        self.node.utf8_text(self.source.as_bytes())
     }
 
     fn code_range(&self) -> CodeRange {


### PR DESCRIPTION
text function should not be cloning the string every time it's called

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved text handling across various components to enhance performance and reduce memory usage by using more efficient data types.
	- Updated usage of data types and methods for text handling to align with best practices and improve code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->