### PR TITLE
fix: Switch to fs_err crate for better file error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "fs-set-times"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,6 +1449,7 @@ name = "grit_cache"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fs-err",
  "marzano-gritmodule",
  "marzano-util",
  "tokio",
@@ -2019,6 +2029,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "fs-err",
  "fs_extra",
  "insta",
  "marzano-cli",
@@ -2073,6 +2084,7 @@ dependencies = [
  "dialoguer",
  "env_logger",
  "flate2",
+ "fs-err",
  "futures-util",
  "git2",
  "grit-util",
@@ -2115,6 +2127,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "embeddings",
+ "fs-err",
  "getrandom",
  "grit-pattern-matcher",
  "grit-util",
@@ -2156,6 +2169,7 @@ name = "marzano-gritmodule"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "fs-err",
  "git2",
  "grit-util",
  "homedir",
@@ -2258,6 +2272,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "fs-err",
  "futures",
  "grit-util",
  "http",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -78,6 +78,8 @@ tracing-subscriber = { version = "0.3", default-features = false, optional = tru
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
 
+fs-err = { version = "2.11.0" }
+
 [dev-dependencies]
 trim-margin = "0.1.0"
 buildkite-test-collector = "0.1.1"

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -148,17 +148,17 @@ mod tests {
         let fixtures_root = get_fixtures_root(env!("CARGO_MANIFEST_DIR"))?;
         let pattern_grit = fixtures_root.join("stdlib").join("raw_no_console_log.grit");
         let pattern_dest = tempdir.path().join("raw_no_console_log.grit");
-        std::fs::copy(pattern_grit, pattern_dest.clone())?;
+        fs_err::copy(pattern_grit, pattern_dest.clone())?;
         let input = fixtures_root.join("stdlib").join("simple.js");
         let input_dest = tempdir.path().join("simple.js");
-        std::fs::copy(input, &input_dest)?;
+        fs_err::copy(input, &input_dest)?;
         env::set_current_dir(tempdir.path())?;
         test_apply(
             "raw_no_console_log.grit".to_string(),
             vec![input_dest.clone()],
         )
         .await?;
-        let content = std::fs::read_to_string(&input_dest)?;
+        let content = fs_err::read_to_string(&input_dest)?;
         assert_eq!(content, "\n".to_owned());
         Ok(())
     }
@@ -173,10 +173,10 @@ mod tests {
         let fixtures_root = get_fixtures_root(env!("CARGO_MANIFEST_DIR"))?;
         let pattern_grit = fixtures_root.join("openai").join("pattern.grit");
         let pattern_dest = tempdir.path().join("pattern.grit");
-        std::fs::copy(pattern_grit, pattern_dest.clone())?;
+        fs_err::copy(pattern_grit, pattern_dest.clone())?;
         let input = fixtures_root.join("openai").join("input.py");
         let input_dest = tempdir.path().join("input.py");
-        std::fs::copy(input, &input_dest)?;
+        fs_err::copy(input, &input_dest)?;
         env::set_current_dir(tempdir.path())?;
         test_apply("pattern.grit".to_string(), vec![input_dest.clone()]).await?;
         Ok(())

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -374,7 +374,7 @@ pub(crate) async fn run_check(
                     .collect::<HashSet<_>>();
                 for pattern in applicable_patterns {
                     let problem = compiled_map.get(pattern).unwrap();
-                    let src = std::fs::read_to_string(file)?;
+                    let src = fs_err::read_to_string(file)?;
                     let res = problem.execute_file(&RichFile::new(file.to_string(), src), &context);
                     for r in res {
                         if let MatchResult::Rewrite(r) = r {

--- a/crates/cli/src/commands/docgen.rs
+++ b/crates/cli/src/commands/docgen.rs
@@ -19,7 +19,7 @@ pub(crate) async fn run_docgen(arg: DocGenArgs) -> Result<()> {
         hide_footer: true,
     });
 
-    std::fs::write(arg.outpath, output)?;
+    fs_err::write(arg.outpath, output)?;
 
     Ok(())
 }

--- a/crates/cli/src/commands/patterns.rs
+++ b/crates/cli/src/commands/patterns.rs
@@ -172,7 +172,7 @@ pub(crate) async fn run_patterns_edit(arg: PatternsEditArgs) -> Result<()> {
     let (_, repo) = resolve_from_cwd(&resolver::Source::All).await?;
     let _pattern = collect_from_file(&arg.path, &Some(repo)).await?;
 
-    let content = std::fs::read_to_string(&arg.path)?;
+    let content = fs_err::read_to_string(&arg.path)?;
     let payload = serde_json::to_value(OpenStudioSettings {
         content,
         path: arg.path.to_string_lossy().to_string(),

--- a/crates/cli/src/commands/plumbing.rs
+++ b/crates/cli/src/commands/plumbing.rs
@@ -95,7 +95,7 @@ pub enum PlumbingArgs {
 
 fn read_input(shared_args: &SharedPlumbingArgs) -> Result<String> {
     let buffer = if let Some(input) = &shared_args.input {
-        std::fs::read_to_string(input)?
+        fs_err::read_to_string(input)?
     } else {
         let mut buffer = String::new();
         stdin().read_to_string(&mut buffer)?;

--- a/crates/cli/src/github.rs
+++ b/crates/cli/src/github.rs
@@ -6,7 +6,7 @@ use log::info;
 use marzano_core::{api::EnforcementLevel, fs::extract_ranges};
 use marzano_gritmodule::config::ResolvedGritDefinition;
 use marzano_gritmodule::utils::extract_path;
-use std::fs::OpenOptions;
+use fs_err::OpenOptions;
 use std::io::prelude::*;
 
 fn format_level(level: &EnforcementLevel) -> String {

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -167,7 +167,7 @@ pub async fn create_emitter<'a>(
     _root_path: Option<&PathBuf>,
 ) -> Result<MessengerVariant<'a>> {
     let writer: Option<Box<dyn Write + Send>> = if let Some(output_file) = output_file {
-        let file = std::fs::File::create(output_file)?;
+        let file = fs_err::File::create(output_file)?;
         let bufwriter = io::BufWriter::new(file);
         Some(Box::new(bufwriter))
     } else {

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -10,7 +10,7 @@ use marzano_core::api::{
 use marzano_core::constants::DEFAULT_FILE_NAME;
 use marzano_messenger::output_mode::OutputMode;
 use std::fmt::Display;
-use std::fs::read_to_string;
+use fs_err::read_to_string;
 use std::{
     io::Write,
     sync::{Arc, Mutex},

--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -550,7 +550,7 @@ impl Updater {
         {
             use std::os::unix::fs::PermissionsExt;
 
-            let target_file = std::fs::File::open(&target_path)?;
+            let target_file = fs_err::File::open(&target_path)?;
             let mut perms = target_file.metadata()?.permissions();
             perms.set_mode(0o744);
             if let Err(e) = target_file.set_permissions(perms) {
@@ -832,7 +832,7 @@ fn release_details_relative_url(release: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::create_dir_all;
+    use fs_err::create_dir_all;
 
     use anyhow::Result;
     use chrono::NaiveDate;

--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -18,6 +18,7 @@ marzano-cli = { path = "../cli", default-features = false }
 marzano-util = { path = "../util", default-features = false }
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.11", features = ["json", "stream"] }
+fs-err = { version = "2.11.0" }
 
 tracing = { version = "0.1.40", default-features = false }
 opentelemetry-otlp = { version = "0.14.0", optional = true, features = [

--- a/crates/cli_bin/tests/apply.rs
+++ b/crates/cli_bin/tests/apply.rs
@@ -224,7 +224,7 @@ fn run_stdlib_pattern_without_grit_config() -> Result<()> {
     let fixtures_root = get_fixtures_root()?;
     let require_js = fixtures_root.join("test_es6imports.js");
     let require_js_dest = tempdir.path().join("test_es6imports.js");
-    std::fs::copy(require_js, &require_js_dest)?;
+    fs_err::copy(require_js, &require_js_dest)?;
 
     // from the tempdir as cwd, run init
     run_init(&tempdir.path())?;
@@ -246,7 +246,7 @@ fn run_stdlib_pattern_without_grit_config() -> Result<()> {
     );
 
     // Read back the require.js file
-    let content: String = std::fs::read_to_string(&require_js_dest)?;
+    let content: String = fs_err::read_to_string(&require_js_dest)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -281,7 +281,7 @@ fn run_pattern_with_sequential() -> Result<()> {
     );
 
     // Read back the lifecycle.tsx file
-    let content: String = std::fs::read_to_string(dir.join("react_to_hooks/input/lifecycle.tsx"))?;
+    let content: String = fs_err::read_to_string(dir.join("react_to_hooks/input/lifecycle.tsx"))?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -298,7 +298,7 @@ fn run_pattern_file_referencing_stdlib() -> Result<()> {
     let fixtures_root = get_fixtures_root()?;
     let pattern_grit = fixtures_root.join("stdlib").join("no_console_log.grit");
     let pattern_dest = tempdir.path().join("no_console_log.grit");
-    std::fs::copy(pattern_grit, pattern_dest)?;
+    fs_err::copy(pattern_grit, pattern_dest)?;
     let extensions = ["js", "cjs", "mjs", "cts", "mts"];
     let mut destinations = vec![];
     for extension in extensions {
@@ -306,7 +306,7 @@ fn run_pattern_file_referencing_stdlib() -> Result<()> {
             .join("stdlib")
             .join(format!("simple.{}", extension));
         let input_dest = tempdir.path().join(format!("simple.{}", extension));
-        std::fs::copy(input, &input_dest)?;
+        fs_err::copy(input, &input_dest)?;
         destinations.push(input_dest);
     }
 
@@ -334,7 +334,7 @@ fn run_pattern_file_referencing_stdlib() -> Result<()> {
         "Command didn't finish successfully"
     );
     for destination in destinations {
-        let content = std::fs::read_to_string(&destination)?;
+        let content = fs_err::read_to_string(&destination)?;
         assert_eq!(content, "\n".to_owned());
     }
 
@@ -371,7 +371,7 @@ fn run_pattern_file_referencing_stdlib_function() -> Result<()> {
 
     // Check contents
     let target_file = dir.join("simple.js");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
     assert_eq!(
         content,
         "// TODO: Fix this\n// console.log('sanity');\n".to_owned()
@@ -402,7 +402,7 @@ fn run_pattern_file_referencing_python_stdlib() -> Result<()> {
     );
 
     let input_dest = dir.as_path().join("log.py");
-    let content: String = std::fs::read_to_string(input_dest)?;
+    let content: String = fs_err::read_to_string(input_dest)?;
     assert_eq!(content, "log(\"hello world!\")\n".to_owned());
 
     Ok(())
@@ -416,7 +416,7 @@ fn run_python_stdlib_pattern_name() -> Result<()> {
     let fixtures_root = get_fixtures_root()?;
     let input = fixtures_root.join("stdlib-python").join("log.py");
     let input_dest = tempdir.path().join("log.py");
-    std::fs::copy(input, &input_dest)?;
+    fs_err::copy(input, &input_dest)?;
 
     // from the tempdir as cwd, run marzano apply
     let mut apply_cmd = get_test_cmd()?;
@@ -435,7 +435,7 @@ fn run_python_stdlib_pattern_name() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let content: String = std::fs::read_to_string(&input_dest)?;
+    let content: String = fs_err::read_to_string(&input_dest)?;
     assert_eq!(content, "log(\"hello world!\")\n".to_owned());
 
     Ok(())
@@ -454,10 +454,10 @@ fn run_named_pattern_referencing_python_stdlib() -> Result<()> {
         .join(REPO_CONFIG_PATTERNS_DIR)
         .join("fun_logger.md");
     fs::create_dir_all(pattern_dest.parent().unwrap())?;
-    std::fs::copy(pattern_grit, pattern_dest)?;
+    fs_err::copy(pattern_grit, pattern_dest)?;
     let input = fixtures_root.join("stdlib-python").join("log.py");
     let input_dest = tempdir.path().join("log.py");
-    std::fs::copy(input, &input_dest)?;
+    fs_err::copy(input, &input_dest)?;
 
     run_init(&tempdir.path())?;
 
@@ -478,7 +478,7 @@ fn run_named_pattern_referencing_python_stdlib() -> Result<()> {
         String::from_utf8(output.stderr)?
     );
 
-    let content: String = std::fs::read_to_string(&input_dest)?;
+    let content: String = fs_err::read_to_string(&input_dest)?;
     assert_eq!(content, "log(\"hello world!\")\n".to_owned());
 
     Ok(())
@@ -492,7 +492,7 @@ fn grit_dir_with_only_empty_gritmodules() -> Result<()> {
     let fixtures_root = get_fixtures_root()?;
     let require_js = fixtures_root.join("short-story.ts");
     let require_js_dest = tempdir.path().join("short-story.ts");
-    std::fs::copy(require_js, &require_js_dest)?;
+    fs_err::copy(require_js, &require_js_dest)?;
 
     // make an empty .grit/.gritmodules in the tempdir
     let grit_modules_dir = tempdir
@@ -523,7 +523,7 @@ fn grit_dir_with_only_empty_gritmodules() -> Result<()> {
     println!("stdout: {:?}", String::from_utf8(output.stdout)?);
 
     // Read back the require.js file
-    let content: String = std::fs::read_to_string(&require_js_dest)?;
+    let content: String = fs_err::read_to_string(&require_js_dest)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -539,7 +539,7 @@ fn grit_dir_with_no_gritmodules_and_empty_config() -> Result<()> {
     let fixtures_root = get_fixtures_root()?;
     let require_js = fixtures_root.join("short-story.ts");
     let require_js_dest = tempdir.path().join("short-story.ts");
-    std::fs::copy(require_js, &require_js_dest)?;
+    fs_err::copy(require_js, &require_js_dest)?;
 
     let empty_config = r#"version: 0.0.1
 patterns: []"#;
@@ -572,7 +572,7 @@ patterns: []"#;
     println!("stdout: {:?}", String::from_utf8(output.stdout)?);
 
     // Read back the require.js file
-    let content: String = std::fs::read_to_string(&require_js_dest)?;
+    let content: String = fs_err::read_to_string(&require_js_dest)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -664,7 +664,7 @@ fn random_int() -> Result<()> {
     );
 
     let file = dir.join("input.ts");
-    let content = std::fs::read_to_string(file)?;
+    let content = fs_err::read_to_string(file)?;
 
     println!("content: {:?}", content);
 
@@ -702,7 +702,7 @@ fn shuffle_list() -> Result<()> {
     );
 
     let file = dir.join("input.ts");
-    let content = std::fs::read_to_string(file)?;
+    let content = fs_err::read_to_string(file)?;
     println!("content: {:?}", content);
 
     // Split it by line
@@ -757,7 +757,7 @@ fn test_absolute_path() -> Result<()> {
     let mut content = None;
     for path in paths {
         let file = dir.join(path);
-        let file_content = std::fs::read_to_string(file)?;
+        let file_content = fs_err::read_to_string(file)?;
         if let Some(ref content) = content {
             assert_eq!(content, &file_content);
         } else {
@@ -770,7 +770,7 @@ fn test_absolute_path() -> Result<()> {
 
     // Now we read unique.js
     let file = dir.join("dir2/unique.js");
-    let content = std::fs::read_to_string(file)?;
+    let content = fs_err::read_to_string(file)?;
 
     println!("content: {:?}", content);
 
@@ -804,7 +804,7 @@ fn shuffle_binding() -> Result<()> {
     );
 
     let file = dir.join("input.ts");
-    let content = std::fs::read_to_string(file)?;
+    let content = fs_err::read_to_string(file)?;
     println!("content: {:?}", content);
 
     // Split it by line
@@ -843,7 +843,7 @@ fn basic_python_apply() -> Result<()> {
 
     // Read back the require.js file
     let target_file = dir.join("main.py");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -876,7 +876,7 @@ fn basic_js_in_vue_apply() -> Result<()> {
 
     // Read back the require.js file
     let target_file = dir.join("simple.vue");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -909,7 +909,7 @@ fn basic_css_in_vue_apply() -> Result<()> {
 
     // Read back the require.js file
     let target_file = dir.join("simple.vue");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -925,7 +925,7 @@ fn invalid_md_file_parse_errors() -> Result<()> {
     let fixtures_root = get_fixtures_root()?;
     let require_js = fixtures_root.join("short-story.ts");
     let require_js_dest = tempdir.path().join("short-story.ts");
-    std::fs::copy(require_js, require_js_dest)?;
+    fs_err::copy(require_js, require_js_dest)?;
 
     // make an empty .grit/.gritmodules in the tempdir
     let grit_modules_dir = tempdir
@@ -947,7 +947,7 @@ fn invalid_md_file_parse_errors() -> Result<()> {
         .join("patterns")
         .join("js")
         .join("bad_pattern.md");
-    std::fs::copy(bad_pattern, bad_pattern_dest)?;
+    fs_err::copy(bad_pattern, bad_pattern_dest)?;
 
     let mut apply_cmd = get_test_cmd()?;
     apply_cmd.current_dir(tempdir.path());
@@ -970,7 +970,7 @@ fn grit_dir_with_outdated_grit_modules() -> Result<()> {
     let fixtures_root = get_fixtures_root()?;
     let require_js = fixtures_root.join("short-story.ts");
     let require_js_dest = tempdir.path().join("short-story.ts");
-    std::fs::copy(require_js, &require_js_dest)?;
+    fs_err::copy(require_js, &require_js_dest)?;
 
     // make an empty .grit/.gritmodules in the tempdir
     let grit_modules_dir = tempdir
@@ -1011,7 +1011,7 @@ fn grit_dir_with_outdated_grit_modules() -> Result<()> {
     );
 
     // Read back the require.js file
-    let content: String = std::fs::read_to_string(&require_js_dest)?;
+    let content: String = fs_err::read_to_string(&require_js_dest)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -1028,7 +1028,7 @@ fn removes_extraneous_whitespace() -> Result<()> {
     let fixtures_root = get_fixtures_root()?;
     let fixture_path = fixtures_root.join("format").join("whitespace.js");
     let fixture_dest = tempdir.path().join("whitespace.js");
-    std::fs::copy(fixture_path, &fixture_dest)?;
+    fs_err::copy(fixture_path, &fixture_dest)?;
 
     cmd.arg("apply")
         .arg("no_console_log")
@@ -1041,7 +1041,7 @@ fn removes_extraneous_whitespace() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let content: String = std::fs::read_to_string(&fixture_dest)?;
+    let content: String = fs_err::read_to_string(&fixture_dest)?;
 
     assert_snapshot!(content);
 
@@ -1123,7 +1123,7 @@ fn python_with_tabs() -> Result<()> {
 
     // Read back the main.py file
     let target_file = dir.join("main.py");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -1253,10 +1253,10 @@ fn applies_openai_js() -> Result<()> {
     let fixtures_root = get_fixtures_root()?;
     let pattern_grit = fixtures_root.join("openai").join("basic_llm_call.grit");
     let pattern_dest = tempdir.path().join("basic_llm_call.grit");
-    std::fs::copy(pattern_grit, pattern_dest.clone())?;
+    fs_err::copy(pattern_grit, pattern_dest.clone())?;
     let input = fixtures_root.join("openai").join("foo.js");
     let input_dest = tempdir.path().join("foo.js");
-    std::fs::copy(input, &input_dest)?;
+    fs_err::copy(input, &input_dest)?;
     run_init(&tempdir.path())?;
     let mut apply_cmd = get_test_cmd()?;
     apply_cmd.current_dir(tempdir.path());
@@ -1271,7 +1271,7 @@ fn applies_openai_js() -> Result<()> {
         output.status.success(),
         "Command didn't finish successfully"
     );
-    let content = std::fs::read_to_string(&input_dest)?;
+    let content = fs_err::read_to_string(&input_dest)?;
     assert!(content.contains("How can I assist you today?"));
     Ok(())
 }
@@ -1293,7 +1293,7 @@ fn embedding_like() -> Result<()> {
         output.status.success(),
         "Command didn't finish successfully"
     );
-    let content = std::fs::read_to_string(dir.join("simple_assign.js"))?;
+    let content = fs_err::read_to_string(dir.join("simple_assign.js"))?;
     assert_eq!(content, "console.log('hello')");
     Ok(())
 }
@@ -1320,10 +1320,10 @@ fn filtered_apply_custom() -> Result<()> {
     println!("stdout: {:?}", stdout);
     assert!(stdout.contains("1 matches"));
 
-    let content = std::fs::read_to_string(dir.join("file.js"))?;
+    let content = fs_err::read_to_string(dir.join("file.js"))?;
     assert_snapshot!(content);
 
-    let content2 = std::fs::read_to_string(dir.join("file2.js"))?;
+    let content2 = fs_err::read_to_string(dir.join("file2.js"))?;
     assert_snapshot!(content2);
 
     Ok(())
@@ -1333,7 +1333,7 @@ fn filtered_apply_custom() -> Result<()> {
 fn filtered_apply() -> Result<()> {
     let (_temp_dir, dir) = get_fixture("filtered_apply", true)?;
 
-    let eslint_content = std::fs::read_to_string(dir.join("eslint.json"))?;
+    let eslint_content = fs_err::read_to_string(dir.join("eslint.json"))?;
 
     let mut apply_cmd = get_test_cmd()?;
     apply_cmd.current_dir(dir.clone());
@@ -1353,10 +1353,10 @@ fn filtered_apply() -> Result<()> {
     println!("stdout: {:?}", stdout);
     assert!(stdout.contains("2 matches"));
 
-    let content = std::fs::read_to_string(dir.join("file.js"))?;
+    let content = fs_err::read_to_string(dir.join("file.js"))?;
     assert_snapshot!(content);
 
-    let content2 = std::fs::read_to_string(dir.join("file2.js"))?;
+    let content2 = fs_err::read_to_string(dir.join("file2.js"))?;
     assert_snapshot!(content2);
 
     Ok(())
@@ -1381,7 +1381,7 @@ fn uses_llm_choice() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let content = std::fs::read_to_string(dir.join("color.js"))?;
+    let content = fs_err::read_to_string(dir.join("color.js"))?;
     assert_snapshot!(content);
 
     Ok(())
@@ -1402,7 +1402,7 @@ fn yaml_padding() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let content = std::fs::read_to_string(dir.join("file.yaml"))?;
+    let content = fs_err::read_to_string(dir.join("file.yaml"))?;
     assert_snapshot!(content);
 
     Ok(())
@@ -1515,7 +1515,7 @@ fn output_jsonl() -> Result<()> {
         String::from_utf8(output.stderr)?
     );
 
-    let content = std::fs::read_to_string(dir.join("output.jsonl"))?;
+    let content = fs_err::read_to_string(dir.join("output.jsonl"))?;
     assert_snapshot!(content);
 
     let line_count = content.lines().count();
@@ -1539,7 +1539,7 @@ fn nested_dir() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let content = std::fs::read_to_string(dir.join("main.hcl"))?;
+    let content = fs_err::read_to_string(dir.join("main.hcl"))?;
     assert_snapshot!(content);
 
     Ok(())
@@ -1582,7 +1582,7 @@ fn fizzbuzz_ffi() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let content = std::fs::read_to_string(dir.join("input.js"))?;
+    let content = fs_err::read_to_string(dir.join("input.js"))?;
     assert_snapshot!(content);
 
     Ok(())
@@ -1603,7 +1603,7 @@ fn ffi_assignment() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let content = std::fs::read_to_string(dir.join("input.js"))?;
+    let content = fs_err::read_to_string(dir.join("input.js"))?;
     assert_snapshot!(content);
 
     Ok(())
@@ -1634,7 +1634,7 @@ fn apply_multifile_sample() -> Result<()> {
     println!("stdout: {:?}", stdout);
 
     // Read user2.ts
-    let content = std::fs::read_to_string(dir.join("user2.ts"))?;
+    let content = fs_err::read_to_string(dir.join("user2.ts"))?;
     assert_snapshot!(content);
 
     Ok(())
@@ -1659,7 +1659,7 @@ fn ai_constraint() -> Result<()> {
     let stdout = String::from_utf8(output.stdout)?;
     println!("stdout: {:?}", stdout);
 
-    let content = std::fs::read_to_string(dir.join("input.js"))?;
+    let content = fs_err::read_to_string(dir.join("input.js"))?;
     assert_snapshot!(content);
 
     Ok(())
@@ -1757,9 +1757,9 @@ fn applies_multifile_pattern_from_resolved_md() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let test1 = std::fs::read_to_string(fixture_dir.join("file1.js"))?;
+    let test1 = fs_err::read_to_string(fixture_dir.join("file1.js"))?;
     assert_eq!(test1, "foo(1)");
-    let test2 = std::fs::read_to_string(fixture_dir.join("file2.js"))?;
+    let test2 = fs_err::read_to_string(fixture_dir.join("file2.js"))?;
     assert_eq!(test2, "baz(1)\nbar(3)");
 
     Ok(())
@@ -1783,9 +1783,9 @@ fn applies_recursive_multifile_pattern_from_resolved_md() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let test1 = std::fs::read_to_string(fixture_dir.join("file1.js"))?;
+    let test1 = fs_err::read_to_string(fixture_dir.join("file1.js"))?;
     assert_eq!(test1, "foo(1)");
-    let test2 = std::fs::read_to_string(fixture_dir.join("file2.js"))?;
+    let test2 = fs_err::read_to_string(fixture_dir.join("file2.js"))?;
     assert_eq!(test2, "baz(1)\nbar(3)");
 
     Ok(())
@@ -1809,9 +1809,9 @@ fn applies_indirect_multi() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let test1 = std::fs::read_to_string(fixture_dir.join("file1.js"))?;
+    let test1 = fs_err::read_to_string(fixture_dir.join("file1.js"))?;
     assert_eq!(test1, "foo(1)");
-    let test2 = std::fs::read_to_string(fixture_dir.join("file2.js"))?;
+    let test2 = fs_err::read_to_string(fixture_dir.join("file2.js"))?;
     assert_eq!(test2, "baz(1)\nbar(3)");
 
     Ok(())
@@ -1835,8 +1835,8 @@ fn applies_limit_on_multifile() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let test1 = std::fs::read_to_string(fixture_dir.join("file1.js"))?;
-    let test2 = std::fs::read_to_string(fixture_dir.join("file2.js"))?;
+    let test1 = fs_err::read_to_string(fixture_dir.join("file1.js"))?;
+    let test2 = fs_err::read_to_string(fixture_dir.join("file2.js"))?;
 
     assert!(test1 == "const x = 6;" || test2 == "const x = 6;");
     assert!(test1 == "const y = 6;" || test2 == "const y = 6;");
@@ -1854,8 +1854,8 @@ fn applies_limit_on_multifile() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let test1 = std::fs::read_to_string(fixture_dir.join("file1.js"))?;
-    let test2 = std::fs::read_to_string(fixture_dir.join("file2.js"))?;
+    let test1 = fs_err::read_to_string(fixture_dir.join("file1.js"))?;
+    let test2 = fs_err::read_to_string(fixture_dir.join("file2.js"))?;
     assert!(test1 == "const y = 6;" && test2 == "const y = 6;");
 
     Ok(())
@@ -1955,7 +1955,7 @@ fn run_simultaneous_apply_ops() -> Result<()> {
     for i in 0..total_cases {
         let src = fixture_dir.join("test.js");
         let dest = fixture_dir.join(format!("test{}.js", i));
-        std::fs::copy(src, dest)?;
+        fs_err::copy(src, dest)?;
     }
 
     println!("Copied files, starting actual test");
@@ -1980,7 +1980,7 @@ fn run_simultaneous_apply_ops() -> Result<()> {
                 bail!("Command didn't finish successfully");
             }
 
-            let test = std::fs::read_to_string(fixture_dir.join(&file))?;
+            let test = fs_err::read_to_string(fixture_dir.join(&file))?;
             if !test.contains("const did_it_get_touched = true;") {
                 bail!("File {} was not mutated", file);
             }
@@ -2030,7 +2030,7 @@ fn applies_user_pattern() -> Result<()> {
     let stdout = String::from_utf8(output.stdout)?;
     assert!(stdout.contains("Processed 1 files and found 1 matches"));
 
-    let content: String = std::fs::read_to_string(dir.join("whitespace.js"))?;
+    let content: String = fs_err::read_to_string(dir.join("whitespace.js"))?;
     assert_snapshot!(content);
 
     Ok(())
@@ -2112,7 +2112,7 @@ fn applies_on_file_in_hidden_directory() -> Result<()> {
     let stdout = String::from_utf8(output.stdout)?;
     assert!(stdout.contains("Processed 1 files and found 1 matches"));
 
-    let content: String = std::fs::read_to_string(dir.join(".circleci").join("config.yml"))?;
+    let content: String = fs_err::read_to_string(dir.join(".circleci").join("config.yml"))?;
     assert_eq!(content, "");
 
     Ok(())
@@ -2142,7 +2142,7 @@ fn ignores_file_in_grit_dir() -> Result<()> {
 fn language_option_file_pattern_apply() -> Result<()> {
     // Keep _temp_dir around so that the tempdir is not deleted
     let (_temp_dir, dir) = get_fixture("simple_python", false)?;
-    let origin_content = std::fs::read_to_string(dir.join("main.py"))?;
+    let origin_content = fs_err::read_to_string(dir.join("main.py"))?;
 
     // from the tempdir as cwd, run init
     run_init(&dir.as_path())?;
@@ -2167,7 +2167,7 @@ fn language_option_file_pattern_apply() -> Result<()> {
 
     // Read back the main.py file
     let target_file = dir.join("main.py");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
 
     assert_eq!(origin_content, content);
 
@@ -2203,7 +2203,7 @@ fn language_option_inline_pattern_apply() -> Result<()> {
 
     // Read back the main.py file
     let target_file = dir.join("main.py");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -2244,7 +2244,7 @@ fn language_option_named_pattern_apply() -> Result<()> {
 
     // Read back the main.py file
     let target_file = dir.join("main.py");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);
@@ -2259,7 +2259,7 @@ fn language_option_conflict_apply() -> Result<()> {
     // Keep _temp_dir around so that the tempdir is not deleted
     let (_temp_dir, dir) = get_fixture("simple_python", false)?;
 
-    let origin_content = std::fs::read_to_string(dir.join("main.py"))?;
+    let origin_content = fs_err::read_to_string(dir.join("main.py"))?;
 
     // from the tempdir as cwd, run init
     run_init(&dir.as_path())?;
@@ -2283,7 +2283,7 @@ fn language_option_conflict_apply() -> Result<()> {
 
     // Read back the main.py file
     let target_file = dir.join("main.py");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
 
     // assert that it matches snapshot
     assert_eq!(origin_content, content);
@@ -2296,7 +2296,7 @@ fn invalid_language_option_apply() -> Result<()> {
     let pattern = r"`os.getenv` => `dotenv.fetch`";
     // Keep _temp_dir around so that the tempdir is not deleted
     let (_temp_dir, dir) = get_fixture("simple_python", false)?;
-    let origin_content = std::fs::read_to_string(dir.join("main.py"))?;
+    let origin_content = fs_err::read_to_string(dir.join("main.py"))?;
 
     // from the tempdir as cwd, run init
     run_init(&dir.as_path())?;
@@ -2321,7 +2321,7 @@ fn invalid_language_option_apply() -> Result<()> {
 
     // Read back the main.py file
     let target_file = dir.join("main.py");
-    let content: String = std::fs::read_to_string(target_file)?;
+    let content: String = fs_err::read_to_string(target_file)?;
 
     // assert that it matches snapshot
     assert_eq!(origin_content, content);
@@ -2335,7 +2335,7 @@ fn apply_only_in_diff() -> Result<()> {
 
     let mut cmd = get_test_cmd()?;
 
-    let diff_content = std::fs::read_to_string(dir.join("test.diff"))?;
+    let diff_content = fs_err::read_to_string(dir.join("test.diff"))?;
 
     cmd.arg("apply")
         .arg("no_console_log")
@@ -2355,7 +2355,7 @@ fn apply_only_in_diff() -> Result<()> {
 
     assert!(stdout.contains("Processed 1 files and found 1 match"));
 
-    let content = std::fs::read_to_string(dir.join("index.js"))?;
+    let content = fs_err::read_to_string(dir.join("index.js"))?;
     assert!(!content.contains("console.log('really cool')"));
     assert!(content.contains("console.log('cool')"));
 
@@ -2429,7 +2429,7 @@ fn tty_behavior() -> Result<()> {
     assert!(stderr.contains("--force"));
 
     // Confirm file is not modified
-    let content = std::fs::read_to_string(dir.join("file.yaml"))?;
+    let content = fs_err::read_to_string(dir.join("file.yaml"))?;
     assert_snapshot!(content);
 
     // Run again with force
@@ -2447,7 +2447,7 @@ fn tty_behavior() -> Result<()> {
         "Command didn't finish successfully"
     );
 
-    let content = std::fs::read_to_string(dir.join("file.yaml"))?;
+    let content = fs_err::read_to_string(dir.join("file.yaml"))?;
     assert_snapshot!(content);
 
     Ok(())

--- a/crates/cli_bin/tests/check.rs
+++ b/crates/cli_bin/tests/check.rs
@@ -134,7 +134,7 @@ fn check_github_output() -> Result<()> {
     assert_snapshot!(output);
 
     // Make sure we wrote the summary file
-    let summary = std::fs::read_to_string(summary_file)?;
+    let summary = fs_err::read_to_string(summary_file)?;
     assert_snapshot!(summary);
 
     Ok(())
@@ -170,7 +170,7 @@ fn check_clean_github_output() -> Result<()> {
     assert_snapshot!(output);
 
     // Make sure we wrote the summary file
-    let summary = std::fs::read_to_string(summary_file)?;
+    let summary = fs_err::read_to_string(summary_file)?;
     assert_snapshot!(summary);
 
     Ok(())
@@ -190,7 +190,7 @@ fn check_only_in_diff() -> Result<()> {
 
     let mut cmd = get_test_cmd()?;
 
-    let diff_content = std::fs::read_to_string(dir.join("test.diff"))?;
+    let diff_content = fs_err::read_to_string(dir.join("test.diff"))?;
 
     cmd.arg("check")
         .arg("--only-in-diff")

--- a/crates/cli_bin/tests/patterns_test.rs
+++ b/crates/cli_bin/tests/patterns_test.rs
@@ -8,10 +8,10 @@ mod common;
 #[test]
 fn updates_nothing_valid_patterns() -> Result<()> {
     let (_temp_dir, _) = get_fixture("patterns_list", true)?;
-    let before_files = std::fs::read_dir(_temp_dir.path().join("patterns_list"))?
+    let before_files = fs_err::read_dir(_temp_dir.path().join("patterns_list"))?
         .filter_map(|res| {
             let path = res.ok()?.path();
-            std::fs::read_to_string(path).ok()
+            fs_err::read_to_string(path).ok()
         })
         .collect::<Vec<_>>();
 
@@ -23,10 +23,10 @@ fn updates_nothing_valid_patterns() -> Result<()> {
 
     println!("{:?}", cmd.output());
 
-    let after_files = std::fs::read_dir(_temp_dir.path().join("patterns_list"))?
+    let after_files = fs_err::read_dir(_temp_dir.path().join("patterns_list"))?
         .filter_map(|res| {
             let path = res.ok()?.path();
-            std::fs::read_to_string(path).ok()
+            fs_err::read_to_string(path).ok()
         })
         .collect::<Vec<_>>();
 
@@ -47,7 +47,7 @@ fn updates_invalid_pattern() -> Result<()> {
 
     println!("{:?}", cmd.output());
 
-    let after = std::fs::read_to_string(
+    let after = fs_err::read_to_string(
         _temp_dir
             .path()
             .join("patterns_list/.grit/patterns/broken_pattern.md"),
@@ -112,7 +112,7 @@ fn updates_multiple_invalid_patterns() -> Result<()> {
 
     let stdout = String::from_utf8(cmd.output()?.stdout)?;
     println!("stdout: {}", stdout);
-    let after = std::fs::read_to_string(
+    let after = fs_err::read_to_string(
         _temp_dir
             .path()
             .join("patterns_list/.grit/patterns/multiple_broken_patterns.md"),

--- a/crates/cli_bin/tests/plumbing.rs
+++ b/crates/cli_bin/tests/plumbing.rs
@@ -232,7 +232,7 @@ fn lists_imported_patterns() -> Result<()> {
 
     // Delete fixtures_path/.gritmodules, if it exists
     if fixture_path.join(".gritmodules").exists() {
-        std::fs::remove_dir_all(fixture_path.join(".gritmodules"))?;
+        fs_err::remove_dir_all(fixture_path.join(".gritmodules"))?;
     }
 
     let input = format!(r#"{{ "grit_dir" : {:?} }}"#, fixture_path.to_str().unwrap());

--- a/crates/cli_bin/tests/private.rs
+++ b/crates/cli_bin/tests/private.rs
@@ -46,7 +46,7 @@ fn run_pattern_with_private() -> Result<()> {
     );
 
     // Read back the lifecycle.tsx file
-    let content: String = std::fs::read_to_string(dir.join("input.ts"))?;
+    let content: String = fs_err::read_to_string(dir.join("input.ts"))?;
 
     // assert that it matches snapshot
     assert_snapshot!(content);

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,6 +42,7 @@ path-absolutize = { version = "3.1.1", optional = false, features = [
 getrandom = { version = "0.2.11", optional = true }
 lazy_static = {version = "1.4.0", optional = true }
 walkdir = { version = "2.3.3", optional = true }
+fs-err = { version = "2.11.0" }
 
 [dev-dependencies]
 similar = "2.2.1"

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -186,7 +186,7 @@ impl MatchResult {
         let original_file_name = self.extract_original_path()?;
         let original_match = self.extract_original_match()?;
 
-        let original_src = std::fs::read_to_string(original_file_name).ok()?;
+        let original_src = fs_err::read_to_string(original_file_name).ok()?;
         let rewritten_content =
             split_string_at_indices(&original_src, ranges_starts).join(&comment);
         let ef = EntireFile::file_to_entire_file(original_file_name, &rewritten_content, None);

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -10,31 +10,31 @@ pub fn apply_rewrite(result: &MatchResult) -> Result<()> {
         MatchResult::CreateFile(f) => {
             let path = Path::new(&f.rewritten.source_file);
             if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)?;
+                fs_err::create_dir_all(parent)?;
             }
             // Write the file
-            std::fs::write(path, f.rewritten.content.as_bytes())?;
+            fs_err::write(path, f.rewritten.content.as_bytes())?;
         }
 
         MatchResult::Rewrite(r) => {
             let new_path = Path::new(&r.rewritten.source_file);
             if let Some(parent) = new_path.parent() {
-                std::fs::create_dir_all(parent)?;
+                fs_err::create_dir_all(parent)?;
             }
             if r.rewritten.source_file != r.original.source_file {
                 let old_path = Path::new(&r.original.source_file);
                 if old_path.exists() {
-                    std::fs::remove_file(old_path)?;
+                    fs_err::remove_file(old_path)?;
                 }
             }
             // Write the file
-            std::fs::write(new_path, r.rewritten.content.as_bytes())?;
+            fs_err::write(new_path, r.rewritten.content.as_bytes())?;
         }
 
         MatchResult::RemoveFile(f) => {
             let path = Path::new(&f.original.source_file);
             if path.exists() {
-                std::fs::remove_file(path)?;
+                fs_err::remove_file(path)?;
             }
         }
 

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -213,7 +213,7 @@ fn test_rewrite(dir: &str, pattern: &str, test: &str) -> Result<()> {
             .join("expected")
             .join(actual_filename);
 
-        std::fs::write(actual_path, &rewrite)?;
+        fs_err::write(actual_path, &rewrite)?;
     }
     assert_eq!(
         rewrite.trim(),
@@ -244,7 +244,7 @@ fn new_files_assertion(
     if !files_path.is_dir() {
         return Ok(());
     }
-    let files = std::fs::read_dir(files_path)?;
+    let files = fs_err::read_dir(files_path)?;
     let count = files.count();
     assert_eq!(
         count,
@@ -262,7 +262,7 @@ fn new_files_assertion(
     for file in files {
         let name = file.file_name();
         let name = name.to_str().unwrap();
-        let content = std::fs::read(file.path())?;
+        let content = fs_err::read(file.path())?;
         let content = String::from_utf8(content)?;
         let content = content.trim();
         let message = format!("pattern result missing file: {}", name);
@@ -311,9 +311,9 @@ fn test_setup(dir: &str, pattern: &str, test: &str) -> Result<(ExecutionResult, 
             test
         )
     })?;
-    let pattern = std::fs::read_to_string(pattern)?;
-    let input = std::fs::read_to_string(input)?;
-    let expected = std::fs::read_to_string(expected).ok();
+    let pattern = fs_err::read_to_string(pattern)?;
+    let input = fs_err::read_to_string(input)?;
+    let expected = fs_err::read_to_string(expected).ok();
     Ok((
         match_pattern_one_file(pattern, "test-file.tsx", &input, lang)?,
         expected,
@@ -4503,7 +4503,7 @@ fn simple_predicate_false() {
 fn test_import_none() {
     let root = get_fixtures_root().unwrap();
     let import_patterns = format!("{}/test_patterns/imports.grit", root.display());
-    let import_patterns = std::fs::read_to_string(import_patterns).unwrap();
+    let import_patterns = fs_err::read_to_string(import_patterns).unwrap();
 
     let pattern = r#"
 
@@ -4555,7 +4555,7 @@ fn rewrite_or_bubble_pattern_argument() {
 fn test_import_just_insert() {
     let root = get_fixtures_root().unwrap();
     let import_patterns = format!("{}/test_patterns/imports.grit", root.display());
-    let import_patterns = std::fs::read_to_string(import_patterns).unwrap();
+    let import_patterns = fs_err::read_to_string(import_patterns).unwrap();
 
     let pattern = r#"
 
@@ -4583,7 +4583,7 @@ fn test_import_just_insert() {
 fn pattern_call_as_rhs() {
     let root = get_fixtures_root().unwrap();
     let import_patterns = format!("{}/test_patterns/imports.grit", root.display());
-    let import_patterns = std::fs::read_to_string(import_patterns).unwrap();
+    let import_patterns = fs_err::read_to_string(import_patterns).unwrap();
 
     let pattern = r#"
         // does not work:
@@ -4623,7 +4623,7 @@ fn pattern_call_as_rhs() {
 fn pattern_call_as_lhs_and_rhs() {
     let root = get_fixtures_root().unwrap();
     let import_patterns = format!("{}/test_patterns/imports.grit", root.display());
-    let import_patterns = std::fs::read_to_string(import_patterns).unwrap();
+    let import_patterns = fs_err::read_to_string(import_patterns).unwrap();
 
     let pattern = r#"
             $x where {
@@ -4647,7 +4647,7 @@ fn pattern_call_as_lhs_and_rhs() {
 fn test_import_all_already_there() {
     let root = get_fixtures_root().unwrap();
     let import_patterns = format!("{}/test_patterns/imports.grit", root.display());
-    let import_patterns = std::fs::read_to_string(import_patterns).unwrap();
+    let import_patterns = fs_err::read_to_string(import_patterns).unwrap();
 
     let pattern = r#"
 
@@ -4679,7 +4679,7 @@ fn test_import_all_already_there() {
 fn test_import_multiple() {
     let root = get_fixtures_root().unwrap();
     let import_patterns = format!("{}/test_patterns/imports.grit", root.display());
-    let import_patterns = std::fs::read_to_string(import_patterns).unwrap();
+    let import_patterns = fs_err::read_to_string(import_patterns).unwrap();
 
     let pattern = r#"
 

--- a/crates/gritcache/Cargo.toml
+++ b/crates/gritcache/Cargo.toml
@@ -17,6 +17,7 @@ marzano-gritmodule = { path = "../gritmodule", features = [
 ], default-features = false }
 anyhow = { version = "1.0.70" }
 marzano-util = { path = "../util", features = [], default-features = false }
+fs-err = { version = "2.11.0" }
 
 [dev-dependencies]
 marzano-util = { path = "../util", features = ["finder"] }

--- a/crates/gritcache/src/new_cache.rs
+++ b/crates/gritcache/src/new_cache.rs
@@ -51,7 +51,7 @@ impl ThreadedCache {
 
     fn reset(path: &PathBuf) -> Result<()> {
         let mut writer = BufWriter::new(
-            std::fs::OpenOptions::new()
+            fs_err::OpenOptions::new()
                 .create(true)
                 .write(true)
                 .truncate(true)
@@ -63,7 +63,7 @@ impl ThreadedCache {
     }
 
     fn initialize(path: &PathBuf) -> Result<HashMap<HashKey, bool>> {
-        let file_vector = match std::fs::read(path) {
+        let file_vector = match fs_err::read(path) {
             Ok(bytes) => bytes,
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
@@ -99,9 +99,9 @@ impl ThreadedCache {
         Ok(map)
     }
 
-    fn new_writer(path: &PathBuf) -> Result<BufWriter<std::fs::File>> {
+    fn new_writer(path: &PathBuf) -> Result<BufWriter<fs_err::File>> {
         let writer = BufWriter::new(
-            std::fs::OpenOptions::new()
+            fs_err::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(path)
@@ -182,7 +182,7 @@ mod tests {
 
         // Delete file if exists
         if mismatches_cache_path.exists() {
-            std::fs::remove_file(&mismatches_cache_path)?;
+            fs_err::remove_file(&mismatches_cache_path)?;
         }
 
         // assert cache creation fails gracefully on invalid paths
@@ -262,7 +262,7 @@ mod tests {
         manager.join().unwrap();
 
         // Delete file
-        std::fs::remove_file(mismatches_cache_path.clone())?;
+        fs_err::remove_file(mismatches_cache_path.clone())?;
         Ok(())
     }
 }

--- a/crates/gritmodule/Cargo.toml
+++ b/crates/gritmodule/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = { version = "0.11.22", features = ["blocking", "json"] }
 ignore = { version = "0.4.20" }
 homedir = { version = "0.2.1" }
 tracing = { version = "0.1.40", default-features = false, features = [] }
+fs-err = { version = "2.11.0" }
 
 [dev-dependencies]
 insta = { version = "1.30.0", features = ["yaml"] }

--- a/crates/gritmodule/src/fetcher.rs
+++ b/crates/gritmodule/src/fetcher.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use lazy_static::lazy_static;
-use std::fs;
+use fs_err;
 
 use crate::{config::GRIT_MODULE_DIR, searcher::find_git_dir_from, utils::remove_dir_all_safe};
 
@@ -270,7 +270,7 @@ fn reset_grit_modules(grit_modules_path: &Path) -> Result<()> {
     if grit_modules_path.exists() {
         remove_dir_all_safe(grit_modules_path)?;
     }
-    fs::create_dir_all(grit_modules_path)?;
+    fs_err::create_dir_all(grit_modules_path)?;
     Ok(())
 }
 
@@ -369,7 +369,7 @@ impl GritModuleFetcher for KeepFetcher {
     }
 
     fn prep_grit_modules(&self) -> Result<()> {
-        let _ = fs::create_dir_all(&self.clone_dir);
+        let _ = fs_err::create_dir_all(&self.clone_dir);
         Ok(())
     }
 }

--- a/crates/gritmodule/src/formatting.rs
+++ b/crates/gritmodule/src/formatting.rs
@@ -74,7 +74,7 @@ async fn format_temp_dir(dir: &TempDir, languages: Vec<&PatternLanguage>) -> Res
         let mut cmd = Command::new("google-java-format");
         cmd.current_dir(dir);
         cmd.arg("--replace");
-        for entry in std::fs::read_dir(dir)? {
+        for entry in fs_err::read_dir(dir.as_ref())? {
             let entry = entry?;
             if let Some(name) = entry.path().file_name() {
                 if let Some(name_str) = name.to_str() {
@@ -96,7 +96,7 @@ async fn format_temp_dir(dir: &TempDir, languages: Vec<&PatternLanguage>) -> Res
         let mut cmd = Command::new("gofmt");
         cmd.current_dir(dir);
         cmd.arg("-w");
-        for entry in std::fs::read_dir(dir)? {
+        for entry in fs_err::read_dir(dir.as_ref())? {
             let entry = entry?;
             if let Some(name) = entry.path().file_name() {
                 if let Some(name_str) = name.to_str() {
@@ -117,7 +117,7 @@ async fn format_temp_dir(dir: &TempDir, languages: Vec<&PatternLanguage>) -> Res
     if languages.contains(&&PatternLanguage::Rust) {
         let mut cmd = Command::new("rustfmt");
         cmd.current_dir(dir);
-        for entry in std::fs::read_dir(dir)? {
+        for entry in fs_err::read_dir(dir.as_ref())? {
             let entry = entry?;
             if let Some(name) = entry.path().file_name() {
                 if let Some(name_str) = name.to_str() {
@@ -139,7 +139,7 @@ async fn format_temp_dir(dir: &TempDir, languages: Vec<&PatternLanguage>) -> Res
         let mut cmd = Command::new("ruff");
         cmd.current_dir(dir);
         cmd.arg("format");
-        for entry in std::fs::read_dir(dir)? {
+        for entry in fs_err::read_dir(dir.as_ref())? {
             let entry = entry?;
             if let Some(name) = entry.path().file_name() {
                 if let Some(name_str) = name.to_str() {
@@ -162,7 +162,7 @@ async fn format_temp_dir(dir: &TempDir, languages: Vec<&PatternLanguage>) -> Res
         cmd.current_dir(dir);
         cmd.arg("fmt");
 
-        for entry in std::fs::read_dir(dir)? {
+        for entry in fs_err::read_dir(dir.as_ref())? {
             let entry = entry?;
             if let Some(name) = entry.path().file_name() {
                 if let Some(name_str) = name.to_str() {

--- a/crates/gritmodule/src/markdown.rs
+++ b/crates/gritmodule/src/markdown.rs
@@ -14,7 +14,7 @@ use marzano_language::language::MarzanoLanguage as _;
 use marzano_util::cursor_wrapper::CursorWrapper;
 use marzano_util::node_with_source::NodeWithSource;
 use marzano_util::rich_path::RichFile;
-use std::fs::OpenOptions;
+use fs_err::OpenOptions;
 use std::io::{Read, Seek, Write};
 use std::path::Path;
 use tokio::io::SeekFrom;

--- a/crates/gritmodule/src/searcher.rs
+++ b/crates/gritmodule/src/searcher.rs
@@ -116,7 +116,7 @@ async fn fetch_remote_workflow(workflow_path_or_name: &str) -> Result<WorkflowIn
     let temp_file_path = temp_dir.into_path().join("downloaded_workflow.ts");
     let response = reqwest::get(workflow_path_or_name).await?;
     let content = response.text().await?;
-    std::fs::write(&temp_file_path, content)?;
+    fs_err::write(&temp_file_path, content)?;
     Ok(WorkflowInfo {
         path: temp_file_path,
     })

--- a/crates/gritmodule/src/utils.rs
+++ b/crates/gritmodule/src/utils.rs
@@ -23,7 +23,7 @@ pub fn remove_dir_all_safe(dir: &Path) -> Result<()> {
     if current_exe()?.starts_with(canonicalize(dir)?) {
         bail!("Fatal error: refusing to remove the directory containing the current executable")
     }
-    std::fs::remove_dir_all(dir)?;
+    fs_err::remove_dir_all(dir)?;
     Ok(())
 }
 

--- a/crates/lsp/src/scan.rs
+++ b/crates/lsp/src/scan.rs
@@ -152,7 +152,7 @@ pub async fn make_pseudo_document(uri: &Url, client: &Client) -> Option<TextDocu
         uri.clone(),
         language_id,
         0,
-        std::fs::read_to_string(file_path).unwrap(),
+        fs_err::read_to_string(file_path).unwrap(),
     );
     Some(pseudo_document)
 }

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.35.1", optional = true }
 serde_json = { version = "1.0.114" }
 futures = { version = "0.3.29", optional = true }
 http = { version = "0.2.11" }
+fs-err = { version = "2.11.0" }
 
 
 napi = { version = "2.16.4", default-features = false, features = [

--- a/crates/util/fixtures/long_diff.diff
+++ b/crates/util/fixtures/long_diff.diff
@@ -780,7 +780,7 @@ index 6785249..0f8780c 100644
 -    assert!(String::from_utf8(output.stdout)?.contains("Processed 1 files and found 1 match"));
 +    assert!(stdout.contains("Processed 1 files and found 1 match"));
  
-     let content = std::fs::read_to_string(dir.join("index.js"))?;
+     let content = fs_err::read_to_string(dir.join("index.js"))?;
      assert!(!content.contains("console.log('really cool')"));
 diff --git a/crates/util/Cargo.toml b/crates/util/Cargo.toml
 index 042a67d..e20e595 100644

--- a/crates/util/src/finder.rs
+++ b/crates/util/src/finder.rs
@@ -30,7 +30,7 @@ pub fn get_canonical_paths(walker: Walk) -> Result<Vec<PathBuf>, std::io::Error>
 pub fn get_input_files(files: &[PathBuf]) -> Vec<RichPath> {
     files
         .iter()
-        .filter_map(|p| match std::fs::read_to_string(p) {
+        .filter_map(|p| match fs_err::read_to_string(p) {
             Ok(content) => {
                 let hash = hash(&content);
                 Some(RichPath::new(p.to_owned(), Some(hash)))

--- a/crates/util/src/rich_path.rs
+++ b/crates/util/src/rich_path.rs
@@ -106,7 +106,7 @@ impl TryIntoInputFile for RichFile {
 impl TryIntoInputFile for PathBuf {
     fn try_into_cow(&self) -> Result<Cow<RichFile>> {
         let name = self.to_string_lossy().to_string();
-        let content = std::fs::read_to_string(self).map_err(|e| anyhow!(e))?;
+        let content = fs_err::read_to_string(self).map_err(|e| anyhow!(e))?;
         Ok(Cow::Owned(RichFile::new(name, content)))
     }
 }
@@ -114,7 +114,7 @@ impl TryIntoInputFile for PathBuf {
 impl TryIntoInputFile for &RichPath {
     fn try_into_cow(&self) -> Result<Cow<RichFile>> {
         let name = self.path.to_string_lossy().to_string();
-        let content = std::fs::read_to_string(&self.path).map_err(|e| anyhow!(e))?;
+        let content = fs_err::read_to_string(&self.path).map_err(|e| anyhow!(e))?;
         Ok(Cow::Owned(RichFile::new(name, content)))
     }
 }


### PR DESCRIPTION
Have not replaced **tokio::fs** as **fs_err** crate does not handles asynchronous operations.

"cargo test" ran successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Improved file system error handling by integrating the `fs-err` library.

- **Refactor**
  - Replaced standard file system operations with `fs-err` across multiple modules for better error messaging and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->