### PR TITLE
chore: publish util and pattern-matcher crates

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --features test_ci --exclude gritql-wasm-bindings -- -D warnings
+          args: --workspace --features test_ci --exclude grit-wasm-bindings -- -D warnings

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --features test_ci --exclude marzano-wasm-bindings -- -D warnings
+          args: --workspace --features test_ci --exclude gritql-wasm-bindings -- -D warnings

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           cargo test --workspace \
             --features test_ci \
-            --exclude marzano-wasm-bindings \
+            --exclude gritql-wasm-bindings \
             --exclude rustfsm \
             --exclude temporal-sdk-core-test-utils \
             --exclude temporal-client \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           cargo test --workspace \
             --features test_ci \
-            --exclude gritql-wasm-bindings \
+            --exclude grit-wasm-bindings \
             --exclude rustfsm \
             --exclude temporal-sdk-core-test-utils \
             --exclude temporal-client \

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -1,4 +1,4 @@
-name: Release-plz
+name: release-plz
 
 permissions:
   pull-requests: write
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release-plz:
-    name: Release-plz
+    name: release-plz
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.grit/patterns/cargo_meta.md
+++ b/.grit/patterns/cargo_meta.md
@@ -14,6 +14,7 @@ $props` where {
     and { $props <: not contains `documentation`, $props += `documentation.workspace = true` },
     and { $props <: not contains `homepage`, $props += `homepage.workspace = true` },
     and { $props <: not contains `license`, $props += `license = "MIT"` },
+    and { $props <: not contains `publish`, $props += `publish = false` },
   }
 }
 ```

--- a/.grit/patterns/cargo_meta.md
+++ b/.grit/patterns/cargo_meta.md
@@ -8,7 +8,12 @@ $props` where {
   $filename <: includes "Cargo.toml",
   $filename <: not includes or {"language-metavariables", "language-submodules" },
   any {
-    $props <: not contains `version` where $props += `version.workspace = true`
+    and { $props <: not contains `version`, $props += `version.workspace = true` },
+    and { $props <: not contains `authors`, $props += `authors.workspace = true` },
+    and { $props <: not contains `description`, $props += `description.workspace = true` },
+    and { $props <: not contains `documentation`, $props += `documentation.workspace = true` },
+    and { $props <: not contains `homepage`, $props += `homepage.workspace = true` },
+    and { $props <: not contains `license`, $props += `license = "MIT"` },
   }
 }
 ```

--- a/.grit/patterns/cargo_meta.md
+++ b/.grit/patterns/cargo_meta.md
@@ -1,0 +1,14 @@
+# Inject correct cargo metadata into the markdown file
+
+```grit
+language toml
+
+`[package]
+$props` where {
+  $filename <: includes "Cargo.toml",
+  $filename <: not includes or {"language-metavariables", "language-submodules" },
+  any {
+    $props <: not contains `version` where $props += `version.workspace = true`
+  }
+}
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "marzano-gritmodule"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "gritql-wasm-bindings"
+name = "grit-wasm-bindings"
 version = "0.0.0"
 dependencies = [
  "ai_builtins",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "gritql-wasm-bindings"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ai_builtins",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,6 +1340,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "gritql-wasm-bindings"
+version = "0.1.0"
+dependencies = [
+ "ai_builtins",
+ "anyhow",
+ "console_error_panic_hook",
+ "grit-util",
+ "marzano-core",
+ "marzano-language",
+ "marzano-util",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tree-sitter-facade-sg",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-tree-sitter-sg",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,26 +2144,6 @@ dependencies = [
  "sha2",
  "tokio",
  "tree-sitter-facade-sg",
-]
-
-[[package]]
-name = "marzano-wasm-bindings"
-version = "0.1.0"
-dependencies = [
- "ai_builtins",
- "anyhow",
- "console_error_panic_hook",
- "grit-util",
- "marzano-core",
- "marzano-language",
- "marzano-util",
- "serde-wasm-bindgen",
- "serde_json",
- "tree-sitter-facade-sg",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test",
- "web-tree-sitter-sg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ exclude = ["resources", "vendor/web-tree-sitter", "vendor/tree-sitter-facade"]
 version = "0.1.0"
 authors = ["Iuvo AI, Inc."]
 description = "GritQL is a query language for searching, linting, and modifying code."
-documentation = "https://docs.grit.io"
+homepage = "https://docs.grit.io/language/overview"
+documentation = "https://docs.grit.io/tutorials/gritql"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["resources", "vendor/web-tree-sitter", "vendor/tree-sitter-facade"]
 
 [workspace.package]
 version = "0.1.0"
-authors = ["Iuvo AI, Inc."]
+authors = ["Iuvo AI, Inc.", "Grit Contributors"]
 description = "GritQL is a query language for searching, linting, and modifying code."
 homepage = "https://docs.grit.io/language/overview"
 documentation = "https://docs.grit.io/tutorials/gritql"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ members = [
   "crates/cli_bin",
 ]
 exclude = ["resources", "vendor/web-tree-sitter", "vendor/tree-sitter-facade"]
+
+[workspace.package]
+version = "0.1.0"
+authors = ["Iuvo AI, Inc."]
+description = "GritQL is a query language for searching, linting, and modifying code."
+documentation = "https://docs.grit.io"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -2,6 +2,11 @@
 name = "marzano-auth"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,6 +3,10 @@ name = "marzano-cli"
 version = "0.1.1"
 edition = "2021"
 authors = ["Grit Developers <support@grit.io>"]
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -6,6 +6,9 @@ description = "GritQL is a query language for searching, linting, and modifying 
 homepage = "https://docs.grit.io/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors.workspace = true
+documentation.workspace = true
+license = "MIT"
 
 [dependencies]
 anyhow = { version = "1.0.70" }

--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://docs.grit.io/"
 authors.workspace = true
 documentation.workspace = true
 license = "MIT"
+publish = false
 
 [dependencies]
 anyhow = { version = "1.0.70" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -2,6 +2,11 @@
 name = "marzano-core"
 version = "0.2.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/externals/Cargo.toml
+++ b/crates/externals/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/externals/Cargo.toml
+++ b/crates/externals/Cargo.toml
@@ -2,6 +2,11 @@
 name = "marzano-externals"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -2,6 +2,11 @@
 name = "marzano-graphql"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/grit-pattern-matcher/Cargo.toml
+++ b/crates/grit-pattern-matcher/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "grit-pattern-matcher"
-description = "Grit pattern definitions and matching logic"
-version = "0.1.0"
+description = "Grit pattern definitions and matching logic for GritQL"
 edition = "2021"
+version.workspace = true
 authors.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
-publish = false
+publish = true
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/grit-pattern-matcher/Cargo.toml
+++ b/crates/grit-pattern-matcher/Cargo.toml
@@ -2,6 +2,8 @@
 name = "grit-pattern-matcher"
 description = "Grit pattern definitions and matching logic for GritQL"
 edition = "2021"
+keywords = ["gritql", "ast", "query", "language", "pl"]
+repository = "https://github.com/getgrit/gritql/tree/main/crates/grit-pattern-matcher"
 version.workspace = true
 authors.workspace = true
 documentation.workspace = true
@@ -16,7 +18,7 @@ rust.unused_crate_dependencies = "warn"
 anyhow = { version = "1.0.70" }
 elsa = { version = "1.9.0" }
 getrandom = { version = "0.2.11", optional = true }
-grit-util = { path = "../grit-util", version = "*"}
+grit-util = { path = "../grit-util", version = "0.1.0" }
 im = { version = "15.1.0" }
 itertools = { version = "0.10.5" }
 rand = { version = "0.8.5" }

--- a/crates/grit-pattern-matcher/Cargo.toml
+++ b/crates/grit-pattern-matcher/Cargo.toml
@@ -3,6 +3,10 @@ name = "grit-pattern-matcher"
 description = "Grit pattern definitions and matching logic"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/grit-pattern-matcher/Cargo.toml
+++ b/crates/grit-pattern-matcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grit-pattern-matcher"
-description = "Grit pattern definitions and matching logic for GritQL"
+description = "Pattern definitions and core matching logic for GritQL"
 edition = "2021"
 keywords = ["gritql", "ast", "query", "language", "pl"]
 repository = "https://github.com/getgrit/gritql/tree/main/crates/grit-pattern-matcher"

--- a/crates/grit-pattern-matcher/Cargo.toml
+++ b/crates/grit-pattern-matcher/Cargo.toml
@@ -16,7 +16,7 @@ rust.unused_crate_dependencies = "warn"
 anyhow = { version = "1.0.70" }
 elsa = { version = "1.9.0" }
 getrandom = { version = "0.2.11", optional = true }
-grit-util = { path = "../grit-util" }
+grit-util = { path = "../grit-util", version = "*"}
 im = { version = "15.1.0" }
 itertools = { version = "0.10.5" }
 rand = { version = "0.8.5" }

--- a/crates/grit-pattern-matcher/Cargo.toml
+++ b/crates/grit-pattern-matcher/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/grit-util/Cargo.toml
+++ b/crates/grit-util/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/grit-util/Cargo.toml
+++ b/crates/grit-util/Cargo.toml
@@ -2,6 +2,11 @@
 name = "grit-util"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/grit-util/Cargo.toml
+++ b/crates/grit-util/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "grit-util"
+description = "Utility functions for GritQL and associated tools"
 edition = "2021"
 version.workspace = true
 authors.workspace = true
-description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
-publish = false
+publish = true
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/grit-util/Cargo.toml
+++ b/crates/grit-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grit-util"
-version = "0.1.0"
 edition = "2021"
+version.workspace = true
 authors.workspace = true
 description.workspace = true
 documentation.workspace = true

--- a/crates/grit-util/Cargo.toml
+++ b/crates/grit-util/Cargo.toml
@@ -2,6 +2,8 @@
 name = "grit-util"
 description = "Utility functions for GritQL and associated tools"
 edition = "2021"
+keywords = ["gritql", "grit", "util"]
+repository = "https://github.com/getgrit/gritql/tree/main/crates/grit-util"
 version.workspace = true
 authors.workspace = true
 documentation.workspace = true

--- a/crates/grit-util/README.md
+++ b/crates/grit-util/README.md
@@ -1,0 +1,7 @@
+# `grit-util`
+
+This crate contains miscellaneous utility functions and types that are used
+throughout the GritQL engine. It is intended to be a catch-all for things that
+don't fit neatly into other crates, without taking any dependencies on other `grit` crates.
+
+See the [GritQL homepage](https://docs.grit.io/language/overview) for more information about GritQL.

--- a/crates/gritcache/Cargo.toml
+++ b/crates/gritcache/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/gritcache/Cargo.toml
+++ b/crates/gritcache/Cargo.toml
@@ -2,6 +2,11 @@
 name = "grit_cache"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/gritmodule/Cargo.toml
+++ b/crates/gritmodule/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/gritmodule/Cargo.toml
+++ b/crates/gritmodule/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "marzano-gritmodule"
-version = "0.1.0"
 edition = "2021"
 
 [lints]

--- a/crates/gritmodule/Cargo.toml
+++ b/crates/gritmodule/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
 name = "marzano-gritmodule"
 edition = "2021"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -2,6 +2,11 @@
 name = "marzano-language"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -2,6 +2,11 @@
 name = "marzano-lsp"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/marzano_messenger/Cargo.toml
+++ b/crates/marzano_messenger/Cargo.toml
@@ -2,6 +2,11 @@
 name = "marzano_messenger"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/marzano_messenger/Cargo.toml
+++ b/crates/marzano_messenger/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -2,6 +2,11 @@
 name = "marzano-test-utils"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 license = "MIT"
+publish = false
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -2,6 +2,11 @@
 name = "marzano-util"
 version = "0.1.0"
 edition = "2021"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/wasm-bindings/Cargo.toml
+++ b/crates/wasm-bindings/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gritql-wasm-bindings"
+name = "grit-wasm-bindings"
 description = "WASM bindings for GritQL"
 edition = "2021"
 publish = false

--- a/crates/wasm-bindings/Cargo.toml
+++ b/crates/wasm-bindings/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "marzano-wasm-bindings"
+name = "gritql-wasm-bindings"
+description = "WASM bindings for GritQL"
 version = "0.1.0"
 edition = "2021"
+publish = false
+license = "MIT"
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/wasm-bindings/Cargo.toml
+++ b/crates/wasm-bindings/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "gritql-wasm-bindings"
 description = "WASM bindings for GritQL"
-version = "0.1.0"
 edition = "2021"
 publish = false
 license = "MIT"
+version.workspace = true
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/wasm-bindings/Cargo.toml
+++ b/crates/wasm-bindings/Cargo.toml
@@ -4,6 +4,10 @@ description = "WASM bindings for GritQL"
 edition = "2021"
 publish = false
 license = "MIT"
+version.workspace = true
+authors.workspace = true
+documentation.workspace = true
+homepage.workspace = true
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/crates/wasm-bindings/Cargo.toml
+++ b/crates/wasm-bindings/Cargo.toml
@@ -4,7 +4,6 @@ description = "WASM bindings for GritQL"
 edition = "2021"
 publish = false
 license = "MIT"
-version.workspace = true
 
 [lints]
 rust.unused_crate_dependencies = "warn"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "test:wasm": "cd wasm-bindings && wasm-pack test --node",
-    "test:watch": "nodemon --ext rs --exec \"cargo test --exclude marzano-wasm-bindings\"",
+    "test:watch": "nodemon --ext rs --exec \"cargo test --exclude gritql-wasm-bindings\"",
     "lint:clippy": "cargo clippy -- -D warnings"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "test:wasm": "cd wasm-bindings && wasm-pack test --node",
-    "test:watch": "nodemon --ext rs --exec \"cargo test --exclude gritql-wasm-bindings\"",
+    "test:watch": "nodemon --ext rs --exec \"cargo test --exclude grit-wasm-bindings\"",
     "lint:clippy": "cargo clippy -- -D warnings"
   }
 }


### PR DESCRIPTION
These are live:
- https://crates.io/crates/grit-pattern-matcher
- https://crates.io/crates/grit-util

@arendjr Can you confirm you have what you need now?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub workflow settings to replace `marzano-wasm-bindings` with `grit-wasm-bindings` in code quality checks and test configurations.
- **Refactor**
	- Renamed `wasm-bindings` package to `grit-wasm-bindings` and updated metadata.
- **Documentation**
	- Enhanced package metadata in `grit-pattern-matcher` and `grit-wasm-bindings` to include keywords, repository links, versioning, authors, documentation URLs, homepage URLs, and licensing details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->