### PR TITLE
fix: move fs_err to normal dep

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -75,10 +75,10 @@ tracing-opentelemetry = { version = "0.22.0", optional = true, default-features 
 tracing = { version = "0.1.40", default-features = false, features = [] }
 tracing-subscriber = { version = "0.3", default-features = false, optional = true }
 
+fs-err = { version = "2.11.0" }
+
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
-
-fs-err = { version = "2.11.0" }
 
 [dev-dependencies]
 trim-margin = "0.1.0"


### PR DESCRIPTION
Follow up to https://github.com/getgrit/gritql/pull/349, which accidentally broke Windows builds.