### PR TITLE
fix: exit gracefully in non-tty

### DIFF
--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -239,7 +239,7 @@ pub(crate) async fn run_apply_pattern(
         if warn_uncommitted {
             let term = console::Term::stderr();
             if !term.is_term() {
-                bail!("Your working tree currently has untracked changes and Grit will rewrite files in place by default. Commit all changes or use --force to proceed.");
+                bail!("Error: Untracked changes detected. Grit will not proceed with rewriting files in non-TTY environments unless '--force' is used. Please commit all changes or use '--force' to override this safety check.");
             }
 
             let proceed = flushable_unwrap!(emitter, Confirm::new()

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -240,9 +240,9 @@ pub(crate) async fn run_apply_pattern(
             let proceed = flushable_unwrap!(emitter, Confirm::new()
                 .with_prompt("Your working tree currently has untracked changes and Grit will rewrite files in place. Do you want to proceed?")
                 .default(false)
-                .interact());
+                .interact_opt());
 
-            if !proceed {
+            if proceed != Some(true) {
                 return Ok(());
             }
         }

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -237,6 +237,11 @@ pub(crate) async fn run_apply_pattern(
         let warn_uncommitted =
             !arg.dry_run && !arg.force && has_uncommitted_changes(cwd.clone()).await;
         if warn_uncommitted {
+            let term = console::Term::stderr();
+            if !term.is_term() {
+                bail!("Your working tree currently has untracked changes and Grit will rewrite files in place by default. Commit all changes or use --force to proceed.");
+            }
+
             let proceed = flushable_unwrap!(emitter, Confirm::new()
                 .with_prompt("Your working tree currently has untracked changes and Grit will rewrite files in place. Do you want to proceed?")
                 .default(false)

--- a/crates/cli_bin/tests/apply.rs
+++ b/crates/cli_bin/tests/apply.rs
@@ -2408,5 +2408,23 @@ fn tty_behavior() -> Result<()> {
     let content = std::fs::read_to_string(dir.join("file.yaml"))?;
     assert_snapshot!(content);
 
+    // Run again with force
+    let mut apply_cmd = get_test_cmd()?;
+    apply_cmd.current_dir(dir.clone());
+    apply_cmd
+        .arg("apply")
+        .arg("pattern.grit")
+        .arg("file.yaml")
+        .arg("--force");
+
+    let output = apply_cmd.output()?;
+    assert!(
+        output.status.success(),
+        "Command didn't finish successfully"
+    );
+
+    let content = std::fs::read_to_string(dir.join("file.yaml"))?;
+    assert_snapshot!(content);
+
     Ok(())
 }

--- a/crates/cli_bin/tests/apply.rs
+++ b/crates/cli_bin/tests/apply.rs
@@ -2399,9 +2399,7 @@ fn tty_behavior() -> Result<()> {
 
     // Confirm the explanation is good
     assert!(!stderr.contains("Not a terminal"));
-    assert!(stderr.contains(
-        "Your working tree currently has untracked changes and Grit will rewrite files in place by default."
-    ));
+    assert!(stderr.contains("Untracked changes detected."));
     assert!(stderr.contains("--force"));
 
     // Confirm file is not modified

--- a/crates/cli_bin/tests/apply.rs
+++ b/crates/cli_bin/tests/apply.rs
@@ -2399,7 +2399,10 @@ fn tty_behavior() -> Result<()> {
 
     // Confirm the explanation is good
     assert!(!stderr.contains("Not a terminal"));
-    assert!(stderr.contains("Your working tree currently has untracked changes and Grit will rewrite files in place."));
+    assert!(stderr.contains(
+        "Your working tree currently has untracked changes and Grit will rewrite files in place by default."
+    ));
+    assert!(stderr.contains("--force"));
 
     // Confirm file is not modified
     let content = std::fs::read_to_string(dir.join("file.yaml"))?;

--- a/crates/cli_bin/tests/snapshots/apply__tty_behavior-2.snap
+++ b/crates/cli_bin/tests/snapshots/apply__tty_behavior-2.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli_bin/tests/apply.rs
+expression: content
+---
+this list:
+  - nice: car
+    second: detail
+  - item: two
+map:
+  stuff: good
+  things: bad
+  indented:
+    item: pig
+    distro: true

--- a/crates/cli_bin/tests/snapshots/apply__tty_behavior.snap
+++ b/crates/cli_bin/tests/snapshots/apply__tty_behavior.snap
@@ -1,0 +1,16 @@
+---
+source: crates/cli_bin/tests/apply.rs
+expression: content
+---
+this list:
+  - item: one
+    description: |
+      This is a description
+      that spans multiple lines
+  - item: two
+map:
+  stuff: good
+  things: bad
+  indented:
+    item: map
+    items: two


### PR DESCRIPTION
Fixes https://github.com/getgrit/gritql/issues/258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced safety in file rewriting operations by checking for untracked changes before proceeding.
	- Added user prompts for confirmation to proceed with changes when untracked files are detected.

- **Tests**
	- Implemented new tests to verify correct behavior under non-interactive conditions and ensure error handling with untracked changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->