### PR TITLE
chore: add Release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -1,0 +1,27 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This PR adds a workflow for [Release-plz](https://release-plz.ieni.dev/). The way this tool works:

- Whenever something is merged to `main`, it creates a PR for publishing unpublished crates. It automatically bumps versions and generates changelogs for you, but you have to ability to make manual changes to this PR as well.
- Whenever the release PR is merged, it publishes the bumped versions for you.

I cannot test this setup on your repository, but I think this will attempt to publish all crates referenced from your root `Cargo.toml`, so it will include `marzano-*` crates. If you want to exclude crates, add `publish = false` to the relevant `Cargo.toml`s.

Tokens and permissions will need to be setup as well. Instructions can be found here, which is where I basically pulled this workflow from as well :) https://release-plz.ieni.dev/docs/github/quickstart

Personally I mainly care about the publication of the `grit-util` and `grit-pattern-matcher` crates, so I can add `publish = false` to the others if you like. But I figured I'd leave to choice to you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a new automated release workflow to enhance software updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->