### PR TITLE
chore: expose test_utils

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -40,6 +40,8 @@ path-absolutize = { version = "3.1.1", optional = false, features = [
   "use_unix_paths_on_wasm",
 ] }
 getrandom = { version = "0.2.11", optional = true }
+lazy_static = {version = "1.4.0", optional = true }
+walkdir = { version = "2.3.3", optional = true }
 
 [dev-dependencies]
 similar = "2.2.1"
@@ -86,3 +88,4 @@ language-parsers = ["marzano-language/builtin-parser"]
 grit-parser = ["marzano-language/grit-parser"]
 absolute_filename = []
 non_wasm = ["absolute_filename"]
+test_utils = []

--- a/crates/core/src/ast_node.rs
+++ b/crates/core/src/ast_node.rs
@@ -27,6 +27,8 @@ impl ASTNode {
 }
 
 impl AstNodePattern<MarzanoQueryContext> for ASTNode {
+    const INCLUDES_TRIVIA: bool = false;
+
     fn children(&self) -> Vec<PatternOrPredicate<MarzanoQueryContext>> {
         self.args
             .iter()

--- a/crates/core/src/ast_node.rs
+++ b/crates/core/src/ast_node.rs
@@ -144,7 +144,11 @@ impl AstLeafNode {
     }
 }
 
-impl AstLeafNodePattern<MarzanoQueryContext> for AstLeafNode {}
+impl AstLeafNodePattern<MarzanoQueryContext> for AstLeafNode {
+    fn text(&self) -> Option<&str> {
+        Some(&self.text)
+    }
+}
 
 impl PatternName for AstLeafNode {
     fn name(&self) -> &'static str {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -38,5 +38,5 @@ use getrandom as _;
 mod test;
 #[cfg(test)]
 mod test_files;
-#[cfg(feature = "test_utils")]
+#[cfg(any(test, feature = "test_utils"))]
 pub mod test_utils;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -38,3 +38,5 @@ use getrandom as _;
 mod test;
 #[cfg(test)]
 mod test_files;
+#[cfg(feature = "test_utils")]
+pub mod test_utils;

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -143,9 +143,9 @@ fn match_pattern_libs(
     Ok(execution_result)
 }
 
-struct TestArg {
-    pattern: String,
-    source: String,
+pub struct TestArg {
+    pub pattern: String,
+    pub source: String,
 }
 
 struct TestArgExpected {
@@ -392,7 +392,7 @@ fn run_test_expected_with_new_file(arg: TestArgExpectedWithNewFile) -> Result<()
     Ok(())
 }
 
-fn run_test_match(arg: TestArg) -> Result<()> {
+pub fn run_test_match(arg: TestArg) -> Result<()> {
     let pattern = arg.pattern;
     let js_lang: TargetLanguage = PatternLanguage::Tsx.try_into().unwrap();
     let source = arg.source;

--- a/crates/core/src/test_files.rs
+++ b/crates/core/src/test_files.rs
@@ -6,61 +6,16 @@ use marzano_util::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::api::{MatchResult, Rewrite};
+use crate::{
+    api::{MatchResult, Rewrite},
+    test_utils::{run_on_test_files, SyntheticFile},
+};
 
 use self::{pattern_compiler::src_to_problem_libs, problem::Problem};
 use anyhow::Result;
 
 use super::*;
 use std::{borrow::Cow, collections::BTreeMap, sync::mpsc};
-
-/// SyntheticFile is used for ensuring we don't read files until their file names match
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-struct SyntheticFile {
-    pub path: String,
-    pub content: String,
-    pub can_read: bool,
-}
-
-impl SyntheticFile {
-    pub fn new(path: String, content: String, can_read: bool) -> Self {
-        Self {
-            path,
-            content,
-            can_read,
-        }
-    }
-}
-
-impl TryIntoInputFile for SyntheticFile {
-    fn try_into_cow(&self) -> Result<Cow<RichFile>> {
-        if !self.can_read {
-            println!("Tried to read file that should not be read: {}", self.path);
-        }
-
-        Ok(Cow::Owned(RichFile::new(
-            self.path.clone(),
-            self.content.clone(),
-        )))
-    }
-}
-
-impl FileName for SyntheticFile {
-    fn name(&self) -> String {
-        self.path.to_owned()
-    }
-}
-
-fn run_on_test_files(problem: &Problem, test_files: &[SyntheticFile]) -> Vec<MatchResult> {
-    let mut results = vec![];
-    let context = ExecutionContext::default();
-    let (tx, rx) = mpsc::channel::<Vec<MatchResult>>();
-    problem.execute_shared(test_files.to_vec(), &context, tx, &NullCache::new());
-    for r in rx.iter() {
-        results.extend(r)
-    }
-    results
-}
 
 #[test]
 fn test_lazy_file_parsing() {

--- a/crates/core/src/test_files.rs
+++ b/crates/core/src/test_files.rs
@@ -1,21 +1,14 @@
 use marzano_language::target_language::TargetLanguage;
-use marzano_util::{
-    cache::NullCache,
-    rich_path::{FileName, RichFile, TryIntoInputFile},
-    runtime::ExecutionContext,
-};
-use serde::{Deserialize, Serialize};
 
 use crate::{
     api::{MatchResult, Rewrite},
     test_utils::{run_on_test_files, SyntheticFile},
 };
 
-use self::{pattern_compiler::src_to_problem_libs, problem::Problem};
-use anyhow::Result;
+use self::pattern_compiler::src_to_problem_libs;
 
 use super::*;
-use std::{borrow::Cow, collections::BTreeMap, sync::mpsc};
+use std::collections::BTreeMap;
 
 #[test]
 fn test_lazy_file_parsing() {

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -1,0 +1,96 @@
+use marzano_language::target_language::TargetLanguage;
+
+use crate::pattern_compiler::src_to_problem_libs;
+
+/// SyntheticFile is used for ensuring we don't read files until their file names match
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub(crate) struct SyntheticFile {
+    pub path: String,
+    pub content: String,
+    pub can_read: bool,
+}
+
+impl SyntheticFile {
+    pub fn new(path: String, content: String, can_read: bool) -> Self {
+        Self {
+            path,
+            content,
+            can_read,
+        }
+    }
+}
+
+impl TryIntoInputFile for SyntheticFile {
+    fn try_into_cow(&self) -> Result<Cow<RichFile>> {
+        if !self.can_read {
+            println!("Tried to read file that should not be read: {}", self.path);
+        }
+
+        Ok(Cow::Owned(RichFile::new(
+            self.path.clone(),
+            self.content.clone(),
+        )))
+    }
+}
+
+impl FileName for SyntheticFile {
+    fn name(&self) -> String {
+        self.path.to_owned()
+    }
+}
+
+pub struct TestCase {
+    files: Vec<SyntheticFile>,
+    pattern: String,
+}
+
+impl TestCase {
+    pub fn new(file_contents: &str, pattern: &str) -> Self {
+        Self {
+            files: vec![SyntheticFile::new(
+                "target.js".to_string(),
+                file_contents.to_string(),
+                true,
+            )],
+            pattern: pattern.to_string(),
+        }
+    }
+}
+
+pub(crate) fn run_on_test_files(
+    problem: &Problem,
+    test_files: &[SyntheticFile],
+) -> Vec<MatchResult> {
+    let mut results = vec![];
+    let context = ExecutionContext::default();
+    let (tx, rx) = mpsc::channel::<Vec<MatchResult>>();
+    problem.execute_shared(test_files.to_vec(), &context, tx, &NullCache::new());
+    for r in rx.iter() {
+        results.extend(r)
+    }
+    results
+}
+
+pub fn run_test(case: TestCase) -> Vec<MatchResult> {
+    let pattern_src = r#"
+        file(name=includes "target.js", body=contains bubble `$x` where {
+            $x <: contains `console.log($_)`
+        })
+        "#;
+    let libs = BTreeMap::new();
+
+    let pattern = src_to_problem_libs(
+        pattern_src.to_string(),
+        &libs,
+        TargetLanguage::default(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .unwrap()
+    .problem;
+
+    let results = run_on_test_files(&pattern, &test_files);
+    results
+}

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -49,7 +49,6 @@ impl FileName for SyntheticFile {
 }
 
 enum TestCaseExpectation {
-    None,
     Match,
 }
 
@@ -88,11 +87,7 @@ pub(crate) fn run_on_test_files(
 }
 
 pub fn run_test(case: TestCase) -> Vec<MatchResult> {
-    let pattern_src = r#"
-        file(name=includes "target.js", body=contains bubble `$x` where {
-            $x <: contains `console.log($_)`
-        })
-        "#;
+    let pattern_src = case.pattern;
     let libs = BTreeMap::new();
 
     let pattern = src_to_problem_libs(

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -105,7 +105,6 @@ pub fn run_test(case: TestCase) -> Vec<MatchResult> {
     let results = run_on_test_files(&pattern, &case.files);
 
     match case.expectation {
-        TestCaseExpectation::None => {}
         TestCaseExpectation::Match => {
             let match_case = results.iter().any(|r| r.is_match());
             assert!(match_case, "Expected a match, but got none");

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -1,6 +1,15 @@
-use marzano_language::target_language::TargetLanguage;
+use std::{borrow::Cow, collections::BTreeMap, sync::mpsc};
 
-use crate::pattern_compiler::src_to_problem_libs;
+use marzano_language::target_language::TargetLanguage;
+use marzano_util::{
+    cache::NullCache,
+    rich_path::{FileName, RichFile, TryIntoInputFile},
+    runtime::ExecutionContext,
+};
+use serde::{Deserialize, Serialize};
+use anyhow::Result;
+
+use crate::{api::MatchResult, pattern_compiler::src_to_problem_libs, problem::Problem};
 
 /// SyntheticFile is used for ensuring we don't read files until their file names match
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -91,6 +100,6 @@ pub fn run_test(case: TestCase) -> Vec<MatchResult> {
     .unwrap()
     .problem;
 
-    let results = run_on_test_files(&pattern, &test_files);
+    let results = run_on_test_files(&pattern, &case.files);
     results
 }

--- a/crates/grit-pattern-matcher/src/errors.rs
+++ b/crates/grit-pattern-matcher/src/errors.rs
@@ -28,3 +28,27 @@ pub fn debug<'a, Q: QueryContext>(
     }
     Ok(())
 }
+
+pub fn warning<'a, Q: QueryContext>(
+    analysis_logs: &mut AnalysisLogs,
+    state: &State<'a, Q>,
+    lang: &Q::Language<'a>,
+    message: &str,
+) -> Result<()> {
+    let mut builder = AnalysisLogBuilder::default();
+    builder.level(301_u16);
+    builder.message(message);
+
+    if let Ok(file) = get_file_name(state, lang) {
+        builder.file(file);
+    }
+
+    let log = builder.build();
+    match log {
+        Ok(log) => analysis_logs.push(log),
+        Err(err) => {
+            bail!(err);
+        }
+    }
+    Ok(())
+}

--- a/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
@@ -8,8 +8,8 @@ use crate::context::QueryContext;
 pub trait AstNodePattern<Q: QueryContext>:
     Clone + std::fmt::Debug + Matcher<Q> + PatternName + Sized
 {
-    // Does this AST include trivia?
-    // Trivia is useful for being able to re-print an AST, but not all parsers support collecting it.
+    /// Does this AST include trivia?
+    /// Trivia is useful for being able to re-print an AST, but not all parsers support collecting it.
     const INCLUDES_TRIVIA: bool;
 
     fn children(&self) -> Vec<PatternOrPredicate<Q>>;

--- a/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
@@ -17,4 +17,6 @@ pub trait AstNodePattern<Q: QueryContext>:
 pub trait AstLeafNodePattern<Q: QueryContext>:
     Clone + std::fmt::Debug + Matcher<Q> + PatternName + Sized
 {
+    /// Provides a *possible* text value for the leaf node.
+    fn text(&self) -> Option<&str>;
 }

--- a/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
@@ -22,5 +22,8 @@ pub trait AstLeafNodePattern<Q: QueryContext>:
     Clone + std::fmt::Debug + Matcher<Q> + PatternName + Sized
 {
     /// Provides a *possible* text value for the leaf node.
-    fn text(&self) -> Option<&str>;
+    /// This is not mandatory, but enables some advanced functionality.
+    fn text(&self) -> Option<&str> {
+        None
+    }
 }

--- a/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
@@ -8,6 +8,10 @@ use crate::context::QueryContext;
 pub trait AstNodePattern<Q: QueryContext>:
     Clone + std::fmt::Debug + Matcher<Q> + PatternName + Sized
 {
+    // Does this AST include trivia?
+    // Trivia is useful for being able to re-print an AST, but not all parsers support collecting it.
+    const INCLUDES_TRIVIA: bool;
+
     fn children(&self) -> Vec<PatternOrPredicate<Q>>;
 
     fn matches_kind_of(&self, node: &Q::Node<'_>) -> bool;

--- a/crates/grit-pattern-matcher/src/pattern/patterns.rs
+++ b/crates/grit-pattern-matcher/src/pattern/patterns.rs
@@ -308,6 +308,7 @@ impl<Q: QueryContext> Matcher<Q> for Pattern<Q> {
 }
 
 pub trait CodeSnippet<Q: QueryContext + 'static>: Clone + Debug + Matcher<Q> + PatternName {
+    /// Return the different patterns which could *all* possibly match the code snippet.
     fn patterns(&self) -> impl Iterator<Item = &Pattern<Q>>;
 
     fn dynamic_snippet(&self) -> Option<&DynamicPattern<Q>>;


### PR DESCRIPTION
Make it easier to make test asserts from anywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new constant to indicate whether the AST includes trivia.
	- Introduced methods to retrieve text from AST leaf nodes.
	- Expanded testing capabilities with new utilities for synthetic files and test cases.
	- Added a public function to log warning messages in the analysis logs.

- **Enhancements**
	- Made `TestArg` struct and `run_test_match` function public to increase their accessibility.
	- Improved documentation for the `patterns` method to clarify its purpose.

- **Refactor**
	- Reorganized test file handling and utility functions for better modularity and reusability.

- **Dependencies**
	- Included new optional dependencies to support enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->