### PR TITLE
refactor: don't expose node internals through `AstNode`

### DIFF
--- a/crates/grit-util/src/ast_node.rs
+++ b/crates/grit-util/src/ast_node.rs
@@ -3,14 +3,11 @@ use std::{borrow::Cow, str::Utf8Error};
 
 /// Represents an AST node and offers convenient AST-specific functionality.
 ///
-/// This trait should be free from dependencies on TreeSitter.
+/// This trait should be free from dependencies on TreeSitter. This also implies
+/// it should not expose details about the node that may make it infeasible to
+/// implement the trait by implementations that use different node
+/// representations internally.
 pub trait AstNode: std::fmt::Debug + Sized {
-    // returns the id of the node kind
-    fn kind_id(&self) -> u16;
-
-    // returns the node kind
-    fn kind(&self) -> Cow<str>;
-
     /// Returns an iterator over the node's ancestors, starting with the node
     /// itself and moving up to the root.
     fn ancestors(&self) -> impl Iterator<Item = Self>;

--- a/crates/language/src/python.rs
+++ b/crates/language/src/python.rs
@@ -93,7 +93,7 @@ impl Language for Python {
     }
 
     fn should_skip_padding(&self, node: &NodeWithSource<'_>) -> bool {
-        self.skip_padding_sorts.contains(&node.kind_id())
+        self.skip_padding_sorts.contains(&node.node.kind_id())
     }
 
     fn get_skip_padding_ranges_for_snippet(&self, snippet: &str) -> Vec<CodeRange> {

--- a/crates/util/src/node_with_source.rs
+++ b/crates/util/src/node_with_source.rs
@@ -69,14 +69,6 @@ impl<'a> PartialEq for NodeWithSource<'a> {
 }
 
 impl<'a> AstNode for NodeWithSource<'a> {
-    fn kind_id(&self) -> u16 {
-        self.node.kind_id()
-    }
-
-    fn kind(&self) -> Cow<str> {
-        self.node.kind()
-    }
-
     fn ancestors(&self) -> impl Iterator<Item = Self> {
         AncestorIterator::new(self)
     }


### PR DESCRIPTION
This is the tiniest of refactors, but it has a tricky semantic implication: The `AstNode` trait is intended to provide an abstraction over nodes so that code using the trait is no longer relying on TreeSitter.

Unfortunately, a `kind()` method was added that assumes nodes have a string representation for the kind of node they represent. This is true for TreeSitter nodes, but for Biome's CST such a string representation does not exist (there is a debug representation, but it's only exposed through the `Debug` trait).

Similarly, even though Biome does have `u16` kinds for its node kinds, it makes it dangerous to expose such implementation details through the trait, since it cannot be relied upon the semantics will be the same.

cc @ilevyor 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed methods related to node kind identification from AST node implementations to reduce dependency on external libraries and enhance modularity.
	- Updated method handling in the Python language implementation for improved accuracy in processing syntax nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->