### PR TITLE
feat: add cloud workflow connectivity

### DIFF
--- a/crates/auth/src/env.rs
+++ b/crates/auth/src/env.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use crate::{info::AuthInfo, testing::get_testing_auth_info};
 
+pub static ENV_VAR_GRIT_LOCAL_SERVER: &str = "GRIT_LOCAL_SERVER";
 pub static ENV_VAR_GRIT_AUTH_TOKEN: &str = "GRIT_AUTH_TOKEN";
 pub static ENV_VAR_GRIT_API_URL: &str = "GRIT_API_URL";
 pub static DEFAULT_GRIT_API_URL: &str = "https://api-gateway-prod-6et7uue.uc.gateway.dev";

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -89,7 +89,7 @@ default = [
   "workflows_v2",
   "grit_tracing",
   # Grit cloud feature for relaying workflow results
-  "workflow_server",
+  # "workflow_server",
   # "remote_workflows",
   # "server",
   # "remote_redis",
@@ -144,7 +144,7 @@ grit_beta = [
   "ai_builtins",
   "workflows_v2",
   "remote_workflows",
-  # "workflow_server"
+  "workflow_server"
   # "grit_timing",
 ]
 grit_timing = []

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -88,6 +88,8 @@ default = [
   "updater",
   "workflows_v2",
   "grit_tracing",
+  # Grit cloud feature for relaying workflow results
+  "embedded_server",
   # "remote_workflows",
   # "server",
   # "remote_redis",
@@ -100,6 +102,9 @@ bundled_workflows = []
 remote_redis = []
 remote_pubsub = []
 remote_workflows = [
+  "dep:grit_cloud_client",
+]
+embedded_server = [
   "dep:grit_cloud_client",
 ]
 server = [

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -89,7 +89,7 @@ default = [
   "workflows_v2",
   "grit_tracing",
   # Grit cloud feature for relaying workflow results
-  "embedded_server",
+  "workflow_server",
   # "remote_workflows",
   # "server",
   # "remote_redis",
@@ -104,7 +104,7 @@ remote_pubsub = []
 remote_workflows = [
   "dep:grit_cloud_client",
 ]
-embedded_server = [
+workflow_server = [
   "dep:grit_cloud_client",
 ]
 server = [
@@ -143,7 +143,8 @@ grit_beta = [
   "updater",
   "ai_builtins",
   "workflows_v2",
-  "remote_workflows"
+  "remote_workflows",
+  # "workflow_server"
   # "grit_timing",
 ]
 grit_timing = []

--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -558,7 +558,6 @@ impl Updater {
     pub async fn get_app_bin_and_install(&mut self, app: SupportedApp) -> Result<PathBuf> {
         // If the path is overridden, skip checking install
         if let Some(bin_path) = self.get_env_bin(&app)? {
-            info!("Using {} from: {}", app, bin_path.display());
             return Ok(bin_path);
         }
         let bin_path = self.get_app_bin(&app)?;

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use console::style;
 use grit_util::FileRange;
 use log::debug;
-use marzano_auth::env::ENV_VAR_GRIT_AUTH_TOKEN;
+use marzano_auth::env::{get_grit_api_url, ENV_VAR_GRIT_API_URL, ENV_VAR_GRIT_AUTH_TOKEN};
 use marzano_gritmodule::{fetcher::LocalRepo, searcher::find_grit_dir_from};
 use marzano_messenger::{emit::Messager, workflows::PackagedWorkflowOutcome};
 use serde::Serialize;
@@ -131,6 +131,7 @@ where
     let mut child = Command::new(runner_path)
         .arg(tempfile_path.to_string_lossy().to_string())
         .env("GRIT_MARZANO_PATH", marzano_bin)
+        .env(ENV_VAR_GRIT_API_URL, get_grit_api_url())
         .env(ENV_VAR_GRIT_AUTH_TOKEN, grit_token)
         .env(ENV_GRIT_WORKSPACE_ROOT, root)
         .arg("--file")

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -66,7 +66,7 @@ where
 
     #[cfg(feature = "workflow_server")]
     let (server_addr, handle, shutdown_tx) = {
-        let (shutdown_tx, shutdown_rx) = tokio::sync::overshot::channel::<()>();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let socket = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
         let server_addr = format!("http://{}", socket.local_addr()?);
         let handle = grit_cloud_client::spawn_server_tasks(emitter, shutdown_rx, socket);
@@ -143,7 +143,7 @@ where
         .env("GRIT_MARZANO_PATH", marzano_bin);
 
     #[cfg(feature = "workflow_server")]
-    child.env(ENV_VAR_GRIT_LOCAL_SERVER, server_addr.to_string());
+    child.env(marzano_auth::env::ENV_VAR_GRIT_LOCAL_SERVER, &server_addr);
 
     let mut final_child = child
         .env(ENV_VAR_GRIT_API_URL, get_grit_api_url())

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -149,6 +149,10 @@ where
 
     let status = child.wait().await?;
 
+    // Stop the embedded server
+    shutdown_tx.send(()).unwrap();
+    let emitter = handle.await?;
+
     // TODO: pass along outcome message
     if status.success() {
         Ok((

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -285,10 +285,14 @@ pub struct InputFile {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub struct Match {
+    #[serde(default)]
     pub messages: Vec<Message>,
+    #[serde(default)]
     pub variables: Vec<VariableMatch>,
     pub source_file: String,
+    #[serde(default)]
     pub ranges: Vec<Range>,
+    #[serde(default)]
     pub debug: String,
 }
 
@@ -356,6 +360,8 @@ impl EntireFile {
 pub struct Rewrite {
     pub original: Match,
     pub rewritten: EntireFile,
+    /// Deprecated
+    #[serde(default)]
     pub ansi_summary: String,
     pub reason: Option<RewriteReason>,
 }

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -330,7 +330,9 @@ impl FileMatchResult for Match {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub struct EntireFile {
+    #[serde(default)]
     pub messages: Vec<Message>,
+    #[serde(default)]
     pub variables: Vec<VariableMatch>,
     pub source_file: String,
     pub content: String,

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -546,8 +546,19 @@ pub struct DoneFile {
     pub has_results: Option<bool>,
     #[serde(skip_serializing)]
     pub file_hash: Option<[u8; 32]>,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing, skip_deserializing)]
     pub from_cache: bool,
+}
+
+impl DoneFile {
+    pub fn new(relative_file_path: String) -> Self {
+        Self {
+            relative_file_path,
+            has_results: None,
+            file_hash: None,
+            from_cache: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/grit-util/src/ranges.rs
+++ b/crates/grit-util/src/ranges.rs
@@ -7,7 +7,10 @@ use std::{ops::Add, path::PathBuf};
 pub struct Range {
     pub start: Position,
     pub end: Position,
+    // TODO: automatically derive these from the start and end positions during deserialization
+    #[serde(skip_deserializing)]
     pub start_byte: u32,
+    #[serde(skip_deserializing)]
     pub end_byte: u32,
 }
 

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -279,9 +279,10 @@ pub trait Messager: Send + Sync {
 }
 
 /// Visibility levels dictate *which* objects we show (ex. just rewrites, or also every file analyzed)
-#[derive(Debug, PartialEq, PartialOrd, Clone, Copy, ValueEnum, Serialize)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Copy, ValueEnum, Serialize, Default)]
 pub enum VisibilityLevels {
-    Primary = 3,      // Always show this to users
+    #[default]
+    Primary = 3, // Always show this to users
     Supplemental = 2, // Show to users as secondary information
     Debug = 1,        // Only show to users if they ask for it
     Hidden = 0,       // Never show to users

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -281,11 +281,11 @@ pub trait Messager: Send + Sync {
 /// Visibility levels dictate *which* objects we show (ex. just rewrites, or also every file analyzed)
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy, ValueEnum, Serialize, Default)]
 pub enum VisibilityLevels {
-    #[default]
     Primary = 3, // Always show this to users
+    #[default]
     Supplemental = 2, // Show to users as secondary information
-    Debug = 1,        // Only show to users if they ask for it
-    Hidden = 0,       // Never show to users
+    Debug = 1,   // Only show to users if they ask for it
+    Hidden = 0,  // Never show to users
 }
 
 impl std::fmt::Display for VisibilityLevels {

--- a/crates/marzano_messenger/src/lib.rs
+++ b/crates/marzano_messenger/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod emit;
 pub mod format;
 pub mod output_mode;
+pub mod testing;
 pub mod workflows;

--- a/crates/marzano_messenger/src/testing.rs
+++ b/crates/marzano_messenger/src/testing.rs
@@ -20,8 +20,14 @@ impl TestingMessenger {
     }
 }
 
+impl Default for TestingMessenger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Messager for TestingMessenger {
-    fn raw_emit(&mut self, message: &MatchResult) -> anyhow::Result<()> {
+    fn raw_emit(&mut self, _message: &MatchResult) -> Result<()> {
         self.message_count += 1;
         Ok(())
     }

--- a/crates/marzano_messenger/src/testing.rs
+++ b/crates/marzano_messenger/src/testing.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use marzano_core::api::MatchResult;
+
+use crate::emit::Messager;
+
+/// A testing messenger that doesn't actually send messages anywhere.
+///
+/// This should be used in tests to avoid sending messages to real backends.
+pub struct TestingMessenger {
+    message_count: usize,
+}
+
+impl TestingMessenger {
+    pub fn new() -> Self {
+        Self { message_count: 0 }
+    }
+
+    pub fn message_count(&self) -> usize {
+        self.message_count
+    }
+}
+
+impl Messager for TestingMessenger {
+    fn raw_emit(&mut self, message: &MatchResult) -> anyhow::Result<()> {
+        self.message_count += 1;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add a local relay server for allowing workflows to report their activity back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new environment variable `GRIT_LOCAL_SERVER` for local server configuration.
  - Added a `TestingMessenger` struct for enhanced testing capabilities.

- **Improvements**
  - Updated dependencies to support Grit cloud features for workflow results.
  - Enhanced environment variable handling in workflow execution.

- **Bug Fixes**
  - Removed unnecessary logging of the app path to streamline output.

- **Enhancements**
  - Added default serialization attributes to various fields in API-related structs.
  - Implemented a new constructor for improved struct initialization.
  - Updated `VisibilityLevels` enum to include a default trait for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->