### PR TITLE
chore: exclude `tree-sitter-gritql`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,12 @@ members = [
   "crates/marzano_messenger",
   "crates/cli_bin",
 ]
-exclude = ["resources", "vendor/web-tree-sitter", "vendor/tree-sitter-facade"]
+exclude = [
+  "resources",
+  "vendor/web-tree-sitter",
+  "vendor/tree-sitter-gritql",
+  "vendor/tree-sitter-facade",
+]
 
 [workspace.package]
 version = "0.2.0"


### PR DESCRIPTION
Trying again for CI failure: https://github.com/getgrit/gritql/actions/runs/8908683431

It appears the issue is to do with `tree-sitter-gritql`. Maybe we can fix it by adding a `publish = false` to it. Or maybe excluding it like this will already do the trick. I'm just giving it a shot :)

Locally the tests ran for me, but I'm not sure if excluding it like this has other consequences?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package configuration to enhance project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->