### PR TITLE
chore: checkout submodules for release

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: true
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz


### PR DESCRIPTION
Previous release job failed, looks like due to a lack of the submodules: https://github.com/getgrit/gritql/actions/runs/8908198285/job/24463410476

Hopefully this fixes it.