### PR TITLE
fix: use FileDiff instead of FileRange

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -58,7 +58,10 @@ pub(crate) async fn run_apply(
             .map(|repo| repo.root())
             .transpose()?;
 
-        let ranges = extract_filter_ranges(&args.shared_apply_args, current_repo_root.as_ref())?;
+        let ranges = crate::commands::filters::extract_filter_diff(
+            &args.shared_apply_args,
+            current_repo_root.as_ref(),
+        )?;
 
         #[cfg(feature = "remote_workflows")]
         if args.apply_migration_args.remote {

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use std::env::current_dir;
 use std::path::PathBuf;
 
-use crate::{commands::filters::extract_filter_ranges, flags::GlobalFormatFlags};
+use crate::flags::GlobalFormatFlags;
 
 #[cfg(feature = "workflows_v2")]
 use super::apply_migration::{run_apply_migration, ApplyMigrationArgs};

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -60,7 +60,7 @@ pub(crate) async fn run_apply_migration(
 pub(crate) async fn run_apply_migration(
     workflow: WorkflowInfo,
     paths: Vec<PathBuf>,
-    ranges: Option<Vec<grit_util::FileRange>>,
+    ranges: Option<Vec<marzano_util::diff::FileDiff>>,
     arg: ApplyMigrationArgs,
     flags: &GlobalFormatFlags,
 ) -> Result<()> {

--- a/crates/cli/src/commands/filters.rs
+++ b/crates/cli/src/commands/filters.rs
@@ -38,7 +38,6 @@ pub(crate) fn extract_filter_ranges(
     } else {
         let raw_diff = extract_target_diffs(&args.only_in_diff, root)?;
         let Some(raw_diff) = raw_diff else {
-            log::info!("No diff found, skipping range extraction");
             return Ok(None);
         };
         Ok(Some(

--- a/crates/cli/src/commands/filters.rs
+++ b/crates/cli/src/commands/filters.rs
@@ -4,9 +4,13 @@ use anyhow::Result;
 use clap::Args;
 
 use grit_util::FileRange;
+use marzano_util::diff::FileDiff;
 use serde::Serialize;
 
-use crate::{community::parse_eslint_output, diff::extract_target_ranges};
+use crate::{
+    community::parse_eslint_output,
+    diff::{extract_target_diffs, extract_target_ranges},
+};
 
 #[derive(Args, Debug, Serialize, Default)]
 /// Shared arguments for apply and check commands.
@@ -37,4 +41,12 @@ pub(crate) fn extract_filter_ranges(
     } else {
         Ok(extract_target_ranges(&args.only_in_diff, root)?)
     }
+}
+
+#[tracing::instrument]
+pub(crate) fn extract_filter_diff(
+    args: &SharedFilterArgs,
+    root: Option<&PathBuf>,
+) -> Result<Option<Vec<FileDiff>>> {
+    extract_target_diffs(&args.only_in_diff, root)
 }

--- a/crates/cli/src/commands/filters.rs
+++ b/crates/cli/src/commands/filters.rs
@@ -3,14 +3,11 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Args;
 
-use grit_util::FileRange;
+use grit_util::{FileRange, UtilRange};
 use marzano_util::diff::FileDiff;
 use serde::Serialize;
 
-use crate::{
-    community::parse_eslint_output,
-    diff::{extract_target_diffs, extract_target_ranges},
-};
+use crate::{community::parse_eslint_output, diff::extract_target_diffs};
 
 #[derive(Args, Debug, Serialize, Default)]
 /// Shared arguments for apply and check commands.
@@ -39,7 +36,29 @@ pub(crate) fn extract_filter_ranges(
         let json_ranges = parse_eslint_output(json_content)?;
         Ok(Some(json_ranges))
     } else {
-        Ok(extract_target_ranges(&args.only_in_diff, root)?)
+        let raw_diff = extract_target_diffs(&args.only_in_diff, root)?;
+        let Some(raw_diff) = raw_diff else {
+            log::info!("No diff found, skipping range extraction");
+            return Ok(None);
+        };
+        Ok(Some(
+            raw_diff
+                .into_iter()
+                .flat_map(|diff| match diff.new_path {
+                    Some(new_path) => {
+                        let mapped = diff.ranges.into_iter().map(|range| FileRange {
+                            range: UtilRange::RangeWithoutByte(range.after),
+                            file_path: PathBuf::from(&new_path),
+                        });
+                        mapped.collect::<Vec<_>>()
+                    }
+                    None => {
+                        log::info!("Skipping diff with no new path: {:?}", diff);
+                        vec![]
+                    }
+                })
+                .collect(),
+        ))
     }
 }
 

--- a/crates/cli/src/commands/filters.rs
+++ b/crates/cli/src/commands/filters.rs
@@ -52,7 +52,6 @@ pub(crate) fn extract_filter_ranges(
                         mapped.collect::<Vec<_>>()
                     }
                     None => {
-                        log::info!("Skipping diff with no new path: {:?}", diff);
                         vec![]
                     }
                 })

--- a/crates/cli/src/diff.rs
+++ b/crates/cli/src/diff.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use grit_util::{FileRange, UtilRange};
 use marzano_util::diff::{parse_modified_ranges, run_git_diff, FileDiff};
 use std::path::PathBuf;
 
@@ -16,33 +15,4 @@ pub(crate) fn extract_target_diffs(
         return Ok(None);
     };
     Ok(Some(raw_diff))
-}
-
-pub(crate) fn extract_target_ranges(
-    diff_arg: &Option<Option<String>>,
-    root: Option<&PathBuf>,
-) -> Result<Option<Vec<FileRange>>> {
-    let raw_diff = extract_target_diffs(diff_arg, root)?;
-    let Some(raw_diff) = raw_diff else {
-        log::info!("No diff found, skipping range extraction");
-        return Ok(None);
-    };
-    Ok(Some(
-        raw_diff
-            .into_iter()
-            .flat_map(|diff| match diff.new_path {
-                Some(new_path) => {
-                    let mapped = diff.ranges.into_iter().map(|range| FileRange {
-                        range: UtilRange::RangeWithoutByte(range.after),
-                        file_path: PathBuf::from(&new_path),
-                    });
-                    mapped.collect::<Vec<_>>()
-                }
-                None => {
-                    log::info!("Skipping diff with no new path: {:?}", diff);
-                    vec![]
-                }
-            })
-            .collect(),
-    ))
 }

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -5,6 +5,7 @@ use log::debug;
 use marzano_auth::env::{get_grit_api_url, ENV_VAR_GRIT_API_URL, ENV_VAR_GRIT_AUTH_TOKEN};
 use marzano_gritmodule::{fetcher::LocalRepo, searcher::find_grit_dir_from};
 use marzano_messenger::{emit::Messager, workflows::PackagedWorkflowOutcome};
+use marzano_util::diff::FileDiff;
 use serde::Serialize;
 use serde_json::to_string;
 use std::path::PathBuf;
@@ -39,7 +40,7 @@ pub struct WorkflowInputs {
     // If this is a custom workflow, this will be the path to the entrypoint
     pub workflow_entrypoint: String,
     /// Ranges to target, if any
-    pub ranges: Option<Vec<FileRange>>,
+    pub ranges: Option<Vec<FileDiff>>,
     // Input paths, might include unresolved globs
     pub paths: Vec<PathBuf>,
     // Input

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Result};
 use console::style;
-use grit_util::FileRange;
 use log::debug;
 use marzano_auth::env::{get_grit_api_url, ENV_VAR_GRIT_API_URL, ENV_VAR_GRIT_AUTH_TOKEN};
 use marzano_gritmodule::{fetcher::LocalRepo, searcher::find_grit_dir_from};

--- a/crates/util/src/diff.rs
+++ b/crates/util/src/diff.rs
@@ -5,6 +5,7 @@ use std::{path::PathBuf, str::FromStr};
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[cfg_attr(feature = "napi", napi_derive::napi(object))]
+#[serde(rename_all = "camelCase")]
 pub struct RangePair {
     pub before: RangeWithoutByte,
     pub after: RangeWithoutByte,
@@ -13,6 +14,7 @@ pub struct RangePair {
 // Define a new struct to hold before and after ranges
 #[cfg_attr(feature = "napi", napi_derive::napi(object))]
 #[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct FileDiff {
     pub old_path: Option<String>,
     pub new_path: Option<String>,

--- a/crates/util/src/snapshots/marzano_util__diff__tests__parse_one_file_diff.snap
+++ b/crates/util/src/snapshots/marzano_util__diff__tests__parse_one_file_diff.snap
@@ -2,8 +2,8 @@
 source: crates/util/src/diff.rs
 expression: parsed
 ---
-- old_path: crates/cli_bin/fixtures/es6/empty_export_object.js
-  new_path: crates/cli_bin/fixtures/es6/empty_export_object.js
+- oldPath: crates/cli_bin/fixtures/es6/empty_export_object.js
+  newPath: crates/cli_bin/fixtures/es6/empty_export_object.js
   ranges:
     - before:
         start:

--- a/crates/util/src/snapshots/marzano_util__diff__tests__parse_with_created_file.snap
+++ b/crates/util/src/snapshots/marzano_util__diff__tests__parse_with_created_file.snap
@@ -2,8 +2,8 @@
 source: crates/util/src/diff.rs
 expression: parsed
 ---
-- old_path: crates/cli_bin/fixtures/es6/empty_export_object.js
-  new_path: crates/cli_bin/fixtures/es6/empty_export_object.js
+- oldPath: crates/cli_bin/fixtures/es6/empty_export_object.js
+  newPath: crates/cli_bin/fixtures/es6/empty_export_object.js
   ranges:
     - before:
         start:
@@ -19,8 +19,8 @@ expression: parsed
         end:
           line: 9
           column: 1
-- old_path: crates/cli_bin/fixtures/es6/export_object.js
-  new_path: crates/cli_bin/fixtures/es6/export_object.js
+- oldPath: crates/cli_bin/fixtures/es6/export_object.js
+  newPath: crates/cli_bin/fixtures/es6/export_object.js
   ranges:
     - before:
         start:
@@ -36,8 +36,8 @@ expression: parsed
         end:
           line: 8
           column: 1
-- old_path: ~
-  new_path: crates/cli_bin/fixtures/es6/index.js
+- oldPath: ~
+  newPath: crates/cli_bin/fixtures/es6/index.js
   ranges:
     - before:
         start:

--- a/crates/util/src/snapshots/marzano_util__diff__tests__parse_with_deleted_file.snap
+++ b/crates/util/src/snapshots/marzano_util__diff__tests__parse_with_deleted_file.snap
@@ -2,8 +2,8 @@
 source: crates/util/src/diff.rs
 expression: parsed
 ---
-- old_path: crates/cli_bin/fixtures/es6/empty_export_object.js
-  new_path: crates/cli_bin/fixtures/es6/empty_export_object.js
+- oldPath: crates/cli_bin/fixtures/es6/empty_export_object.js
+  newPath: crates/cli_bin/fixtures/es6/empty_export_object.js
   ranges:
     - before:
         start:
@@ -19,8 +19,8 @@ expression: parsed
         end:
           line: 9
           column: 1
-- old_path: crates/cli_bin/fixtures/es6/export.js
-  new_path: ~
+- oldPath: crates/cli_bin/fixtures/es6/export.js
+  newPath: ~
   ranges:
     - before:
         start:
@@ -36,8 +36,8 @@ expression: parsed
         end:
           line: 1
           column: 1
-- old_path: crates/cli_bin/fixtures/es6/export_object.js
-  new_path: crates/cli_bin/fixtures/es6/export_object.js
+- oldPath: crates/cli_bin/fixtures/es6/export_object.js
+  newPath: crates/cli_bin/fixtures/es6/export_object.js
   ranges:
     - before:
         start:

--- a/crates/util/src/snapshots/marzano_util__diff__tests__parse_with_multiple_files.snap
+++ b/crates/util/src/snapshots/marzano_util__diff__tests__parse_with_multiple_files.snap
@@ -2,8 +2,8 @@
 source: crates/util/src/diff.rs
 expression: parsed
 ---
-- old_path: crates/cli_bin/fixtures/es6/empty_export_object.js
-  new_path: crates/cli_bin/fixtures/es6/empty_export_object.js
+- oldPath: crates/cli_bin/fixtures/es6/empty_export_object.js
+  newPath: crates/cli_bin/fixtures/es6/empty_export_object.js
   ranges:
     - before:
         start:
@@ -19,8 +19,8 @@ expression: parsed
         end:
           line: 9
           column: 1
-- old_path: crates/cli_bin/fixtures/es6/export_object.js
-  new_path: crates/cli_bin/fixtures/es6/export_object.js
+- oldPath: crates/cli_bin/fixtures/es6/export_object.js
+  newPath: crates/cli_bin/fixtures/es6/export_object.js
   ranges:
     - before:
         start:

--- a/crates/util/src/snapshots/marzano_util__diff__tests__parses_verified_baseline.snap
+++ b/crates/util/src/snapshots/marzano_util__diff__tests__parses_verified_baseline.snap
@@ -2,8 +2,8 @@
 source: crates/util/src/diff.rs
 expression: parsed
 ---
-- old_path: crates/cli/src/analyze.rs
-  new_path: crates/cli/src/analyze.rs
+- oldPath: crates/cli/src/analyze.rs
+  newPath: crates/cli/src/analyze.rs
   ranges:
     - before:
         start:

--- a/crates/util/src/snapshots/marzano_util__diff__tests__process_confusing_case.snap
+++ b/crates/util/src/snapshots/marzano_util__diff__tests__process_confusing_case.snap
@@ -2,8 +2,8 @@
 source: crates/util/src/diff.rs
 expression: parsed
 ---
-- old_path: ".grit/workflows/autoreview/local.ts"
-  new_path: ".grit/workflows/autoreview/local.ts"
+- oldPath: ".grit/workflows/autoreview/local.ts"
+  newPath: ".grit/workflows/autoreview/local.ts"
   ranges:
     - before:
         start:
@@ -131,8 +131,8 @@ expression: parsed
         end:
           line: 137
           column: 1
-- old_path: apps/minas/src/sdk/internal.ts
-  new_path: apps/minas/src/sdk/internal.ts
+- oldPath: apps/minas/src/sdk/internal.ts
+  newPath: apps/minas/src/sdk/internal.ts
   ranges:
     - before:
         start:
@@ -162,8 +162,8 @@ expression: parsed
         end:
           line: 103
           column: 1
-- old_path: packages/api/src/types.ts
-  new_path: packages/api/src/types.ts
+- oldPath: packages/api/src/types.ts
+  newPath: packages/api/src/types.ts
   ranges:
     - before:
         start:

--- a/crates/util/src/snapshots/marzano_util__diff__tests__processes_multiline_edit.snap
+++ b/crates/util/src/snapshots/marzano_util__diff__tests__processes_multiline_edit.snap
@@ -2,8 +2,8 @@
 source: crates/util/src/diff.rs
 expression: parsed
 ---
-- old_path: crates/util/fixtures/file.multiline.js
-  new_path: crates/util/fixtures/file.multiline.js
+- oldPath: crates/util/fixtures/file.multiline.js
+  newPath: crates/util/fixtures/file.multiline.js
   ranges:
     - before:
         start:

--- a/crates/util/src/snapshots/marzano_util__diff__tests__processes_newline_add.snap
+++ b/crates/util/src/snapshots/marzano_util__diff__tests__processes_newline_add.snap
@@ -2,8 +2,8 @@
 source: crates/util/src/diff.rs
 expression: parsed
 ---
-- old_path: crates/util/fixtures/file.baseline.js
-  new_path: crates/util/fixtures/file.newline.js
+- oldPath: crates/util/fixtures/file.baseline.js
+  newPath: crates/util/fixtures/file.newline.js
   ranges:
     - before:
         start:

--- a/crates/util/src/snapshots/marzano_util__diff__tests__processes_newline_rm.snap
+++ b/crates/util/src/snapshots/marzano_util__diff__tests__processes_newline_rm.snap
@@ -2,8 +2,8 @@
 source: crates/util/src/diff.rs
 expression: parsed
 ---
-- old_path: crates/util/fixtures/file.baseline.js
-  new_path: crates/util/fixtures/file.baseline.js
+- oldPath: crates/util/fixtures/file.baseline.js
+  newPath: crates/util/fixtures/file.baseline.js
   ranges:
     - before:
         start:


### PR DESCRIPTION
For workflows, we want to inspect the full diff not just the ranges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved data structure for handling file differences, providing more detailed and accurate migration and filtering capabilities.
  
- **Bug Fixes**
  - Fixed inconsistencies in file difference handling across various commands, ensuring smoother and more reliable workflows.

- **Developer Experience**
  - Updated import statements and function names for better clarity and maintainability.
  - Added tracing instrumentation to new functions for improved debugging and performance monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->