### PR TITLE
chore: add cargo-dist config

### DIFF
--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -2,6 +2,8 @@
 name = "marzano"
 version = "0.1.0"
 edition = "2021"
+description = "GritQL is a query language for searching, linting, and modifying code"
+homepage = "https://docs.grit.io/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -29,3 +31,7 @@ grit_tracing = [
   "marzano-cli/grit_tracing",
 ]
 docgen = ["marzano-cli/docgen"]
+
+[package.metadata.dist]
+default-features = false
+features = ["marzano-cli/grit_beta"]


### PR DESCRIPTION
this needs to exist here for the way the submodules work

* description/homepage added for installers to have the metadata people expect
* feature settings added so distributable builds have the right feature flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added project description and homepage URL in the metadata.
	- Included distribution features information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->