### PR TITLE
feat: clean up --only-in-json

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -134,14 +134,6 @@ jobs:
         uses: actions/setup-go@v5.0.0
         with:
           go-version: "^1.22.0"
-      - name: test redirection
-        working-directory: ./crates/cli_bin/fixtures/filtered_apply
-        run: |
-          output=$(../../../../target/release/marzano apply --dry-run fix.grit --only-in-json <( echo '[{"filePath":"file.js", "messages": [{ "line": 4, "column": 1, "endLine": 4, "endColumn": 50}]}]' ))
-          if ! echo "$output" | grep -q "found 1 matches"; then
-            echo "Error: Expected output to contain 'found 1 matches'"
-            exit 1
-          fi
       - name: test stdlib
         working-directory: ./stdlib
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -134,6 +134,14 @@ jobs:
         uses: actions/setup-go@v5.0.0
         with:
           go-version: "^1.22.0"
+      - name: test redirection
+        working-directory: ./crates/cli_bin/fixtures/filtered_apply
+        run: |
+          output=$(../../../../target/release/marzano apply --dry-run fix.grit --only-in-json <( echo '[{"filePath":"file.js", "messages": [{ "line": 4, "column": 1, "endLine": 4, "endColumn": 50}]}]' ))
+          if ! echo "$output" | grep -q "found 1 matches"; then
+            echo "Error: Expected output to contain 'found 1 matches'"
+            exit 1
+          fi
       - name: test stdlib
         working-directory: ./stdlib
         run: |

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -18,8 +18,7 @@ use super::apply_pattern::{run_apply_pattern, ApplyPatternArgs};
 pub struct SharedApplyArgs {
     #[clap(
         long = "only-in-json",
-        help = "Only rewrite ranges that are inside the provided eslint-style JSON file",
-        hide = true,
+        help = r#"Only rewrite ranges inside a provided eslint-style JSON file. The JSON file should be an array of objects formatted as `{"filePath": "path/to/file", "messages": [{"ruleId": "rule-id", "message": "message", "line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}`."#,
         conflicts_with = "only_in_diff"
     )]
     pub(crate) only_in_json: Option<PathBuf>,

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -15,7 +15,8 @@ use super::apply_migration::{run_apply_migration, ApplyMigrationArgs};
 use super::apply_pattern::{run_apply_pattern, ApplyPatternArgs};
 
 #[derive(Args, Debug, Serialize, Default)]
-pub struct SharedApplyArgs {
+/// Shared arguments for apply and check commands.
+pub struct SharedFilterArgs {
     #[clap(
         long = "only-in-json",
         help = r#"Only rewrite ranges inside a provided eslint-style JSON string. The JSON should be an array of objects formatted as `[{"filePath": "path/to/file", "messages": [{"line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}]`."#,
@@ -55,7 +56,7 @@ pub struct ApplyArgs {
     apply_pattern_args: ApplyPatternArgs,
 
     #[command(flatten)]
-    shared_apply_args: SharedApplyArgs,
+    shared_apply_args: SharedFilterArgs,
 }
 
 pub(crate) async fn run_apply(

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -18,13 +18,13 @@ use super::apply_pattern::{run_apply_pattern, ApplyPatternArgs};
 pub struct SharedApplyArgs {
     #[clap(
         long = "only-in-json",
-        help = r#"Only rewrite ranges inside a provided eslint-style JSON string. The JSON file should be an array of objects formatted as `{"filePath": "path/to/file", "messages": [{"ruleId": "rule-id", "message": "message", "line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}`."#,
+        help = r#"Only rewrite ranges inside a provided eslint-style JSON string. The JSON should be an array of objects formatted as `[{"filePath": "path/to/file", "messages": [{"line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}]`."#,
         conflicts_with = "only_in_diff"
     )]
     pub(crate) only_in_json: Option<String>,
     #[clap(
         long = "only-in-diff",
-        help = "Only rewrite ranges that are inside the provided unified diff, or the results of git diff HEAD if no path is provided.",
+        help = "Only rewrite ranges that are inside the provided unified diff, or the results of git diff HEAD if no diff is provided.",
         hide = true,
         conflicts_with = "only_in_json"
     )]

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -18,17 +18,17 @@ use super::apply_pattern::{run_apply_pattern, ApplyPatternArgs};
 pub struct SharedApplyArgs {
     #[clap(
         long = "only-in-json",
-        help = r#"Only rewrite ranges inside a provided eslint-style JSON file. The JSON file should be an array of objects formatted as `{"filePath": "path/to/file", "messages": [{"ruleId": "rule-id", "message": "message", "line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}`."#,
+        help = r#"Only rewrite ranges inside a provided eslint-style JSON string. The JSON file should be an array of objects formatted as `{"filePath": "path/to/file", "messages": [{"ruleId": "rule-id", "message": "message", "line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}`."#,
         conflicts_with = "only_in_diff"
     )]
-    pub(crate) only_in_json: Option<PathBuf>,
+    pub(crate) only_in_json: Option<String>,
     #[clap(
         long = "only-in-diff",
-        help = "Only rewrite ranges that are inside the unified diff if a path to the diff is provided, or the results of git diff HEAD if no path is provided.",
+        help = "Only rewrite ranges that are inside the provided unified diff, or the results of git diff HEAD if no path is provided.",
         hide = true,
         conflicts_with = "only_in_json"
     )]
-    pub(crate) only_in_diff: Option<Option<PathBuf>>,
+    pub(crate) only_in_diff: Option<Option<String>>,
 }
 
 #[derive(Args, Debug, Serialize)]

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -12,25 +12,10 @@ use crate::flags::GlobalFormatFlags;
 
 #[cfg(feature = "workflows_v2")]
 use super::apply_migration::{run_apply_migration, ApplyMigrationArgs};
-use super::apply_pattern::{run_apply_pattern, ApplyPatternArgs};
-
-#[derive(Args, Debug, Serialize, Default)]
-/// Shared arguments for apply and check commands.
-pub struct SharedFilterArgs {
-    #[clap(
-        long = "only-in-json",
-        help = r#"Only rewrite ranges inside a provided eslint-style JSON string. The JSON should be an array of objects formatted as `[{"filePath": "path/to/file", "messages": [{"line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}]`."#,
-        conflicts_with = "only_in_diff"
-    )]
-    pub(crate) only_in_json: Option<String>,
-    #[clap(
-        long = "only-in-diff",
-        help = "Only rewrite ranges that are inside the provided unified diff, or the results of git diff HEAD if no diff is provided.",
-        hide = true,
-        conflicts_with = "only_in_json"
-    )]
-    pub(crate) only_in_diff: Option<Option<String>>,
-}
+use super::{
+    apply_pattern::{run_apply_pattern, ApplyPatternArgs},
+    filters::SharedFilterArgs,
+};
 
 #[derive(Args, Debug, Serialize)]
 pub struct ApplyArgs {

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -28,9 +28,9 @@ use std::sync::atomic::Ordering;
 use tokio::fs;
 
 use crate::commands::filters::extract_filter_ranges;
-use crate::diff::extract_target_ranges;
+
 use crate::{
-    analyze::par_apply_pattern, community::parse_eslint_output, error::GoodError,
+    analyze::par_apply_pattern, error::GoodError,
     flags::OutputFormat, messenger_variant::create_emitter, result_formatting::get_human_error,
     updater::Updater,
 };

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -27,6 +27,7 @@ use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
 use tokio::fs;
 
+use crate::commands::filters::extract_filter_ranges;
 use crate::diff::extract_target_ranges;
 use crate::{
     analyze::par_apply_pattern, community::parse_eslint_output, error::GoodError,
@@ -204,12 +205,7 @@ pub(crate) async fn run_apply_pattern(
     )
     .await?;
 
-    let filter_range = if let Some(json_path) = &shared.only_in_json {
-        let json_ranges = flushable_unwrap!(emitter, parse_eslint_output(json_path));
-        Some(json_ranges)
-    } else {
-        flushable_unwrap!(emitter, extract_target_ranges(&shared.only_in_diff))
-    };
+    let filter_range = flushable_unwrap!(emitter, extract_filter_ranges(&shared));
 
     let (my_input, lang) = if let Some(pattern_libs) = pattern_libs {
         (

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -42,7 +42,7 @@ use marzano_messenger::{
 use crate::resolver::{get_grit_files_from_cwd, GritModuleResolver};
 use crate::utils::has_uncommitted_changes;
 
-use super::apply::SharedApplyArgs;
+use super::apply::SharedFilterArgs;
 use super::init::init_config_from_cwd;
 
 #[derive(Deserialize)]
@@ -152,7 +152,7 @@ macro_rules! flushable_unwrap {
 #[allow(clippy::too_many_arguments, unused_mut)]
 pub(crate) async fn run_apply_pattern(
     mut pattern: String,
-    shared: SharedApplyArgs,
+    shared: SharedFilterArgs,
     paths: Vec<PathBuf>,
     arg: ApplyPatternArgs,
     multi: MultiProgress,

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -42,7 +42,7 @@ use marzano_messenger::{
 use crate::resolver::{get_grit_files_from_cwd, GritModuleResolver};
 use crate::utils::has_uncommitted_changes;
 
-use super::apply::SharedFilterArgs;
+use super::filters::SharedFilterArgs;
 use super::init::init_config_from_cwd;
 
 #[derive(Deserialize)]

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -45,7 +45,7 @@ use crate::{
     ux::{get_check_summary, log_file, print_config, CheckResult},
 };
 
-use super::filters::SharedFilterArgs;
+use super::filters::{extract_filter_ranges, SharedFilterArgs};
 
 #[derive(Args, Serialize, Debug)]
 pub struct CheckArg {
@@ -120,7 +120,7 @@ pub(crate) async fn run_check(
         std::env::current_dir()?
     };
 
-    let filter_range = extract_target_ranges(&arg.only_in_diff)?;
+    let filter_range = extract_filter_ranges(&arg.shared_filters)?;
 
     // Construct a resolver
     let resolver = GritModuleResolver::new(current_dir.to_str().unwrap());

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -70,10 +70,10 @@ pub struct CheckArg {
     pub github_actions: bool,
     #[clap(
         long = "only-in-diff",
-        help = "Only check ranges that are inside the unified diff if a path to the diff is provided, or the results of git diff HEAD if no path is provided.",
+        help = "Only check ranges that are inside the unified diff if one is provided, or the results of git diff HEAD if no diff is provided.",
         hide = true
     )]
-    pub only_in_diff: Option<Option<PathBuf>>,
+    pub only_in_diff: Option<Option<String>>,
 }
 
 pub(crate) async fn run_check(

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -45,6 +45,8 @@ use crate::{
     ux::{get_check_summary, log_file, print_config, CheckResult},
 };
 
+use super::filters::SharedFilterArgs;
+
 #[derive(Args, Serialize, Debug)]
 pub struct CheckArg {
     /// The target paths to apply the checks to
@@ -68,12 +70,8 @@ pub struct CheckArg {
     /// Output annotations for a GitHub actions workflow
     #[clap(long = "github-actions")]
     pub github_actions: bool,
-    #[clap(
-        long = "only-in-diff",
-        help = "Only check ranges that are inside the unified diff if one is provided, or the results of git diff HEAD if no diff is provided.",
-        hide = true
-    )]
-    pub only_in_diff: Option<Option<String>>,
+    #[clap(flatten)]
+    pub shared_filters: SharedFilterArgs,
 }
 
 pub(crate) async fn run_check(

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -31,7 +31,6 @@ use marzano_messenger::emit::{Messager, VisibilityLevels};
 use cli_server::check::CheckMessenger;
 
 use crate::{
-    diff::extract_target_ranges,
     error::GoodError,
     flags::{GlobalFormatFlags, OutputFormat},
     github::{log_check_annotations, write_check_summary},

--- a/crates/cli/src/commands/filters.rs
+++ b/crates/cli/src/commands/filters.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use clap::Args;
+
+use grit_util::FileRange;
+use serde::Serialize;
+
+use crate::{community::parse_eslint_output, diff::extract_target_ranges};
+
+#[derive(Args, Debug, Serialize, Default)]
+/// Shared arguments for apply and check commands.
+pub struct SharedFilterArgs {
+    #[clap(
+        long = "only-in-json",
+        help = r#"Only rewrite ranges inside a provided eslint-style JSON string. The JSON should be an array of objects formatted as `[{"filePath": "path/to/file", "messages": [{"line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}]`."#,
+        conflicts_with = "only_in_diff"
+    )]
+    pub(crate) only_in_json: Option<String>,
+    #[clap(
+        long = "only-in-diff",
+        help = "Only rewrite ranges that are inside the provided unified diff, or the results of git diff HEAD if no diff is provided.",
+        hide = true,
+        conflicts_with = "only_in_json"
+    )]
+    pub(crate) only_in_diff: Option<Option<String>>,
+}
+
+pub(crate) fn extract_filter_ranges(args: &SharedFilterArgs) -> Result<Option<Vec<FileRange>>> {
+    if let Some(json_content) = &args.only_in_json {
+        let json_ranges = parse_eslint_output(json_content)?;
+        Ok(Some(json_ranges))
+    } else {
+        Ok(extract_target_ranges(&args.only_in_diff)?)
+    }
+}

--- a/crates/cli/src/commands/filters.rs
+++ b/crates/cli/src/commands/filters.rs
@@ -11,13 +11,13 @@ use crate::{community::parse_eslint_output, diff::extract_target_ranges};
 pub struct SharedFilterArgs {
     #[clap(
         long = "only-in-json",
-        help = r#"Only rewrite ranges inside a provided eslint-style JSON string. The JSON should be an array of objects formatted as `[{"filePath": "path/to/file", "messages": [{"line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}]`."#,
+        help = r#"Only analyze ranges inside a provided eslint-style JSON string. The JSON should be an array of objects formatted as `[{"filePath": "path/to/file", "messages": [{"line": 1, "column": 1, "endLine": 1, "endColumn": 1}]}]`."#,
         conflicts_with = "only_in_diff"
     )]
     pub(crate) only_in_json: Option<String>,
     #[clap(
         long = "only-in-diff",
-        help = "Only rewrite ranges that are inside the provided unified diff, or the results of git diff HEAD if no diff is provided.",
+        help = "Only analyze ranges that are inside the provided unified diff, or the results of git diff HEAD if no diff is provided.",
         hide = true,
         conflicts_with = "only_in_json"
     )]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod workflows_list;
 
 #[cfg(feature = "docgen")]
 pub(crate) mod docgen;
+mod filters;
 
 use crate::{
     analytics::{

--- a/crates/cli/src/commands/plumbing.rs
+++ b/crates/cli/src/commands/plumbing.rs
@@ -18,9 +18,9 @@ use crate::lister::list_applyables;
 use crate::resolver::{get_grit_files_from, resolve_from, Source};
 
 use super::super::analytics::AnalyticsArgs;
-use super::apply::SharedFilterArgs;
 use super::apply_pattern::{run_apply_pattern, ApplyPatternArgs};
 use super::check::{run_check, CheckArg};
+use super::filters::SharedFilterArgs;
 use super::init::{init_config_from_cwd, init_global_grit_modules};
 use super::list::ListArgs;
 use super::parse::{run_parse, ParseInput};

--- a/crates/cli/src/commands/plumbing.rs
+++ b/crates/cli/src/commands/plumbing.rs
@@ -18,7 +18,7 @@ use crate::lister::list_applyables;
 use crate::resolver::{get_grit_files_from, resolve_from, Source};
 
 use super::super::analytics::AnalyticsArgs;
-use super::apply::SharedApplyArgs;
+use super::apply::SharedFilterArgs;
 use super::apply_pattern::{run_apply_pattern, ApplyPatternArgs};
 use super::check::{run_check, CheckArg};
 use super::init::{init_config_from_cwd, init_global_grit_modules};
@@ -148,7 +148,7 @@ pub(crate) async fn run_plumbing(
             };
             run_apply_pattern(
                 body,
-                SharedApplyArgs::default(),
+                SharedFilterArgs::default(),
                 input.paths,
                 apply_pattern_args,
                 multi,

--- a/crates/cli/src/community.rs
+++ b/crates/cli/src/community.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use grit_util::{FileRange, Position, RangeWithoutByte};
 use serde::Deserialize;
-use std::fs::File;
-use std::io::Read;
+
+
 use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
@@ -32,7 +32,7 @@ struct EslintFile {
 }
 
 pub fn parse_eslint_output(json: &str) -> Result<Vec<FileRange>> {
-    let output: Vec<EslintFile> = serde_json::from_str(&json)?;
+    let output: Vec<EslintFile> = serde_json::from_str(json)?;
     let items = output
         .into_iter()
         .flat_map(|file| {

--- a/crates/cli/src/community.rs
+++ b/crates/cli/src/community.rs
@@ -31,13 +31,7 @@ struct EslintFile {
     pub messages: Vec<EslintMessage>,
 }
 
-pub fn parse_eslint_output(file_path: &PathBuf) -> Result<Vec<FileRange>> {
-    let mut file = File::open(file_path)?;
-    let mut json = String::new();
-
-    // TODO(perf): skip reading the whole string into memory, parse the JSON iteratively
-    file.read_to_string(&mut json)?;
-
+pub fn parse_eslint_output(json: &str) -> Result<Vec<FileRange>> {
     let output: Vec<EslintFile> = serde_json::from_str(&json)?;
     let items = output
         .into_iter()

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -19,7 +19,7 @@ pub(crate) fn extract_target_ranges(
 ) -> Result<Option<Vec<FileRange>>> {
     let raw_diff = if let Some(Some(diff_content)) = &diff_arg {
         parse_modified_ranges(&diff_content)?
-    } else if let Some(None) = &arg {
+    } else if let Some(None) = &diff_arg {
         let diff = run_git_diff(&std::env::current_dir()?)?;
         parse_modified_ranges(&diff)?
     } else {

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -14,19 +14,11 @@ pub fn run_git_diff(path: &PathBuf) -> Result<String> {
     Ok(String::from_utf8(output.stdout)?)
 }
 
-pub fn extract_modified_ranges(diff_path: &PathBuf) -> Result<Vec<FileDiff>> {
-    let mut file = File::open(diff_path)?;
-    let mut diff = String::new();
-
-    file.read_to_string(&mut diff)?;
-    parse_modified_ranges(&diff)
-}
-
 pub(crate) fn extract_target_ranges(
-    arg: &Option<Option<PathBuf>>,
+    diff_arg: &Option<Option<String>>,
 ) -> Result<Option<Vec<FileRange>>> {
-    let raw_diff = if let Some(Some(diff_path)) = &arg {
-        extract_modified_ranges(diff_path)?
+    let raw_diff = if let Some(Some(diff_content)) = &diff_arg {
+        parse_modified_ranges(&diff_content)?
     } else if let Some(None) = &arg {
         let diff = run_git_diff(&std::env::current_dir()?)?;
         parse_modified_ranges(&diff)?

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use grit_util::{FileRange, UtilRange};
-use marzano_util::diff::{parse_modified_ranges, FileDiff};
-use std::{fs::File, io::Read, path::PathBuf};
+use marzano_util::diff::{parse_modified_ranges};
+use std::{path::PathBuf};
 
 pub fn run_git_diff(path: &PathBuf) -> Result<String> {
     let output = std::process::Command::new("git")
@@ -18,7 +18,7 @@ pub(crate) fn extract_target_ranges(
     diff_arg: &Option<Option<String>>,
 ) -> Result<Option<Vec<FileRange>>> {
     let raw_diff = if let Some(Some(diff_content)) = &diff_arg {
-        parse_modified_ranges(&diff_content)?
+        parse_modified_ranges(diff_content)?
     } else if let Some(None) = &diff_arg {
         let diff = run_git_diff(&std::env::current_dir()?)?;
         parse_modified_ranges(&diff)?

--- a/crates/cli_bin/tests/apply.rs
+++ b/crates/cli_bin/tests/apply.rs
@@ -1308,6 +1308,37 @@ fn embedding_like() -> Result<()> {
 }
 
 #[test]
+fn filtered_apply_custom() -> Result<()> {
+    let (_temp_dir, dir) = get_fixture("filtered_apply", true)?;
+
+    let mut apply_cmd = get_test_cmd()?;
+    apply_cmd.current_dir(dir.clone());
+    apply_cmd
+        .arg("apply")
+        .arg("fix.grit")
+        .arg("--only-in-json")
+        .arg(r#"[{"filePath":"file.js", "messages": [{ "line": 4, "column": 1, "endLine": 4, "endColumn": 50}]}]"#);
+
+    let output = apply_cmd.output()?;
+    assert!(
+        output.status.success(),
+        "Command didn't finish successfully"
+    );
+
+    let stdout = String::from_utf8(output.stdout)?;
+    println!("stdout: {:?}", stdout);
+    assert!(stdout.contains("1 matches"));
+
+    let content = std::fs::read_to_string(dir.join("file.js"))?;
+    assert_snapshot!(content);
+
+    let content2 = std::fs::read_to_string(dir.join("file2.js"))?;
+    assert_snapshot!(content2);
+
+    Ok(())
+}
+
+#[test]
 fn filtered_apply() -> Result<()> {
     let (_temp_dir, dir) = get_fixture("filtered_apply", true)?;
 

--- a/crates/cli_bin/tests/apply.rs
+++ b/crates/cli_bin/tests/apply.rs
@@ -1311,13 +1311,15 @@ fn embedding_like() -> Result<()> {
 fn filtered_apply() -> Result<()> {
     let (_temp_dir, dir) = get_fixture("filtered_apply", true)?;
 
+    let eslint_content = std::fs::read_to_string(dir.join("eslint.json"))?;
+
     let mut apply_cmd = get_test_cmd()?;
     apply_cmd.current_dir(dir.clone());
     apply_cmd
         .arg("apply")
         .arg("fix.grit")
         .arg("--only-in-json")
-        .arg("eslint.json");
+        .arg(eslint_content);
 
     let output = apply_cmd.output()?;
     assert!(

--- a/crates/cli_bin/tests/apply.rs
+++ b/crates/cli_bin/tests/apply.rs
@@ -2313,10 +2313,12 @@ fn apply_only_in_diff() -> Result<()> {
 
     let mut cmd = get_test_cmd()?;
 
+    let diff_content = std::fs::read_to_string(dir.join("test.diff"))?;
+
     cmd.arg("apply")
         .arg("no_console_log")
         .arg("--only-in-diff")
-        .arg("test.diff")
+        .arg(diff_content)
         .current_dir(dir.clone());
 
     let output = cmd.output()?;

--- a/crates/cli_bin/tests/check.rs
+++ b/crates/cli_bin/tests/check.rs
@@ -190,9 +190,11 @@ fn check_only_in_diff() -> Result<()> {
 
     let mut cmd = get_test_cmd()?;
 
+    let diff_content = std::fs::read_to_string(dir.join("test.diff"))?;
+
     cmd.arg("check")
         .arg("--only-in-diff")
-        .arg("test.diff")
+        .arg(diff_content)
         .current_dir(dir.clone());
 
     let output = cmd.output()?;

--- a/crates/cli_bin/tests/snapshots/apply__filtered_apply_custom-2.snap
+++ b/crates/cli_bin/tests/snapshots/apply__filtered_apply_custom-2.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli_bin/tests/apply.rs
+expression: content2
+---
+import { some, uniqBy } from 'lodash';
+import type { BaseUserAccount, UserAccount } from '../services/auth';
+import { isUserAccount } from '../services/auth';
+import { isUserAccount } from '../services/auth';
+import { newbar } from '../services/auth';
+
+// wowza break
+import { foobar } from '../services/auth';
+import { ignoreTHhis } from '../services/auth';
+import { client } from '../lib/client';

--- a/crates/cli_bin/tests/snapshots/apply__filtered_apply_custom.snap
+++ b/crates/cli_bin/tests/snapshots/apply__filtered_apply_custom.snap
@@ -1,0 +1,13 @@
+---
+source: crates/cli_bin/tests/apply.rs
+expression: content
+---
+import { some, uniqBy } from 'lodash';
+import type { BaseUserAccount, UserAccount } from '../services/auth';
+import { isUserAccount } from '../services/auth';
+// eslint-disable-next-line import/no-cycle
+import { client } from '../lib/client';
+import { isUserAccount } from '../services/auth';
+import { foobar } from '../services/auth';
+import { newbar } from '../services/auth';
+import { crewbar } from '../services/auth';


### PR DESCRIPTION
Fixes https://github.com/getgrit/gritql/pull/267

- Drop the file requirement (if you want to use a file, you can always pipe from it)
- Document `--only-in-json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced shared filter arguments for "apply" and "check" commands, enhancing the handling of JSON and diff data.
  - Added parsing functionality for eslint-style JSON inputs.

- **Refactor**
  - Updated command logic to utilize new shared filter arguments, improving data processing consistency across commands.
  - Enhanced handling of modified ranges in diff files, allowing for more precise targeting in command operations.

- **Tests**
  - Added new tests to verify the application of fixes with specific JSON data and in diff-specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->