### PR TITLE
fix(js): treat empty statements properly

### DIFF
--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -3884,6 +3884,38 @@ fn js_paren_params() {
 }
 
 #[test]
+fn js_preserve_significant_empty_statements() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"`$body` => `$body`"#.to_owned(),
+            source: r#"
+            for(;;);
+            if(true);
+            while(true);"#
+                .to_owned(),
+            expected: r#"
+            for(;;);
+            if(true);
+            while(true);"#
+                .to_owned(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
+fn js_remove_redundant_empty_statements() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"`$body` => `$body`"#.to_owned(),
+            source: r#";;{;;};;"#.to_owned(),
+            expected: r#"{}"#.to_owned(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
 fn array_destrcutring_snippet() {
     run_test_match({
         TestArg {

--- a/crates/language/src/js_like.rs
+++ b/crates/language/src/js_like.rs
@@ -170,6 +170,8 @@ pub(crate) fn jslike_check_replacements(
         && n.text()
             .is_ok_and(|t| ["var", "let", "const"].contains(&t.as_ref()))
         || n.node.kind() == "empty_statement"
+            && n.parent()
+                .is_some_and(|p| ["program", "statement_block"].contains(&p.node.kind().as_ref()))
     {
         replacement_ranges.push(Replacement::new(n.range(), ""));
     } else if n.node.kind() == "import_statement" {


### PR DESCRIPTION
Empty statements in JavaScript are not always redundant and removing them regardless will break the code. For example, empty statements (`;`) in the code below are all significant:

```js
for (;;);

if (true);

while (true);
```

This PR treats `empty_statement`s directly under `program` and `statement_block` as redundant ones and they can be removed safely, while the rest are considered as significant ones so we keep them during cleaning up.

Two test cases are added to `crates/core/src/test.rs`.

This PR fixes #307 and also fixes #308.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced JavaScript code processing to better handle empty statements, ensuring more accurate code modifications.

- **Tests**
	- Added new tests to verify the correct preservation and removal of empty statements in JavaScript code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->