### PR TITLE
chore: handle skipping uniformly

### DIFF
--- a/crates/core/src/pattern_compiler/pattern_compiler.rs
+++ b/crates/core/src/pattern_compiler/pattern_compiler.rs
@@ -124,14 +124,6 @@ impl PatternCompiler {
                 fields
                     .iter()
                     .filter(|field| {
-                        // First check if we should skip compilation of this field entirely
-                        if context
-                            .compilation
-                            .lang
-                            .skip_snippet_compilation_of_field(sort, field.id())
-                        {
-                            return false;
-                        }
                         let child_with_source = node
                             .node
                             .child_by_field_id(field.id())

--- a/crates/language/src/javascript.rs
+++ b/crates/language/src/javascript.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     language::{
         check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map, Field,
-        FieldExpectation, FieldId, MarzanoLanguage, NodeTypes, SortId, TSLanguage, Tree,
+        FieldExpectation, MarzanoLanguage, NodeTypes, SortId, TSLanguage, Tree,
     },
 };
 use grit_util::{AstNode, Language, Parser, Range, Replacement};

--- a/crates/language/src/javascript.rs
+++ b/crates/language/src/javascript.rs
@@ -1,12 +1,11 @@
 use crate::{
     js_like::{
         js_disregarded_field_values, js_like_get_statement_sorts, js_like_is_comment,
-        js_skip_snippet_compilation_sorts, jslike_check_replacements, MarzanoJsLikeParser,
+        jslike_check_replacements, MarzanoJsLikeParser,
     },
     language::{
-        check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map,
-        kind_and_field_id_for_names, Field, FieldExpectation, FieldId, MarzanoLanguage, NodeTypes,
-        SortId, TSLanguage, Tree,
+        check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map, Field,
+        FieldExpectation, FieldId, MarzanoLanguage, NodeTypes, SortId, TSLanguage, Tree,
     },
 };
 use grit_util::{AstNode, Language, Parser, Range, Replacement};
@@ -40,7 +39,6 @@ pub struct JavaScript {
     jsx_sort: SortId,
     statement_sorts: &'static [SortId],
     language: &'static TSLanguage,
-    skip_snippet_compilation_sorts: &'static Vec<(SortId, FieldId)>,
     disregarded_snippet_fields: &'static Vec<FieldExpectation>,
 }
 
@@ -54,10 +52,6 @@ impl JavaScript {
 
         let statement_sorts = STATEMENT_SORTS.get_or_init(|| js_like_get_statement_sorts(language));
 
-        let skip_snippet_compilation_sorts = SKIP_SNIPPET_COMPILATION_SORTS.get_or_init(|| {
-            kind_and_field_id_for_names(language, js_skip_snippet_compilation_sorts())
-        });
-
         let disregarded_snippet_fields = DISREGARDED_SNIPPET_FIELDS.get_or_init(|| {
             kind_and_field_id_for_field_map(language, js_disregarded_field_values())
         });
@@ -69,7 +63,6 @@ impl JavaScript {
             jsx_sort,
             statement_sorts,
             language,
-            skip_snippet_compilation_sorts,
             disregarded_snippet_fields,
         }
     }
@@ -169,12 +162,6 @@ impl<'a> MarzanoLanguage<'a> for JavaScript {
             field_id,
             field_node,
         )
-    }
-
-    fn skip_snippet_compilation_of_field(&self, sort_id: SortId, field_id: FieldId) -> bool {
-        self.skip_snippet_compilation_sorts
-            .iter()
-            .any(|(s, f)| *s == sort_id && *f == field_id)
     }
 
     fn is_comment_sort(&self, id: SortId) -> bool {

--- a/crates/language/src/javascript.rs
+++ b/crates/language/src/javascript.rs
@@ -16,7 +16,6 @@ static NODE_TYPES_STRING: &str =
     include_str!("../../../resources/node-types/javascript-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
 static LANGUAGE: OnceLock<TSLanguage> = OnceLock::new();
-static SKIP_SNIPPET_COMPILATION_SORTS: OnceLock<Vec<(SortId, FieldId)>> = OnceLock::new();
 static STATEMENT_SORTS: OnceLock<Vec<SortId>> = OnceLock::new();
 static DISREGARDED_SNIPPET_FIELDS: OnceLock<Vec<FieldExpectation>> = OnceLock::new();
 

--- a/crates/language/src/js_like.rs
+++ b/crates/language/src/js_like.rs
@@ -70,6 +70,14 @@ pub(crate) fn js_like_skip_snippet_compilation_sorts() -> Vec<(&'static str, &'s
 pub(crate) fn js_disregarded_field_values(
 ) -> Vec<(&'static str, &'static str, Option<Vec<&'static str>>)> {
     vec![
+        // Always disregarded:
+        ("method_definition", "parenthesis", None),
+        ("function", "parenthesis", None),
+        ("function_declaration", "parenthesis", None),
+        ("generator_function", "parenthesis", None),
+        ("generator_function_declaration", "parenthesis", None),
+        ("arrow_function", "parenthesis", None),
+        // Disregarded if empty:
         ("function", "async", Some(vec![""])),
         ("arrow_function", "async", Some(vec![""])),
         ("generator_function", "async", Some(vec![""])),
@@ -83,6 +91,14 @@ pub(crate) fn js_disregarded_field_values(
 pub(crate) fn js_like_disregarded_field_values(
 ) -> Vec<(&'static str, &'static str, Option<Vec<&'static str>>)> {
     let mut res = vec![
+        // always disregarded:
+        ("constructor_type", "parenthesis", None),
+        ("construct_signature", "parenthesis", None),
+        ("function_type", "parenthesis", None),
+        ("method_signature", "parenthesis", None),
+        ("abstract_method_signature", "parenthesis", None),
+        ("function_signature", "parenthesis" None),
+        // disregarded if empty:
         ("call_expression", "type_arguments", Some(vec![""])),
         ("new_expression", "type_arguments", Some(vec![""])),
         ("function", "return_type", Some(vec![""])),

--- a/crates/language/src/js_like.rs
+++ b/crates/language/src/js_like.rs
@@ -1,6 +1,8 @@
 use crate::{
     language::{
-        FieldExpectationCondition, MarzanoLanguage, MarzanoParser, SortId, TSLanguage, Tree,
+        FieldExpectationCondition, FieldExpectationCondition::Always,
+        FieldExpectationCondition::OnlyIf, MarzanoLanguage, MarzanoParser, SortId, TSLanguage,
+        Tree,
     },
     vue::get_vue_ranges,
 };
@@ -49,68 +51,20 @@ pub(crate) fn js_disregarded_field_values(
 ) -> Vec<(&'static str, &'static str, FieldExpectationCondition)> {
     vec![
         // Always disregarded:
-        (
-            "method_definition",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
-        ("function", "parenthesis", FieldExpectationCondition::Always),
-        (
-            "function_declaration",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
-        (
-            "generator_function",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
-        (
-            "generator_function_declaration",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
-        (
-            "arrow_function",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
+        ("method_definition", "parenthesis", Always),
+        ("function", "parenthesis", Always),
+        ("function_declaration", "parenthesis", Always),
+        ("generator_function", "parenthesis", Always),
+        ("generator_function_declaration", "parenthesis", Always),
+        ("arrow_function", "parenthesis", Always),
         // Disregarded if empty:
-        (
-            "function",
-            "async",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "arrow_function",
-            "async",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "generator_function",
-            "async",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "generator_function_declaration",
-            "async",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "method_definition",
-            "async",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "function_declaration",
-            "async",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "import_statement",
-            "import",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
+        ("function", "async", OnlyIf(vec![""])),
+        ("arrow_function", "async", OnlyIf(vec![""])),
+        ("generator_function", "async", OnlyIf(vec![""])),
+        ("generator_function_declaration", "async", OnlyIf(vec![""])),
+        ("method_definition", "async", OnlyIf(vec![""])),
+        ("function_declaration", "async", OnlyIf(vec![""])),
+        ("import_statement", "import", OnlyIf(vec![""])),
     ]
 }
 
@@ -118,72 +72,20 @@ pub(crate) fn js_like_disregarded_field_values(
 ) -> Vec<(&'static str, &'static str, FieldExpectationCondition)> {
     let mut res = vec![
         // always disregarded:
-        (
-            "constructor_type",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
-        (
-            "construct_signature",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
-        (
-            "function_type",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
-        (
-            "method_signature",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
-        (
-            "abstract_method_signature",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
-        (
-            "function_signature",
-            "parenthesis",
-            FieldExpectationCondition::Always,
-        ),
+        ("constructor_type", "parenthesis", Always),
+        ("construct_signature", "parenthesis", Always),
+        ("function_type", "parenthesis", Always),
+        ("method_signature", "parenthesis", Always),
+        ("abstract_method_signature", "parenthesis", Always),
+        ("function_signature", "parenthesis", Always),
         // disregarded if empty:
-        (
-            "call_expression",
-            "type_arguments",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "new_expression",
-            "type_arguments",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "function",
-            "return_type",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "arrow_function",
-            "return_type",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "import_statement",
-            "type",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "public_field_definition",
-            "static",
-            FieldExpectationCondition::OnlyIf(vec![""]),
-        ),
-        (
-            "member_expression",
-            "chain",
-            FieldExpectationCondition::OnlyIf(vec!["", "."]),
-        ),
+        ("call_expression", "type_arguments", OnlyIf(vec![""])),
+        ("new_expression", "type_arguments", OnlyIf(vec![""])),
+        ("function", "return_type", OnlyIf(vec![""])),
+        ("arrow_function", "return_type", OnlyIf(vec![""])),
+        ("import_statement", "type", OnlyIf(vec![""])),
+        ("public_field_definition", "static", OnlyIf(vec![""])),
+        ("member_expression", "chain", OnlyIf(vec!["", "."])),
     ];
     res.extend(js_disregarded_field_values());
     res

--- a/crates/language/src/js_like.rs
+++ b/crates/language/src/js_like.rs
@@ -1,5 +1,7 @@
 use crate::{
-    language::{MarzanoLanguage, MarzanoParser, SortId, TSLanguage, Tree},
+    language::{
+        FieldExpectationCondition, MarzanoLanguage, MarzanoParser, SortId, TSLanguage, Tree,
+    },
     vue::get_vue_ranges,
 };
 use grit_util::{AnalysisLogs, AstNode, Parser, Replacement, SnippetTree};
@@ -44,44 +46,144 @@ pub(crate) fn js_like_get_statement_sorts(lang: &TSLanguage) -> Vec<SortId> {
 }
 
 pub(crate) fn js_disregarded_field_values(
-) -> Vec<(&'static str, &'static str, Option<Vec<&'static str>>)> {
+) -> Vec<(&'static str, &'static str, FieldExpectationCondition)> {
     vec![
         // Always disregarded:
-        ("method_definition", "parenthesis", None),
-        ("function", "parenthesis", None),
-        ("function_declaration", "parenthesis", None),
-        ("generator_function", "parenthesis", None),
-        ("generator_function_declaration", "parenthesis", None),
-        ("arrow_function", "parenthesis", None),
+        (
+            "method_definition",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
+        ("function", "parenthesis", FieldExpectationCondition::Always),
+        (
+            "function_declaration",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
+        (
+            "generator_function",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
+        (
+            "generator_function_declaration",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
+        (
+            "arrow_function",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
         // Disregarded if empty:
-        ("function", "async", Some(vec![""])),
-        ("arrow_function", "async", Some(vec![""])),
-        ("generator_function", "async", Some(vec![""])),
-        ("generator_function_declaration", "async", Some(vec![""])),
-        ("method_definition", "async", Some(vec![""])),
-        ("function_declaration", "async", Some(vec![""])),
-        ("import_statement", "import", Some(vec![""])),
+        (
+            "function",
+            "async",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "arrow_function",
+            "async",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "generator_function",
+            "async",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "generator_function_declaration",
+            "async",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "method_definition",
+            "async",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "function_declaration",
+            "async",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "import_statement",
+            "import",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
     ]
 }
 
 pub(crate) fn js_like_disregarded_field_values(
-) -> Vec<(&'static str, &'static str, Option<Vec<&'static str>>)> {
+) -> Vec<(&'static str, &'static str, FieldExpectationCondition)> {
     let mut res = vec![
         // always disregarded:
-        ("constructor_type", "parenthesis", None),
-        ("construct_signature", "parenthesis", None),
-        ("function_type", "parenthesis", None),
-        ("method_signature", "parenthesis", None),
-        ("abstract_method_signature", "parenthesis", None),
-        ("function_signature", "parenthesis", None),
+        (
+            "constructor_type",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
+        (
+            "construct_signature",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
+        (
+            "function_type",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
+        (
+            "method_signature",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
+        (
+            "abstract_method_signature",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
+        (
+            "function_signature",
+            "parenthesis",
+            FieldExpectationCondition::Always,
+        ),
         // disregarded if empty:
-        ("call_expression", "type_arguments", Some(vec![""])),
-        ("new_expression", "type_arguments", Some(vec![""])),
-        ("function", "return_type", Some(vec![""])),
-        ("arrow_function", "return_type", Some(vec![""])),
-        ("import_statement", "type", Some(vec![""])),
-        ("public_field_definition", "static", Some(vec![""])),
-        ("member_expression", "chain", Some(vec!["", "."])),
+        (
+            "call_expression",
+            "type_arguments",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "new_expression",
+            "type_arguments",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "function",
+            "return_type",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "arrow_function",
+            "return_type",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "import_statement",
+            "type",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "public_field_definition",
+            "static",
+            FieldExpectationCondition::OnlyIf(vec![""]),
+        ),
+        (
+            "member_expression",
+            "chain",
+            FieldExpectationCondition::OnlyIf(vec!["", "."]),
+        ),
     ];
     res.extend(js_disregarded_field_values());
     res

--- a/crates/language/src/js_like.rs
+++ b/crates/language/src/js_like.rs
@@ -43,30 +43,6 @@ pub(crate) fn js_like_get_statement_sorts(lang: &TSLanguage) -> Vec<SortId> {
         .collect()
 }
 
-pub(crate) fn js_skip_snippet_compilation_sorts() -> Vec<(&'static str, &'static str)> {
-    vec![
-        ("method_definition", "parenthesis"),
-        ("function", "parenthesis"),
-        ("function_declaration", "parenthesis"),
-        ("generator_function", "parenthesis"),
-        ("generator_function_declaration", "parenthesis"),
-        ("arrow_function", "parenthesis"),
-    ]
-}
-
-pub(crate) fn js_like_skip_snippet_compilation_sorts() -> Vec<(&'static str, &'static str)> {
-    let mut res = vec![
-        ("constructor_type", "parenthesis"),
-        ("construct_signature", "parenthesis"),
-        ("function_type", "parenthesis"),
-        ("method_signature", "parenthesis"),
-        ("abstract_method_signature", "parenthesis"),
-        ("function_signature", "parenthesis"),
-    ];
-    res.extend(js_skip_snippet_compilation_sorts());
-    res
-}
-
 pub(crate) fn js_disregarded_field_values(
 ) -> Vec<(&'static str, &'static str, Option<Vec<&'static str>>)> {
     vec![
@@ -97,7 +73,7 @@ pub(crate) fn js_like_disregarded_field_values(
         ("function_type", "parenthesis", None),
         ("method_signature", "parenthesis", None),
         ("abstract_method_signature", "parenthesis", None),
-        ("function_signature", "parenthesis" None),
+        ("function_signature", "parenthesis", None),
         // disregarded if empty:
         ("call_expression", "type_arguments", Some(vec![""])),
         ("new_expression", "type_arguments", Some(vec![""])),

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -305,8 +305,8 @@ pub trait MarzanoLanguage<'a>: Language<Node<'a> = NodeWithSource<'a>> + NodeTyp
     /// This method allows you to specify fields that should be (conditionally) disregarded in snippets.
     /// The actual value of the field from the snippet, if any, is passed in as the third argument.
     ///
-    /// Note that if a field is always disregarded, you can still down to ast_node syntax to match on these fields.
-    /// For example, in react_to_hookswe match on `arrow_function` and capture `$parenthesis` for inspection.
+    /// Note that if a field is always disregarded, you can still switch to ast_node syntax to match on these fields.
+    /// For example, in react_to_hooks we match on `arrow_function` and capture `$parenthesis` for inspection.
     ///
     /// ```grit
     /// arrow_function(parameters=$props, $body, $parenthesis) where {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -299,38 +299,10 @@ pub trait MarzanoLanguage<'a>: Language<Node<'a> = NodeWithSource<'a>> + NodeTyp
             .collect()
     }
 
-    /// Certain fields are trivial, and should not be compiled into the snippet because attempting
-    /// to match on them makes snippets too brittle.
-    ///
-    /// For example, in JavaScript, we want arrow functions to match regardless of whether the snippet
-    /// included the parentheses or not.
-    ///
-    /// Fields in this list are skipped during *snippet* compilation and will therefore never prevent a match.
-    /// Note this is distinct from `optional_empty_field_compilation` which only applies to fields that are empty.
-    ///
-    /// Note you can always drop down to ast_node syntax to match on these fields. For example, in react_to_hooks
-    /// we match on `arrow_function` and capture `$parenthesis` for inspection.
-    ///
-    /// ```grit
-    /// arrow_function(parameters=$props, $body, $parenthesis) where {
-    ///     $props <: contains or { `props`, `inputProps` },
-    ///     $body <: not contains `props`,
-    ///    if ($parenthesis <: .) {
-    ///         $props => `()`
-    ///     } else {
-    ///         $props => .
-    ///     }
-    /// }
-    /// ```
-    ///
-    fn skip_snippet_compilation_of_field(&self, _sort_id: SortId, _field_id: FieldId) -> bool {
-        false
-    }
-
     /// Ordinarily, we want to match on all possible fields, including the absence of nodes within a field.
     /// e.g., `my_function()` should not match `my_function(arg)`.
     ///
-    /// However, sometimes we want to allow a field to be empty in the snippet and still match if it is present in the code.
+    /// However, some fields are trivial or not expected to be part of the snippet, and should be disregarded.
     /// For example, in JavaScript, we want to match both `function name() {}` and `async function name() {}` with the same snippet.
     ///
     /// You can still match on the presence/absence of the field in the snippet by including a metavariable and checking its value.
@@ -343,7 +315,7 @@ pub trait MarzanoLanguage<'a>: Language<Node<'a> = NodeWithSource<'a>> + NodeTyp
     /// The actual value of the field from the snippet, if any, is passed in as the third argument.
     ///
     /// Note that if a field is always disregarded, you can still down to ast_node syntax to match on these fields.
-    /// For example, in react_to_hooks we match on `arrow_function` and capture `$parenthesis` for inspection.
+    /// For example, in react_to_hookswe match on `arrow_function` and capture `$parenthesis` for inspection.
     ///
     /// ```grit
     /// arrow_function(parameters=$props, $body, $parenthesis) where {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -117,21 +117,6 @@ pub(crate) fn normalize_double_quote_string(s: &str) -> Option<&str> {
     s.strip_prefix('"')?.strip_suffix('"')
 }
 
-pub(crate) fn kind_and_field_id_for_names(
-    lang: &TSLanguage,
-    names: Vec<(&str, &str)>,
-) -> Vec<(u16, u16)> {
-    names
-        .iter()
-        .map(|(kind, field)| {
-            (
-                lang.id_for_node_kind(kind, true),
-                lang.field_id_for_name(field).unwrap(),
-            )
-        })
-        .collect()
-}
-
 pub(crate) fn kind_and_field_id_for_field_map(
     lang: &TSLanguage,
     names: Vec<(&str, &str, Option<Vec<&'static str>>)>,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -339,8 +339,23 @@ pub trait MarzanoLanguage<'a>: Language<Node<'a> = NodeWithSource<'a>> + NodeTyp
     /// `$async func name(args)` where $async <: .
     /// ```
     ///
-    /// This method allows you to specify that a field can be empty in the snippet and still match.
-    /// You can also specify values that should count as "effectively empty" for the purposes of matching.
+    /// This method allows you to specify fields that should be (conditionally) disregarded in snippets.
+    /// The actual value of the field from the snippet, if any, is passed in as the third argument.
+    ///
+    /// Note that if a field is always disregarded, you can still down to ast_node syntax to match on these fields.
+    /// For example, in react_to_hooks we match on `arrow_function` and capture `$parenthesis` for inspection.
+    ///
+    /// ```grit
+    /// arrow_function(parameters=$props, $body, $parenthesis) where {
+    ///     $props <: contains or { `props`, `inputProps` },
+    ///     $body <: not contains `props`,
+    ///    if ($parenthesis <: .) {
+    ///         $props => `()`
+    ///     } else {
+    ///         $props => .
+    ///     }
+    /// }
+    /// ```
     fn is_disregarded_snippet_field(
         &self,
         _sort_id: SortId,

--- a/crates/language/src/rust.rs
+++ b/crates/language/src/rust.rs
@@ -1,6 +1,6 @@
 use crate::language::{
     check_disregarded_field_map, fields_for_nodes, Field, FieldExpectation,
-    MarzanoLanguage, NodeTypes, SortId, TSLanguage,
+    FieldExpectationCondition, MarzanoLanguage, NodeTypes, SortId, TSLanguage,
 };
 use grit_util::Language;
 use marzano_util::node_with_source::NodeWithSource;
@@ -46,42 +46,42 @@ impl Rust {
                 (
                     language.id_for_node_kind("struct_item", true),
                     language.field_id_for_name("visibility").unwrap(),
-                    Some(vec![""]),
+                    FieldExpectationCondition::OnlyIf(vec![""]),
                 ),
                 (
                     language.id_for_node_kind("union_item", true),
                     language.field_id_for_name("visibility").unwrap(),
-                    Some(vec![""]),
+                    FieldExpectationCondition::OnlyIf(vec![""]),
                 ),
                 (
                     language.id_for_node_kind("enum_item", true),
                     language.field_id_for_name("visibility").unwrap(),
-                    Some(vec![""]),
+                    FieldExpectationCondition::OnlyIf(vec![""]),
                 ),
                 (
                     language.id_for_node_kind("function_item", true),
                     language.field_id_for_name("visibility").unwrap(),
-                    Some(vec![""]),
+                    FieldExpectationCondition::OnlyIf(vec![""]),
                 ),
                 (
                     language.id_for_node_kind("function_signature_item", true),
                     language.field_id_for_name("visibility").unwrap(),
-                    Some(vec![""]),
+                    FieldExpectationCondition::OnlyIf(vec![""]),
                 ),
                 (
                     language.id_for_node_kind("visibility", true),
                     language.field_id_for_name("visibility").unwrap(),
-                    Some(vec![""]),
+                    FieldExpectationCondition::OnlyIf(vec![""]),
                 ),
                 (
                     language.id_for_node_kind("function_item", true),
                     language.field_id_for_name("type_parameters").unwrap(),
-                    Some(vec![""]),
+                    FieldExpectationCondition::OnlyIf(vec![""]),
                 ),
                 (
                     language.id_for_node_kind("function_signature_item", true),
                     language.field_id_for_name("type_parameters").unwrap(),
-                    Some(vec![""]),
+                    FieldExpectationCondition::OnlyIf(vec![""]),
                 ),
             ]
         });

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -554,12 +554,6 @@ macro_rules! generate_target_language {
                 }
             }
 
-            fn skip_snippet_compilation_of_field(&self, sort_id: SortId, field_id: FieldId) -> bool {
-                match self {
-                    $(Self::$language(lang) => MarzanoLanguage::skip_snippet_compilation_of_field(lang, sort_id, field_id)),+
-                }
-            }
-
             fn is_disregarded_snippet_field(&self, sort_id: SortId, field_id: FieldId, field_value: &Option<NodeWithSource<'_>>) -> bool {
                 match self {
                     $(Self::$language(lang) => MarzanoLanguage::is_disregarded_snippet_field(lang, sort_id, field_id, field_value)),+

--- a/crates/language/src/tsx.rs
+++ b/crates/language/src/tsx.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     language::{
         check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map, Field,
-        FieldExpectation, FieldId, MarzanoLanguage, NodeTypes, SortId, TSLanguage, Tree,
+        FieldExpectation, MarzanoLanguage, NodeTypes, SortId, TSLanguage, Tree,
     },
 };
 use grit_util::{AstNode, Language, Parser, Range, Replacement};

--- a/crates/language/src/tsx.rs
+++ b/crates/language/src/tsx.rs
@@ -1,12 +1,11 @@
 use crate::{
     js_like::{
         js_like_disregarded_field_values, js_like_get_statement_sorts, js_like_is_comment,
-        js_like_skip_snippet_compilation_sorts, jslike_check_replacements, MarzanoJsLikeParser,
+        jslike_check_replacements, MarzanoJsLikeParser,
     },
     language::{
-        check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map,
-        kind_and_field_id_for_names, Field, FieldExpectation, FieldId, MarzanoLanguage, NodeTypes,
-        SortId, TSLanguage, Tree,
+        check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map, Field,
+        FieldExpectation, FieldId, MarzanoLanguage, NodeTypes, SortId, TSLanguage, Tree,
     },
 };
 use grit_util::{AstNode, Language, Parser, Range, Replacement};
@@ -16,7 +15,6 @@ use std::sync::OnceLock;
 static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/tsx-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
 static LANGUAGE: OnceLock<TSLanguage> = OnceLock::new();
-static SKIP_SNIPPET_COMPILATION_SORTS: OnceLock<Vec<(SortId, FieldId)>> = OnceLock::new();
 static STATEMENT_SORTS: OnceLock<Vec<SortId>> = OnceLock::new();
 static DISREGARDED_SNIPPET_FIELDS: OnceLock<Vec<FieldExpectation>> = OnceLock::new();
 
@@ -39,7 +37,6 @@ pub struct Tsx {
     jsx_sort: SortId,
     statement_sorts: &'static [SortId],
     language: &'static TSLanguage,
-    skip_snippet_compilation_sorts: &'static Vec<(SortId, FieldId)>,
     disregarded_snippet_fields: &'static Vec<FieldExpectation>,
 }
 
@@ -50,9 +47,6 @@ impl Tsx {
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
         let comment_sort = language.id_for_node_kind("comment", true);
         let jsx_sort = language.id_for_node_kind("jsx_expression", true);
-        let skip_snippet_compilation_sorts = SKIP_SNIPPET_COMPILATION_SORTS.get_or_init(|| {
-            kind_and_field_id_for_names(language, js_like_skip_snippet_compilation_sorts())
-        });
 
         let disregarded_snippet_fields = DISREGARDED_SNIPPET_FIELDS.get_or_init(|| {
             kind_and_field_id_for_field_map(language, js_like_disregarded_field_values())
@@ -67,7 +61,6 @@ impl Tsx {
             jsx_sort,
             statement_sorts,
             language,
-            skip_snippet_compilation_sorts,
             disregarded_snippet_fields,
         }
     }
@@ -168,12 +161,6 @@ impl<'a> MarzanoLanguage<'a> for Tsx {
             field_id,
             field_node,
         )
-    }
-
-    fn skip_snippet_compilation_of_field(&self, sort_id: SortId, field_id: FieldId) -> bool {
-        self.skip_snippet_compilation_sorts
-            .iter()
-            .any(|(s, f)| *s == sort_id && *f == field_id)
     }
 
     fn is_comment_sort(&self, id: SortId) -> bool {

--- a/crates/language/src/typescript.rs
+++ b/crates/language/src/typescript.rs
@@ -3,9 +3,8 @@ use crate::js_like::{
     MarzanoJsLikeParser,
 };
 use crate::language::{
-    check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map,
-    kind_and_field_id_for_names, Field, FieldExpectation, FieldId, MarzanoLanguage, NodeTypes,
-    SortId, TSLanguage, Tree,
+    check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map, Field,
+    FieldExpectation, MarzanoLanguage, NodeTypes, SortId, TSLanguage, Tree,
 };
 use grit_util::{AstNode, Language, Parser, Range, Replacement};
 use marzano_util::node_with_source::NodeWithSource;

--- a/crates/language/src/typescript.rs
+++ b/crates/language/src/typescript.rs
@@ -1,6 +1,6 @@
 use crate::js_like::{
-    js_like_disregarded_field_values, js_like_get_statement_sorts,
-    js_like_skip_snippet_compilation_sorts, jslike_check_replacements, MarzanoJsLikeParser,
+    js_like_disregarded_field_values, js_like_get_statement_sorts, jslike_check_replacements,
+    MarzanoJsLikeParser,
 };
 use crate::language::{
     check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map,
@@ -15,7 +15,6 @@ static NODE_TYPES_STRING: &str =
     include_str!("../../../resources/node-types/typescript-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
 static LANGUAGE: OnceLock<TSLanguage> = OnceLock::new();
-static SKIP_SNIPPET_COMPILATION_SORTS: OnceLock<Vec<(SortId, FieldId)>> = OnceLock::new();
 static STATEMENT_SORTS: OnceLock<Vec<SortId>> = OnceLock::new();
 static DISREGARDED_SNIPPET_FIELDS: OnceLock<Vec<FieldExpectation>> = OnceLock::new();
 
@@ -37,7 +36,6 @@ pub struct TypeScript {
     comment_sort: SortId,
     statement_sorts: &'static [SortId],
     language: &'static TSLanguage,
-    skip_snippet_compilation_sorts: &'static Vec<(SortId, FieldId)>,
     disregarded_snippet_fields: &'static Vec<FieldExpectation>,
 }
 
@@ -47,10 +45,6 @@ impl TypeScript {
         let node_types = NODE_TYPES.get_or_init(|| fields_for_nodes(language, NODE_TYPES_STRING));
         let metavariable_sort = language.id_for_node_kind("grit_metavariable", true);
         let comment_sort = language.id_for_node_kind("comment", true);
-
-        let skip_snippet_compilation_sorts = SKIP_SNIPPET_COMPILATION_SORTS.get_or_init(|| {
-            kind_and_field_id_for_names(language, js_like_skip_snippet_compilation_sorts())
-        });
 
         let disregarded_snippet_fields = DISREGARDED_SNIPPET_FIELDS.get_or_init(|| {
             kind_and_field_id_for_field_map(language, js_like_disregarded_field_values())
@@ -64,7 +58,6 @@ impl TypeScript {
             comment_sort,
             statement_sorts,
             language,
-            skip_snippet_compilation_sorts,
             disregarded_snippet_fields,
         }
     }
@@ -165,12 +158,6 @@ impl<'a> MarzanoLanguage<'a> for TypeScript {
             field_id,
             field_node,
         )
-    }
-
-    fn skip_snippet_compilation_of_field(&self, sort_id: SortId, field_id: FieldId) -> bool {
-        self.skip_snippet_compilation_sorts
-            .iter()
-            .any(|(s, f)| *s == sort_id && *f == field_id)
     }
 
     fn is_comment_sort(&self, id: SortId) -> bool {


### PR DESCRIPTION
Following up on https://github.com/getgrit/gritql/pull/282, combine all snippet field handling into a single interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed outdated compilation skipping logic across multiple programming languages (JavaScript, TSX, TypeScript, Rust) to streamline codebases.
- **Bug Fixes**
	- Enhanced consistency in code handling by integrating and simplifying snippet compilation processes.
- **Documentation**
	- Updated comments for better clarity in JavaScript-like language functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->