### PR TITLE
fix(py): remove trailing commas in short import statements

### DIFF
--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -11953,6 +11953,37 @@ fn trailing_comma_import() {
 }
 
 #[test]
+fn trailing_comma_import_from_python() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"
+                |language python
+                |
+                |`foo` => .
+                |"#
+            .trim_margin()
+            .unwrap(),
+            source: r#"
+                |from somewhere import this, foo
+                |from start import foo, fine
+                |from middle import this, foo, more
+                |"#
+            .trim_margin()
+            .unwrap(),
+            // Don't worry about formatting, just check that the trailing comma is removed
+            expected: r#"
+                |from somewhere import this
+                |from start import  fine
+                |from middle import this,  more
+                |"#
+            .trim_margin()
+            .unwrap(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
 fn yaml_string() {
     run_test_match({
         TestArg {

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -11984,6 +11984,37 @@ fn trailing_comma_import_from_python() {
 }
 
 #[test]
+fn trailing_comma_import_from_python_with_alias() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"
+                |language python
+                |
+                |aliased_import(name=contains `foo`) => .
+                |"#
+            .trim_margin()
+            .unwrap(),
+            source: r#"
+                |from somewhere import this as Sam, foo as Bob
+                |from start import foo as Bob, fine
+                |from middle import this, foo as Bob, more
+                |"#
+            .trim_margin()
+            .unwrap(),
+            // Don't worry about formatting, just check that the trailing comma is removed
+            expected: r#"
+                |from somewhere import this as Sam
+                |from start import  fine
+                |from middle import this,  more
+                |"#
+            .trim_margin()
+            .unwrap(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
 fn yaml_string() {
     run_test_match({
         TestArg {

--- a/crates/language/src/python.rs
+++ b/crates/language/src/python.rs
@@ -86,6 +86,24 @@ impl Language for Python {
         if n.node.is_error() && n.text().is_ok_and(|t| t == "->") {
             replacements.push(Replacement::new(n.range(), ""));
         }
+        if n.node.kind() == "import_from_statement" {
+            if let Ok(t) = n.text() {
+                let mut end_range = n.range().clone();
+                end_range.start_byte = end_range.end_byte;
+                end_range.start = end_range.end.clone();
+
+                let mut chars = t.chars().rev();
+                for ch in chars {
+                    end_range.start_byte -= 1;
+                    if ch == ',' {
+                        replacements.push(Replacement::new(end_range, ""));
+                        break;
+                    } else if !ch.is_whitespace() {
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     fn should_pad_snippet(&self) -> bool {

--- a/crates/language/src/python.rs
+++ b/crates/language/src/python.rs
@@ -88,11 +88,10 @@ impl Language for Python {
         }
         if n.node.kind() == "import_from_statement" {
             if let Ok(t) = n.text() {
-                let mut end_range = n.range().clone();
+                let mut end_range = n.range();
                 end_range.start_byte = end_range.end_byte;
-                end_range.start = end_range.end.clone();
 
-                let mut chars = t.chars().rev();
+                let chars = t.chars().rev();
                 for ch in chars {
                     end_range.start_byte -= 1;
                     if ch == ',' {


### PR DESCRIPTION
We already have logic for handling orphaned commas, but it didn't handle cases where they come at the end of the statement. This is now fixed.