### PR TITLE
chore: use `Option::transpose()`

### DIFF
--- a/crates/core/src/pattern_compiler/contains_compiler.rs
+++ b/crates/core/src/pattern_compiler/contains_compiler.rs
@@ -23,8 +23,8 @@ impl NodeCompiler for ContainsCompiler {
         let contains = PatternCompiler::from_node(&contains, context)?;
         let until = node
             .child_by_field_name("until")
-            .map(|n| PatternCompiler::from_node(&n, context));
-        let until = until.map_or(Ok(None), |v| v.map(Some))?;
+            .map(|n| PatternCompiler::from_node(&n, context))
+            .transpose()?;
         Ok(Contains::new(contains, until))
     }
 }

--- a/crates/core/src/pattern_compiler/if_compiler.rs
+++ b/crates/core/src/pattern_compiler/if_compiler.rs
@@ -28,7 +28,7 @@ impl NodeCompiler for IfCompiler {
         let else_ = node
             .child_by_field_name("else")
             .map(|e| PatternCompiler::from_node(&e, context))
-            .map_or(Ok(None), |v| v.map(Some))?;
+            .transpose()?;
         Ok(If::new(if_, then, else_))
     }
 }
@@ -54,7 +54,7 @@ impl NodeCompiler for PrIfCompiler {
         let else_ = node
             .child_by_field_name("else")
             .map(|e| PredicateCompiler::from_node(&e, context))
-            .map_or(Ok(None), |v| v.map(Some))?;
+            .transpose()?;
         Ok(PrIf::new(if_, then, else_))
     }
 }

--- a/crates/core/src/pattern_compiler/log_compiler.rs
+++ b/crates/core/src/pattern_compiler/log_compiler.rs
@@ -29,9 +29,9 @@ impl NodeCompiler for LogCompiler {
             .map(|n| {
                 let name = n.text()?;
                 let variable = VariableCompiler::from_node(&n, context)?;
-                Ok(VariableInfo::new(name.to_string(), variable))
+                Ok::<_, anyhow::Error>(VariableInfo::new(name.to_string(), variable))
             })
-            .map_or(Ok(None), |v: Result<VariableInfo>| v.map(Some))?;
+            .transpose()?;
 
         Ok(Log::new(variable, message))
     }

--- a/crates/core/src/pattern_compiler/range_compiler.rs
+++ b/crates/core/src/pattern_compiler/range_compiler.rs
@@ -28,5 +28,5 @@ impl NodeCompiler for RangeCompiler {
 fn node_to_int(node: &NodeWithSource, field: &str) -> Result<Option<u32>> {
     node.child_by_field_name(field)
         .map(|n| Ok(n.text()?.parse::<u32>()?))
-        .map_or(Ok(None), |v| v.map(Some))
+        .transpose()
 }


### PR DESCRIPTION
Probably my tiniest PR yet :) 

As I was porting the node compilers to Biome, I came across this use case where `Option<Result>` needs to be converted to `Result<Option>`. I noticed you use `map_or()` for this, but this is a little confusing to read when trying to understand the code. Instead, Rust has a built-in `transpose()` utility for this very purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling and code clarity in pattern compilation modules by adopting a more idiomatic approach using the `transpose` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->