### PR TITLE
feat: implement basic filename query optimizer

### DIFF
--- a/crates/cli_bin/benchmark/bench.sh
+++ b/crates/cli_bin/benchmark/bench.sh
@@ -71,6 +71,7 @@ bench_names=(
   "main_console_log_rewrite"
   "main_react_to_hooks"
   "main_quick_patterns_test"
+  "optimize_filename"
   "stdlib_patterns_test"
 )
 
@@ -81,6 +82,7 @@ commands=(
   "cd ${temp_repo_path} && ${bin_path} apply --force --dry-run --jsonl --min-visibility hidden ${fixtures_dir}/simple_patterns/console_log_rewrite.grit ${temp_repo_path}"
   "cd ${temp_repo_path} && ${bin_path} apply --force ${fixtures_dir}/simple_patterns/console_log_rewrite.grit ${temp_repo_path}"
   "cd ${temp_repo_path} && ${bin_path} apply --force ${fixtures_dir}/simple_patterns/react_to_hooks.grit ${temp_repo_path}"
+  "cd ${temp_repo_path} && ${bin_path} apply --force ${fixtures_dir}/simple_patterns/optimize_filename.grit ${temp_repo_path}"
   "cd ${fixtures_dir}/patterns_test && ${bin_path} patterns test"
   "cd ${temp_repo_path} && ${bin_path} patterns test --exclude ai"
 )

--- a/crates/cli_bin/fixtures/simple_patterns/optimize_filename.grit
+++ b/crates/cli_bin/fixtures/simple_patterns/optimize_filename.grit
@@ -1,0 +1,7 @@
+language rust
+
+// Test that we extract filename patterns
+
+`Option<String>` where {
+  $filename <: includes "smart_insert.rs"
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod marzano_binding;
 pub mod marzano_code_snippet;
 pub mod marzano_context;
 pub mod marzano_resolved_pattern;
+mod optimizer;
 pub mod parse;
 mod paths;
 pub mod pattern_compiler;

--- a/crates/core/src/optimizer/hoist_files.rs
+++ b/crates/core/src/optimizer/hoist_files.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use grit_pattern_matcher::{context::QueryContext, pattern::Pattern};
+
+/// Given a pattern, construct a new pattern that reflects any filename predicates found
+/// If analysis cannot be done reliably, returns None
+pub fn extract_filename_pattern<Q: QueryContext>(
+    pattern: &Pattern<Q>,
+) -> Result<Option<Pattern<Q>>> {
+    print!("extract_filename_pattern: {:?}", pattern);
+    Ok(None)
+}

--- a/crates/core/src/optimizer/hoist_files.rs
+++ b/crates/core/src/optimizer/hoist_files.rs
@@ -13,7 +13,7 @@ trait FilenamePatternExtractor<Q: QueryContext> {
 pub fn extract_filename_pattern<Q: QueryContext>(
     pattern: &Pattern<Q>,
 ) -> Result<Option<Pattern<Q>>> {
-    let filename_pattern = match pattern {
+    match pattern {
         // Once we hit a leaf node that is *not* matched against the filename, we can't go any further
         Pattern::Variable(_)
         | Pattern::CodeSnippet(_)
@@ -89,9 +89,7 @@ pub fn extract_filename_pattern<Q: QueryContext>(
         | Pattern::FloatConstant(_)
         | Pattern::BooleanConstant(_)
         | Pattern::Dynamic(_) => Ok(None),
-    };
-
-    filename_pattern
+    }
 }
 
 impl<Q: QueryContext> FilenamePatternExtractor<Q> for Bubble<Q> {

--- a/crates/core/src/optimizer/hoist_files.rs
+++ b/crates/core/src/optimizer/hoist_files.rs
@@ -295,6 +295,56 @@ fn is_safe_to_hoist<Q: QueryContext>(pattern: &Pattern<Q>) -> Result<bool> {
         Pattern::Includes(inc) => is_safe_to_hoist(&inc.includes),
         Pattern::StringConstant(_) => Ok(true),
         // This is conservative, but it's a start
-        _ => Ok(false),
+        Pattern::AstNode(_)
+        | Pattern::List(_)
+        | Pattern::ListIndex(_)
+        | Pattern::Map(_)
+        | Pattern::Accessor(_)
+        | Pattern::Call(_)
+        | Pattern::Regex(_)
+        | Pattern::File(_)
+        | Pattern::Files(_)
+        | Pattern::Bubble(_)
+        | Pattern::Limit(_)
+        | Pattern::CallBuiltIn(_)
+        | Pattern::CallFunction(_)
+        | Pattern::CallForeignFunction(_)
+        | Pattern::Assignment(_)
+        | Pattern::Accumulate(_)
+        | Pattern::And(_)
+        | Pattern::Or(_)
+        | Pattern::Maybe(_)
+        | Pattern::Any(_)
+        | Pattern::Not(_)
+        | Pattern::If(_)
+        | Pattern::Undefined
+        | Pattern::Top
+        | Pattern::Bottom
+        | Pattern::Underscore
+        | Pattern::AstLeafNode(_)
+        | Pattern::IntConstant(_)
+        | Pattern::FloatConstant(_)
+        | Pattern::BooleanConstant(_)
+        | Pattern::Dynamic(_)
+        | Pattern::CodeSnippet(_)
+        | Pattern::Variable(_)
+        | Pattern::Rewrite(_)
+        | Pattern::Log(_)
+        | Pattern::Range(_)
+        | Pattern::Contains(_)
+        | Pattern::Within(_)
+        | Pattern::After(_)
+        | Pattern::Before(_)
+        | Pattern::Where(_)
+        | Pattern::Some(_)
+        | Pattern::Every(_)
+        | Pattern::Add(_)
+        | Pattern::Subtract(_)
+        | Pattern::Multiply(_)
+        | Pattern::Divide(_)
+        | Pattern::Modulo(_)
+        | Pattern::Dots
+        | Pattern::Sequential(_)
+        | Pattern::Like(_) => Ok(false),
     }
 }

--- a/crates/core/src/optimizer/hoist_files.rs
+++ b/crates/core/src/optimizer/hoist_files.rs
@@ -136,7 +136,7 @@ impl<Q: QueryContext> FilenamePatternExtractor<Q> for Predicate<Q> {
 
                 match &m.pattern {
                     Some(pattern) => extract_filename_pattern(pattern),
-                    // TODO: is this right? It does not seem right
+                    // TODO: is this right? Why do we ever have an empty pattern?
                     None => Ok(None),
                 }
             }

--- a/crates/core/src/optimizer/hoist_files.rs
+++ b/crates/core/src/optimizer/hoist_files.rs
@@ -1,11 +1,159 @@
 use anyhow::Result;
-use grit_pattern_matcher::{context::QueryContext, pattern::Pattern};
+use grit_pattern_matcher::{
+    context::QueryContext,
+    pattern::{And, Bubble, Contains, Pattern, Predicate, Where},
+};
+
+trait FilenamePatternExtractor<Q: QueryContext> {
+    fn extract_filename_pattern(&self) -> Result<Option<Pattern<Q>>>;
+}
 
 /// Given a pattern, construct a new pattern that reflects any filename predicates found
 /// If analysis cannot be done reliably, returns None
 pub fn extract_filename_pattern<Q: QueryContext>(
     pattern: &Pattern<Q>,
 ) -> Result<Option<Pattern<Q>>> {
-    print!("extract_filename_pattern: {:?}", pattern);
-    Ok(None)
+    let filename_pattern = match pattern {
+        Pattern::Contains(c) => c.extract_filename_pattern(),
+        Pattern::Bubble(b) => b.extract_filename_pattern(),
+        Pattern::Where(w) => w.extract_filename_pattern(),
+
+        // TODO: is this right?
+        Pattern::Variable(_) => Ok(Some(Pattern::Top)),
+        Pattern::CodeSnippet(_) => Ok(Some(Pattern::Top)),
+
+        Pattern::Rewrite(_)
+        | Pattern::Log(_)
+        | Pattern::Range(_)
+        | Pattern::Includes(_)
+        | Pattern::Within(_)
+        | Pattern::After(_)
+        | Pattern::Before(_)
+        | Pattern::Some(_)
+        | Pattern::Every(_)
+        | Pattern::Add(_)
+        | Pattern::Subtract(_)
+        | Pattern::Multiply(_)
+        | Pattern::Divide(_)
+        | Pattern::Modulo(_)
+        | Pattern::Dots
+        | Pattern::Sequential(_)
+        | Pattern::Like(_)
+        | Pattern::AstNode(_)
+        | Pattern::List(_)
+        | Pattern::ListIndex(_)
+        | Pattern::Map(_)
+        | Pattern::Accessor(_)
+        | Pattern::Call(_)
+        | Pattern::Regex(_)
+        | Pattern::File(_)
+        | Pattern::Files(_)
+        | Pattern::Limit(_)
+        | Pattern::CallBuiltIn(_)
+        | Pattern::CallFunction(_)
+        | Pattern::CallForeignFunction(_)
+        | Pattern::Assignment(_)
+        | Pattern::Accumulate(_)
+        | Pattern::And(_)
+        | Pattern::Or(_)
+        | Pattern::Maybe(_)
+        | Pattern::Any(_)
+        | Pattern::Not(_)
+        | Pattern::If(_)
+        | Pattern::Undefined
+        | Pattern::Top
+        | Pattern::Bottom
+        | Pattern::Underscore
+        | Pattern::StringConstant(_)
+        | Pattern::AstLeafNode(_)
+        | Pattern::IntConstant(_)
+        | Pattern::FloatConstant(_)
+        | Pattern::BooleanConstant(_)
+        | Pattern::Dynamic(_) => Ok(None),
+    };
+
+    filename_pattern
+}
+
+impl<Q: QueryContext> FilenamePatternExtractor<Q> for Bubble<Q> {
+    fn extract_filename_pattern(&self) -> Result<Option<Pattern<Q>>> {
+        extract_filename_pattern(&self.pattern_def.pattern)
+    }
+}
+
+impl<Q: QueryContext> FilenamePatternExtractor<Q> for Contains<Q> {
+    fn extract_filename_pattern(&self) -> Result<Option<Pattern<Q>>> {
+        extract_filename_pattern(&self.contains)
+    }
+}
+
+impl<Q: QueryContext> FilenamePatternExtractor<Q> for Where<Q> {
+    fn extract_filename_pattern(&self) -> Result<Option<Pattern<Q>>> {
+        let pattern = extract_filename_pattern(&self.pattern)?.unwrap_or(Pattern::Top);
+        let predicate_pattern = self
+            .side_condition
+            .extract_filename_pattern()?
+            .unwrap_or(Pattern::Top);
+        Ok(Some(Pattern::And(Box::new(And::new(vec![
+            pattern,
+            predicate_pattern,
+        ])))))
+    }
+}
+
+impl<Q: QueryContext> FilenamePatternExtractor<Q> for Predicate<Q> {
+    fn extract_filename_pattern(&self) -> Result<Option<Pattern<Q>>> {
+        match self {
+            Predicate::And(and) => {
+                let mut patterns = vec![];
+                for p in &and.predicates {
+                    let pattern = p.extract_filename_pattern()?;
+                    if let Some(pattern) = pattern {
+                        patterns.push(pattern);
+                    } else {
+                        return Ok(None);
+                    }
+                }
+                Ok(Some(Pattern::And(Box::new(And::new(patterns)))))
+            }
+            Predicate::Match(m) => {
+                match m.val {
+                    grit_pattern_matcher::pattern::Container::Variable(var) => {
+                        if var.is_file_name() {
+                            match &m.pattern {
+                                Some(pattern) => {
+                                    // This is the key line of this entire file
+                                    return Ok(Some(pattern.clone()));
+                                }
+                                None => {}
+                            }
+                        }
+                    }
+                    grit_pattern_matcher::pattern::Container::Accessor(_)
+                    | grit_pattern_matcher::pattern::Container::ListIndex(_)
+                    | grit_pattern_matcher::pattern::Container::FunctionCall(_) => {}
+                };
+
+                match &m.pattern {
+                    Some(pattern) => extract_filename_pattern(pattern),
+                    // TODO: is this right? It does not seem right
+                    None => Ok(None),
+                }
+            }
+            Predicate::Accumulate(_) | Predicate::Assignment(_) | Predicate::Return(_) => {
+                Ok(Some(Pattern::Top))
+            }
+            Predicate::Maybe(_)
+            | Predicate::Any(_)
+            | Predicate::Rewrite(_)
+            | Predicate::Log(_)
+            | Predicate::Call(_)
+            | Predicate::Not(_)
+            | Predicate::If(_)
+            | Predicate::True
+            | Predicate::False
+            | Predicate::Or(_)
+            | Predicate::Equal(_) => Ok(None),
+        }
+    }
 }

--- a/crates/core/src/optimizer/hoist_files.rs
+++ b/crates/core/src/optimizer/hoist_files.rs
@@ -61,7 +61,6 @@ pub fn extract_filename_pattern<Q: QueryContext>(
 
         Pattern::Log(_) => Ok(Some(Pattern::Top)),
 
-        // TODO: decide the rest of these
         Pattern::Add(add) => {
             let Some(lhs) = extract_filename_pattern(&add.lhs)? else {
                 return Ok(None);
@@ -108,6 +107,7 @@ pub fn extract_filename_pattern<Q: QueryContext>(
             Ok(Some(Pattern::And(Box::new(And::new(vec![lhs, rhs])))))
         }
 
+        // TODO: decide the rest of these
         Pattern::Dots
         | Pattern::Sequential(_)
         | Pattern::Like(_)

--- a/crates/core/src/optimizer/mod.rs
+++ b/crates/core/src/optimizer/mod.rs
@@ -1,0 +1,1 @@
+pub mod hoist_files;

--- a/crates/core/src/pattern_compiler/auto_wrap.rs
+++ b/crates/core/src/pattern_compiler/auto_wrap.rs
@@ -12,6 +12,7 @@ use grit_pattern_matcher::{
     },
 };
 use grit_util::FileRange;
+use log::debug;
 use std::collections::BTreeMap;
 
 pub(super) fn auto_wrap_pattern<Q: QueryContext>(
@@ -445,9 +446,10 @@ fn wrap_pattern_in_contains<Q: QueryContext>(
 /// }
 /// ```
 fn wrap_pattern_in_file<Q: QueryContext>(pattern: Pattern<Q>) -> Result<Pattern<Q>> {
-    println!("extract pattern from: {:?}", pattern);
-    let filename_pattern = extract_filename_pattern(&pattern)?.unwrap_or(Pattern::Top);
-    println!("filename_pattern: {:?}", filename_pattern);
+    let filename_pattern = extract_filename_pattern(&pattern)?.unwrap_or_else(|| {
+        debug!("Optimization skipped: no filename pattern found, wrapping in top pattern");
+        Pattern::Top
+    });
 
     let pattern = Pattern::File(Box::new(FilePattern::new(filename_pattern, pattern)));
     Ok(pattern)

--- a/crates/core/src/pattern_compiler/auto_wrap.rs
+++ b/crates/core/src/pattern_compiler/auto_wrap.rs
@@ -445,7 +445,10 @@ fn wrap_pattern_in_contains<Q: QueryContext>(
 /// }
 /// ```
 fn wrap_pattern_in_file<Q: QueryContext>(pattern: Pattern<Q>) -> Result<Pattern<Q>> {
+    println!("extract pattern from: {:?}", pattern);
     let filename_pattern = extract_filename_pattern(&pattern)?.unwrap_or(Pattern::Top);
+    println!("filename_pattern: {:?}", filename_pattern);
+
     let pattern = Pattern::File(Box::new(FilePattern::new(filename_pattern, pattern)));
     Ok(pattern)
 }

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -32,7 +32,7 @@ impl SyntheticFile {
 impl TryIntoInputFile for SyntheticFile {
     fn try_into_cow(&self) -> Result<Cow<RichFile>> {
         if !self.can_read {
-            println!("Tried to read file that should not be read: {}", self.path);
+            panic!("Tried to read file that should not be read: {}", self.path);
         }
 
         Ok(Cow::Owned(RichFile::new(

--- a/crates/grit-pattern-matcher/src/pattern/any.rs
+++ b/crates/grit-pattern-matcher/src/pattern/any.rs
@@ -11,7 +11,7 @@ use grit_util::AnalysisLogs;
 
 #[derive(Debug, Clone)]
 pub struct Any<Q: QueryContext> {
-    pub(crate) patterns: Vec<Pattern<Q>>,
+    pub patterns: Vec<Pattern<Q>>,
 }
 
 impl<Q: QueryContext> Any<Q> {

--- a/crates/grit-pattern-matcher/src/pattern/includes.rs
+++ b/crates/grit-pattern-matcher/src/pattern/includes.rs
@@ -10,7 +10,7 @@ use grit_util::AnalysisLogs;
 
 #[derive(Debug, Clone)]
 pub struct Includes<Q: QueryContext> {
-    pub(crate) includes: Pattern<Q>,
+    pub includes: Pattern<Q>,
 }
 
 impl<Q: QueryContext> Includes<Q> {

--- a/crates/grit-pattern-matcher/src/pattern/variable.rs
+++ b/crates/grit-pattern-matcher/src/pattern/variable.rs
@@ -71,6 +71,10 @@ impl Variable {
         Self::new(GLOBAL_VARS_SCOPE_INDEX, FILENAME_INDEX)
     }
 
+    pub fn is_file_name(&self) -> bool {
+        self.scope == GLOBAL_VARS_SCOPE_INDEX && self.index == FILENAME_INDEX
+    }
+
     pub fn text<'a, Q: QueryContext>(
         &self,
         state: &State<'a, Q>,

--- a/crates/grit-pattern-matcher/src/pattern/within.rs
+++ b/crates/grit-pattern-matcher/src/pattern/within.rs
@@ -10,7 +10,7 @@ use grit_util::{AnalysisLogs, AstNode};
 
 #[derive(Debug, Clone)]
 pub struct Within<Q: QueryContext> {
-    pub(crate) pattern: Pattern<Q>,
+    pub pattern: Pattern<Q>,
 }
 
 impl<Q: QueryContext> Within<Q> {


### PR DESCRIPTION
PoC for hoisting filename matches so we avoid parsing unnecessary files for patterns like this:

```
`foo` where {
  $filename <: includes "nice.js"
}
```

## Impact

Even on small repos it makes a large difference.

before:
```
Processed 666 files and found 1 matches
  Time (mean ± σ):     835.1 ms ± 824.5 ms    [User: 4106.8 ms, System: 251.8 ms]
  Range (min … max):   548.3 ms … 3181.0 ms    10 runs
```

after:
```
Processed 666 files and found 1 matches
  Time (mean ± σ):     157.0 ms ±  14.1 ms    [User: 275.6 ms, System: 119.8 ms]
  Range (min … max):   147.7 ms … 204.1 ms    14 runs
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced filename pattern extraction functionality to optimize file matching in queries.
  - Added new test scenarios for filename query optimization.

- **Bug Fixes**
  - Modified behavior in test utilities to ensure proper handling of unexpected file reads.

- **Improvements**
  - Enhanced pattern matching by optimizing filename patterns for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->