### PR TITLE
feat: use axoupdater for cargo-dist built binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axoasset"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d492e2a60fbacf2154ee58fd4bc3dd7385a5febf10fef6145924fd3117cd920"
+dependencies = [
+ "camino",
+ "miette",
+ "mime",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "axoprocess"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de46920588aef95658797996130bacd542436aee090084646521260a74bda7d"
+dependencies = [
+ "miette",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "axotag"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d888fac0b73e64cbdf36a743fc5a25af5ae955c357535cb420b389bf1e1a6c54"
+dependencies = [
+ "miette",
+ "semver",
+ "thiserror",
+]
+
+[[package]]
+name = "axoupdater"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6bf8aaa32e7d33071ed9a339fc34ac30b0a5190f82069fbd12a1266bda9068"
+dependencies = [
+ "axoasset",
+ "axoprocess",
+ "axotag",
+ "camino",
+ "homedir",
+ "miette",
+ "reqwest",
+ "serde",
+ "temp-dir",
+ "thiserror",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +374,15 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cap-fs-ext"
@@ -1519,6 +1584,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +2061,7 @@ version = "0.1.1"
 dependencies = [
  "ai_builtins",
  "anyhow",
+ "axoupdater",
  "buildkite-test-collector",
  "chrono",
  "clap",
@@ -2263,6 +2343,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3050,6 +3153,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3059,6 +3163,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3067,6 +3172,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -3074,6 +3180,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -3143,6 +3250,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
@@ -3150,7 +3269,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.2",
  "subtle",
  "zeroize",
 ]
@@ -3169,6 +3288,16 @@ name = "rustls-pki-types"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3222,6 +3351,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -3539,6 +3678,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
+name = "temp-dir"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,18 +3712,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3657,6 +3802,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -4177,13 +4332,13 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.22.2",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.2",
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -4871,6 +5026,12 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -58,6 +58,9 @@ clap-markdown = { git = "https://github.com/getgrit/clap-markdown", rev = "4568d
 flate2 = { version = "1.0.17", features = [
   "rust_backend",
 ], default-features = false }
+axoupdater = { version = "0.6.4", default-features = false, features = [
+  "github_releases"
+] }
 
 opentelemetry-otlp = { version = "0.14.0", optional = true, features = [
   "http-proto",

--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use anyhow::{Context, Result};
+use axoupdater::{AxoUpdater, ReleaseSource, ReleaseSourceType, Version};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use colored::Colorize;
 use futures_util::StreamExt;
@@ -300,18 +301,15 @@ impl Updater {
             let app_string = app.get_base_name();
             let current_binary = self.binaries.get(&app_string).cloned();
             tasks.push(tokio::spawn(async move {
-                let (_, info_url) = match get_release_url(app, None, None).await {
-                    Ok(urls) => urls,
-                    Err(_) => return,
-                };
-                let manifest = match fetch_manifest(&info_url, app).await {
-                    Ok(manifest) => manifest,
-                    Err(_) => return,
-                };
-                if let Some(current_manifest) = current_binary {
-                    if manifest.release != current_manifest.release && manifest.release.is_some() {
+                {
+                    let version = match check_release(app, &current_binary).await {
+                        Ok(v) => v,
+                        Err(_) => return,
+                    };
+
+                    if let Some(version) = version {
                         let mut found = found_updates.lock().await;
-                        found.push((app, manifest.version.unwrap()));
+                        found.push((app, version));
                     }
                 }
             }));
@@ -334,7 +332,53 @@ impl Updater {
         Ok(!found_updates.is_empty())
     }
 
-    pub async fn install_latest(
+    pub async fn install_latest_axo(&mut self, app: SupportedApp) -> Result<()> {
+        let mut updater = AxoUpdater::new_for(&app.get_base_name());
+        // Disable axo installers' verbose output with info on
+        // where the tool is installed
+        updater.disable_installer_output();
+
+        // Set "always update" to match install_latest_internal,
+        // and because this is preceded by an "is this outdated" check.
+        updater.always_update(true);
+
+        // This can be autodetected if grit was itself installed via an axo
+        // installer in the past, but specifying this source manually is
+        // necessary if no cargo-dist-style install receipt exists.
+        updater.set_release_source(ReleaseSource {
+            release_type: ReleaseSourceType::GitHub,
+            owner: "getgrit".to_owned(),
+            name: "gritql".to_owned(),
+            app_name: app.get_base_name(),
+        });
+        updater.configure_version_specifier(axoupdater::UpdateRequest::LatestMaybePrerelease);
+        // add bin/ since axoupdater wants to know where bins go
+        updater.set_install_dir(&self.install_path.join("bin").to_string_lossy());
+        match updater.run().await {
+            Ok(result) => {
+                if let Some(outcome) = result {
+                    self.set_app_version(
+                        app,
+                        outcome.new_version.to_string(),
+                        outcome.new_version_tag,
+                    )?;
+                    self.dump().await?;
+                // This path is primarily hit if no releases exist, or
+                // if `always_update(false)` is set and there isn't a newer
+                // version available.
+                } else {
+                    info!("New version of {app} not installed");
+                }
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn install_latest_internal(
         &mut self,
         app: SupportedApp,
         os: Option<&str>,
@@ -359,6 +403,18 @@ impl Updater {
         self.dump().await?;
 
         Ok(())
+    }
+
+    pub async fn install_latest(
+        &mut self,
+        app: SupportedApp,
+        os: Option<&str>,
+        arch: Option<&str>,
+    ) -> Result<()> {
+        match app {
+            SupportedApp::Marzano | SupportedApp::Gouda => self.install_latest_axo(app).await,
+            _ => self.install_latest_internal(app, os, arch).await,
+        }
     }
 
     pub fn get_context(&self) -> Result<ExecutionContext> {
@@ -547,6 +603,8 @@ impl Updater {
         }
         let bin_name = app_name.get_base_name();
         let bin_path = self.bin_path.join(bin_name);
+        #[cfg(windows)]
+        let bin_path = bin_path.with_extension("exe");
         Ok(bin_path)
     }
 
@@ -679,6 +737,66 @@ async fn get_release_url(
         latest_release_download_url.to_string(),
         latest_release_info_url.to_string(),
     ))
+}
+
+pub async fn check_release(
+    app: SupportedApp,
+    current_binary: &Option<AppManifest>,
+) -> Result<Option<String>> {
+    match app {
+        SupportedApp::Marzano | SupportedApp::Gouda => check_release_axo(app, current_binary).await,
+        _ => check_release_internal(app, current_binary).await,
+    }
+}
+
+pub async fn check_release_internal(
+    app: SupportedApp,
+    current_binary: &Option<AppManifest>,
+) -> Result<Option<String>> {
+    let (_, info_url) = match get_release_url(app, None, None).await {
+        Ok(urls) => urls,
+        Err(_) => return Ok(None),
+    };
+    let manifest = match fetch_manifest(&info_url, app).await {
+        Ok(manifest) => manifest,
+        Err(_) => return Ok(None),
+    };
+    if let Some(current_manifest) = current_binary {
+        if manifest.release != current_manifest.release && manifest.release.is_some() {
+            Ok(manifest.version)
+        } else {
+            Ok(None)
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+pub async fn check_release_axo(
+    app: SupportedApp,
+    current_binary: &Option<AppManifest>,
+) -> Result<Option<String>> {
+    let mut updater = AxoUpdater::new_for(&app.get_base_name());
+    // Avoids a look up to cargo-dist's install receipt, which may not exist yet;
+    // we want to fetch this data from the current manifest if at all possible
+    if let Some(current_manifest) = current_binary {
+        if let Some(current) = &current_manifest.version {
+            updater.set_current_version(Version::parse(current)?)?;
+        }
+    }
+    updater.set_release_source(ReleaseSource {
+        release_type: ReleaseSourceType::GitHub,
+        owner: "getgrit".to_owned(),
+        name: "gritql".to_owned(),
+        app_name: app.get_base_name(),
+    });
+    updater.configure_version_specifier(axoupdater::UpdateRequest::LatestMaybePrerelease);
+    let update_needed = updater.is_update_needed().await?;
+    if !update_needed {
+        return Ok(None);
+    }
+    let new_version = updater.query_new_version().await?.map(|v| v.to_string());
+    Ok(new_version)
 }
 
 async fn fetch_manifest(relative_url: &str, app: SupportedApp) -> Result<AppManifest> {

--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -63,7 +63,7 @@ dist = true
 default-features = false
 features = ["marzano-cli/grit_beta"]
 # the npm package should have this name
-npm-package = "launcher"
+npm-package = "cli"
 # the homebrew package should have this name
 formula = "grit"
 

--- a/crates/cli_bin/README.md
+++ b/crates/cli_bin/README.md
@@ -1,0 +1,7 @@
+# Grit CLI
+
+Grit is a developer tool to simplify software maintenance.
+
+Learn more about Grit's products on the [website](https://about.grit.io/) or check out the [documentation](https://docs.grit.io/).
+
+The Grit CLI and additional tooling are distributed as pre-built binaries that are either available for direct download or can be managed with an installer or package manager, such as Homebrew and npm. You can see more details about the release artifacts and installation options [on GitHub](https://github.com/getgrit/gritql/releases).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the Grit CLI, a developer tool for simplifying software maintenance.
  - Added functionality for checking and installing the latest releases using GitHub.

- **Updates**
  - Updated npm package name from "launcher" to "cli".
  - Updated Homebrew package name from "grit" to "grit_beta".

- **Documentation**
  - Added README with details on Grit CLI, its products, documentation, and distribution methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->