### PR TITLE
fix(updater): cross-platform compatibility, robustness enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,6 +1930,7 @@ dependencies = [
  "dialoguer",
  "env_logger",
  "flate2",
+ "futures-util",
  "git2",
  "grit-util",
  "grit_cache",
@@ -2967,10 +2968,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -4316,6 +4319,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
 dependencies = [
  "leb128",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,8 @@ serde_json = { version = "1.0.96" }
 uuid = { version = "1.1", features = ["v4", "serde"] }
 tokio = { version = "1", features = ["full"] }
 chrono = { version = "0.4.26", features = ["serde"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "stream"] }
+futures-util = "0.3.30"
 lazy_static = { version = "1.4.0" }
 indicatif-log-bridge = { version = "0.2.1" }
 colored = { version = "2.0.4" }

--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -359,7 +359,10 @@ impl Updater {
         let (downloaded, manifest) = tokio::try_join!(downloader, manifest_fetcher)?;
 
         // Unzip the artifact
-        self.unpack_artifact(app, downloaded).await?;
+        self.unpack_artifact(app, downloaded.to_owned()).await?;
+
+        // Clean up the temp artifact
+        async_fs::remove_file(&downloaded).await?;
 
         self.set_app_version(app, manifest.version.unwrap(), manifest.release.unwrap())?;
         self.dump().await?;


### PR DESCRIPTION
This makes a few changes to the updater with the goal of ensuring it runs across all platforms and that it requires fewer external tools. Since these tools aren't preinstalled on Windows, it should ensure that running on Windows just works the same as on other platforms. In particular:

* The external `curl` call has been replaced by a call to `reqwest`, which was already used in the crate for other things. This should also ensure it works on minimal Linux docker images, some of which come with `wget` but no `curl` preinstalled.
* The calls to Unix commands to move and rename files have been replaced with calls to Tokio's `async_fs`.
* Executable file permissions are now handled via Rust stdlib calls, and are only run on Unix; these permissions don't exist on Windows.
* The temporary paths to which tarballs are downloaded are now deleted after being unpacked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Enhanced the updater tool to automatically clean up temporary files after use.
    - Improved error handling during file downloads and operations.
- **Refactor**
    - Updated file downloading, moving, and permissions setting methods for better performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->