### PR TITLE
feat: expose `--remote` flag to launch remote workflows on Grit Cloud

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -87,7 +87,7 @@ default = [
   "external_functions",
   "updater",
   "workflows_v2",
-  # "remote_workflows",
+  "remote_workflows",
   # "server",
   # "remote_redis",
   # "embeddings",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -87,7 +87,7 @@ default = [
   "external_functions",
   "updater",
   "workflows_v2",
-  "remote_workflows",
+  # "remote_workflows",
   # "server",
   # "remote_redis",
   # "embeddings",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -87,7 +87,6 @@ default = [
   "external_functions",
   "updater",
   "workflows_v2",
-  "remote_workflows",
   # "server",
   # "remote_redis",
   # "embeddings",
@@ -134,6 +133,8 @@ grit_beta = [
   "external_functions",
   "updater",
   "ai_builtins",
+  "workflows_v2",
+  "remote_workflows"
   # "grit_timing",
 ]
 grit_timing = []

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -87,6 +87,7 @@ default = [
   "external_functions",
   "updater",
   "workflows_v2",
+  "remote_workflows",
   # "server",
   # "remote_redis",
   # "embeddings",

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -62,7 +62,11 @@ pub(crate) async fn run_apply(
 
         #[cfg(feature = "remote_workflows")]
         if args.apply_migration_args.remote {
-            return crate::workflows::run_remote_workflow(args.pattern_or_workflow).await;
+            return crate::workflows::run_remote_workflow(
+                args.pattern_or_workflow,
+                args.apply_migration_args,
+            )
+            .await;
         }
 
         let custom_workflow = find_workflow_file_from(current_dir, &args.pattern_or_workflow).await;

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -34,7 +34,7 @@ pub struct ApplyMigrationArgs {
 }
 
 impl ApplyMigrationArgs {
-    /// Extracts the payload from the input if provided, otherwise returns None.
+    /// Extracts the payload from the input if provided, otherwise returns an empty map
     pub fn get_payload(&self) -> Result<serde_json::Map<String, serde_json::Value>> {
         let map = match &self.input {
             Some(i) => serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(i)?,

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -33,6 +33,17 @@ pub struct ApplyMigrationArgs {
     verbose: bool,
 }
 
+impl ApplyMigrationArgs {
+    /// Extracts the payload from the input if provided, otherwise returns None.
+    pub fn get_payload(&self) -> Result<serde_json::Map<String, serde_json::Value>> {
+        let map = match &self.input {
+            Some(i) => serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(i)?,
+            None => serde_json::Map::new(),
+        };
+        Ok(map)
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct WorkflowSettings {}
 
@@ -55,10 +66,7 @@ pub(crate) async fn run_apply_migration(
 ) -> Result<()> {
     use crate::workflows::display_workflow_outcome;
 
-    let input = match &arg.input {
-        Some(i) => serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(i)?,
-        None => serde_json::Map::new(),
-    };
+    let input = arg.get_payload()?;
 
     let format = OutputFormat::from(flags);
     let mut emitter = create_emitter(

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -182,7 +182,7 @@ pub fn display_workflow_outcome(outcome: PackagedWorkflowOutcome) -> Result<()> 
 #[cfg(feature = "remote_workflows")]
 pub async fn run_remote_workflow(workflow_name: String) -> Result<()> {
     use marzano_gritmodule::fetcher::ModuleRepo;
-    let mut updater = Updater::from_current_bin().await?;
+    let updater = Updater::from_current_bin().await?;
     let cwd = std::env::current_dir()?;
 
     let auth = updater.get_valid_auth()?;

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Result};
+use colored::Colorize;
 use console::style;
 use grit_util::FileRange;
 use log::debug;
@@ -9,7 +10,6 @@ use serde::Serialize;
 use serde_json::to_string;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
-
 use tokio::fs;
 use tokio::process::Command;
 use uuid::Uuid;
@@ -189,7 +189,8 @@ pub async fn run_remote_workflow(workflow_name: String) -> Result<()> {
 
     let repo = ModuleRepo::from_dir(&cwd).await;
     let settings = grit_cloud_client::RemoteWorkflowSettings::new(workflow_name, &repo);
-    let outcome = grit_cloud_client::run_remote_workflow(settings, &auth).await?;
-    display_workflow_outcome(outcome)?;
-    return Ok(());
+    let url = grit_cloud_client::run_remote_workflow(settings, &auth).await?;
+    log::info!("Workflow started at: {}", url.bright_blue().underline());
+
+    Ok(())
 }

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -179,28 +179,25 @@ pub fn display_workflow_outcome(outcome: PackagedWorkflowOutcome) -> Result<()> 
 }
 
 #[cfg(feature = "remote_workflows")]
-pub async fn run_remote_workflow(
-    workflow_name: String,
-    multi: indicatif::MultiProgress,
-) -> Result<()> {
+pub async fn run_remote_workflow(workflow_name: String) -> Result<()> {
     use colored::Colorize;
-
     use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
     use marzano_gritmodule::fetcher::ModuleRepo;
+    use std::time::Duration;
+
     let updater = Updater::from_current_bin().await?;
     let cwd = std::env::current_dir()?;
 
-    let pb = ProgressBar::new_spinner();
+    let pb = ProgressBar::with_draw_target(Some(0), ProgressDrawTarget::stderr());
     pb.set_style(ProgressStyle::with_template(
         "{spinner}{prefix:.bold.dim} {wide_msg:.bold.dim}",
     )?);
     pb.set_message("Authenticating with Grit Cloud");
-
-    let pb = multi.add(pb);
+    pb.enable_steady_tick(Duration::from_millis(60));
 
     let auth = updater.get_valid_auth()?;
 
-    pb.set_message("Starting workflow on Grit Cloud");
+    pb.set_message("Launching workflow on Grit Cloud");
 
     let repo = ModuleRepo::from_dir(&cwd).await;
     let settings = grit_cloud_client::RemoteWorkflowSettings::new(workflow_name, &repo);

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -179,18 +179,35 @@ pub fn display_workflow_outcome(outcome: PackagedWorkflowOutcome) -> Result<()> 
 }
 
 #[cfg(feature = "remote_workflows")]
-pub async fn run_remote_workflow(workflow_name: String) -> Result<()> {
+pub async fn run_remote_workflow(
+    workflow_name: String,
+    multi: indicatif::MultiProgress,
+) -> Result<()> {
     use colored::Colorize;
 
+    use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
     use marzano_gritmodule::fetcher::ModuleRepo;
     let updater = Updater::from_current_bin().await?;
     let cwd = std::env::current_dir()?;
 
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(ProgressStyle::with_template(
+        "{spinner}{prefix:.bold.dim} {wide_msg:.bold.dim}",
+    )?);
+    pb.set_message("Authenticating with Grit Cloud");
+
+    let pb = multi.add(pb);
+
     let auth = updater.get_valid_auth()?;
+
+    pb.set_message("Starting workflow on Grit Cloud");
 
     let repo = ModuleRepo::from_dir(&cwd).await;
     let settings = grit_cloud_client::RemoteWorkflowSettings::new(workflow_name, &repo);
     let url = grit_cloud_client::run_remote_workflow(settings, &auth).await?;
+
+    pb.finish_and_clear();
+
     log::info!("Workflow started at: {}", url.bright_blue().underline());
 
     Ok(())

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Result};
-use colored::Colorize;
 use console::style;
 use grit_util::FileRange;
 use log::debug;
@@ -181,6 +180,8 @@ pub fn display_workflow_outcome(outcome: PackagedWorkflowOutcome) -> Result<()> 
 
 #[cfg(feature = "remote_workflows")]
 pub async fn run_remote_workflow(workflow_name: String) -> Result<()> {
+    use colored::Colorize;
+
     use marzano_gritmodule::fetcher::ModuleRepo;
     let updater = Updater::from_current_bin().await?;
     let cwd = std::env::current_dir()?;

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -179,7 +179,10 @@ pub fn display_workflow_outcome(outcome: PackagedWorkflowOutcome) -> Result<()> 
 }
 
 #[cfg(feature = "remote_workflows")]
-pub async fn run_remote_workflow(workflow_name: String) -> Result<()> {
+pub async fn run_remote_workflow(
+    workflow_name: String,
+    args: crate::commands::apply_migration::ApplyMigrationArgs,
+) -> Result<()> {
     use colored::Colorize;
     use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
     use marzano_gritmodule::fetcher::ModuleRepo;
@@ -200,7 +203,10 @@ pub async fn run_remote_workflow(workflow_name: String) -> Result<()> {
     pb.set_message("Launching workflow on Grit Cloud");
 
     let repo = ModuleRepo::from_dir(&cwd).await;
-    let settings = grit_cloud_client::RemoteWorkflowSettings::new(workflow_name, &repo);
+    let input = args.get_payload()?;
+
+    let settings =
+        grit_cloud_client::RemoteWorkflowSettings::new(workflow_name, &repo, Some(input.into()));
     let url = grit_cloud_client::run_remote_workflow(settings, &auth).await?;
 
     pb.finish_and_clear();

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -206,7 +206,7 @@ pub async fn run_remote_workflow(
     let input = args.get_payload()?;
 
     let settings =
-        grit_cloud_client::RemoteWorkflowSettings::new(workflow_name, &repo, Some(input.into()));
+        grit_cloud_client::RemoteWorkflowSettings::new(workflow_name, &repo, input.into());
     let url = grit_cloud_client::run_remote_workflow(settings, &auth).await?;
 
     pb.finish_and_clear();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced advanced workflow capabilities in the command-line interface, including support for remote workflows and enhanced migration application processes.

- **Enhancements**
  - Improved user feedback by logging workflow start URLs, enhancing visibility and traceability of remote operations.

- **Refactor**
  - Streamlined function calls and argument handling in CLI commands to improve performance and maintainability.

- **Style**
  - Added colorized logging to enhance readability and user experience during CLI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->