### PR TITLE
chore: move `alternate_metavariable_kinds` around

### DIFF
--- a/crates/grit-util/src/language.rs
+++ b/crates/grit-util/src/language.rs
@@ -14,10 +14,6 @@ pub trait Language: Sized {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)];
 
-    fn alternate_metavariable_kinds(&self) -> &[&'static str] {
-        &[]
-    }
-
     fn metavariable_prefix(&self) -> &'static str {
         "$"
     }

--- a/crates/language/src/javascript.rs
+++ b/crates/language/src/javascript.rs
@@ -1,7 +1,7 @@
 use crate::{
     js_like::{
         js_disregarded_field_values, js_like_get_statement_sorts, js_like_is_comment,
-        jslike_check_replacements, MarzanoJsLikeParser,
+        js_like_is_metavariable, jslike_check_replacements, MarzanoJsLikeParser,
     },
     language::{
         check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map, Field,
@@ -110,15 +110,11 @@ impl Language for JavaScript {
     }
 
     fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
+        js_like_is_metavariable(node, self, &["template_content"])
     }
 
     fn is_statement(&self, node: &NodeWithSource) -> bool {
         self.statement_sorts.contains(&node.node.kind_id())
-    }
-
-    fn alternate_metavariable_kinds(&self) -> &[&'static str] {
-        &["template_content"]
     }
 
     // assumes trim doesn't do anything otherwise range is off

--- a/crates/language/src/js_like.rs
+++ b/crates/language/src/js_like.rs
@@ -91,6 +91,19 @@ pub(crate) fn js_like_disregarded_field_values(
     res
 }
 
+pub(crate) fn js_like_is_metavariable<'a>(
+    node: &NodeWithSource,
+    lang: &impl MarzanoLanguage<'a>,
+    alternate_metavariable_kinds: &[&str],
+) -> bool {
+    node.node.is_named()
+        && (node.node.kind_id() == lang.metavariable_sort()
+            || (alternate_metavariable_kinds.contains(&node.node.kind().as_ref())
+                && node
+                    .text()
+                    .is_ok_and(|t| lang.exact_replaced_variable_regex().is_match(&t))))
+}
+
 pub(crate) struct MarzanoJsLikeParser(MarzanoParser);
 
 impl MarzanoJsLikeParser {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -342,14 +342,7 @@ pub trait MarzanoLanguage<'a>: Language<Node<'a> = NodeWithSource<'a>> + NodeTyp
     fn metavariable_sort(&self) -> SortId;
 
     fn is_metavariable_node(&self, node: &NodeWithSource<'_>) -> bool {
-        node.node.is_named()
-            && (node.node.kind_id() == self.metavariable_sort()
-                || (self
-                    .alternate_metavariable_kinds()
-                    .contains(&node.node.kind().as_ref())
-                    && node
-                        .text()
-                        .is_ok_and(|t| self.exact_replaced_variable_regex().is_match(&t))))
+        node.node.is_named() && node.node.kind_id() == self.metavariable_sort()
     }
 
     fn get_equivalence_class(

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -400,12 +400,6 @@ macro_rules! generate_target_language {
                 }
             }
 
-            fn alternate_metavariable_kinds(&self) -> &[&'static str] {
-                match self {
-                    $(Self::$language(lang) => Language::alternate_metavariable_kinds(lang)),+
-                }
-            }
-
             fn metavariable_prefix(&self) -> &'static str {
                 match self {
                     $(Self::$language(lang) => Language::metavariable_prefix(lang)),+

--- a/crates/language/src/tsx.rs
+++ b/crates/language/src/tsx.rs
@@ -1,7 +1,7 @@
 use crate::{
     js_like::{
         js_like_disregarded_field_values, js_like_get_statement_sorts, js_like_is_comment,
-        jslike_check_replacements, MarzanoJsLikeParser,
+        js_like_is_metavariable, jslike_check_replacements, MarzanoJsLikeParser,
     },
     language::{
         check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map, Field,
@@ -82,10 +82,6 @@ impl Language for Tsx {
         "TSX"
     }
 
-    fn alternate_metavariable_kinds(&self) -> &[&'static str] {
-        &["template_content", "template_literal_type_content"]
-    }
-
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[
             ("", ""),
@@ -114,7 +110,11 @@ impl Language for Tsx {
     }
 
     fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
+        js_like_is_metavariable(
+            node,
+            self,
+            &["template_content", "template_literal_type_content"],
+        )
     }
 
     fn is_statement(&self, node: &NodeWithSource) -> bool {

--- a/crates/language/src/typescript.rs
+++ b/crates/language/src/typescript.rs
@@ -1,6 +1,6 @@
 use crate::js_like::{
-    js_like_disregarded_field_values, js_like_get_statement_sorts, jslike_check_replacements,
-    MarzanoJsLikeParser,
+    js_like_disregarded_field_values, js_like_get_statement_sorts, js_like_is_metavariable,
+    jslike_check_replacements, MarzanoJsLikeParser,
 };
 use crate::language::{
     check_disregarded_field_map, fields_for_nodes, kind_and_field_id_for_field_map, Field,
@@ -78,10 +78,6 @@ impl Language for TypeScript {
         "TypeScript"
     }
 
-    fn alternate_metavariable_kinds(&self) -> &[&'static str] {
-        &["template_content", "template_literal_type_content"]
-    }
-
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[
             ("", ""),
@@ -110,7 +106,11 @@ impl Language for TypeScript {
     }
 
     fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
+        js_like_is_metavariable(
+            node,
+            self,
+            &["template_content", "template_literal_type_content"],
+        )
     }
 
     fn is_statement(&self, node: &NodeWithSource) -> bool {


### PR DESCRIPTION
This is a tiny PR to make sure `alternate_metavariable_kinds()` is no longer exposed as a method on the `Language` trait. The main motivation is that the return value of the method is a string *kind* of TreeSitter nodes.

Fortunately this functionality is only used for JS-like languages, so it was easily moved to become an implementation detail implemented in the `js_like_is_metavariable` function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified metavariable checks across various programming language implementations to improve consistency and performance.
- **Bug Fixes**
	- Adjusted logic in metavariable identification to prevent incorrect flagging, enhancing accuracy in code analysis tools.
- **New Features**
	- Introduced a unified approach for identifying metavariables in JavaScript-like languages, supporting more robust language processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->