### PR TITLE
refactor: remove `AstNode::full_source()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "grit-pattern-matcher"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "elsa",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "grit-util"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "derive_builder",
  "napi",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "grit-wasm-bindings"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ai_builtins",
  "anyhow",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "marzano-gritmodule"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Iuvo AI, Inc.", "Grit Contributors"]
 description = "GritQL is a query language for searching, linting, and modifying code."
 repository = "https://github.com/getgrit/gritql/"

--- a/crates/core/src/inline_snippets.rs
+++ b/crates/core/src/inline_snippets.rs
@@ -1,7 +1,5 @@
-use crate::marzano_binding;
-use crate::marzano_binding::EffectRange;
 use anyhow::{anyhow, bail, Result};
-use grit_util::Language;
+use grit_util::{EffectRange, Language};
 use itertools::Itertools;
 use std::{cell::RefCell, collections::HashSet, ops::Range, rc::Rc};
 
@@ -113,8 +111,8 @@ fn pad_snippet(
         }
     }
 
-    let padding = padding.into_iter().collect::<String>();
-    marzano_binding::pad_snippet(&padding, snippet, language)
+    let padding: String = padding.into_iter().collect();
+    Ok(language.pad_snippet(snippet, &padding).to_string())
 }
 
 // checks on this one are likely redundant as

--- a/crates/core/src/marzano_context.rs
+++ b/crates/core/src/marzano_context.rs
@@ -238,9 +238,8 @@ impl<'a> ExecContext<'a, MarzanoQueryContext> for MarzanoContext<'a> {
                 .cloned()
                 .is_some()
             {
-                let code = file.tree.root_node();
                 let (new_src, new_ranges, adjustment_ranges) = apply_effects(
-                    code,
+                    &file.tree,
                     state.effects.clone(),
                     &state.files,
                     &file.name,
@@ -248,7 +247,6 @@ impl<'a> ExecContext<'a, MarzanoQueryContext> for MarzanoContext<'a> {
                     self,
                     logs,
                 )?;
-
 
                 if let (Some(new_ranges), Some(edit_ranges)) = (new_ranges, adjustment_ranges) {
                     let new_map = if let Some(old_map) = file.tree.source_map.as_ref() {

--- a/crates/core/src/marzano_resolved_pattern.rs
+++ b/crates/core/src/marzano_resolved_pattern.rs
@@ -7,14 +7,14 @@ use grit_pattern_matcher::{
     binding::Binding,
     constant::Constant,
     context::ExecContext,
-    effects::{Effect, EffectKind},
+    effects::Effect,
     pattern::{
         to_unsigned, Accessor, DynamicPattern, DynamicSnippet, DynamicSnippetPart, File, FilePtr,
         FileRegistry, GritCall, ListIndex, Pattern, PatternName, PatternOrResolved, ResolvedFile,
         ResolvedPattern, ResolvedSnippet, State,
     },
 };
-use grit_util::{AnalysisLogs, Ast, AstNode, CodeRange, Range};
+use grit_util::{AnalysisLogs, Ast, AstNode, CodeRange, EffectKind, Range};
 use im::{vector, Vector};
 use marzano_language::{language::FieldId, target_language::TargetLanguage};
 use marzano_util::node_with_source::NodeWithSource;

--- a/crates/core/src/problem.rs
+++ b/crates/core/src/problem.rs
@@ -503,5 +503,5 @@ impl QueryContext for MarzanoQueryContext {
     type ResolvedPattern<'a> = MarzanoResolvedPattern<'a>;
     type Language<'a> = TargetLanguage;
     type File<'a> = MarzanoFile<'a>;
-    type Tree = Tree;
+    type Tree<'a> = Tree;
 }

--- a/crates/grit-pattern-matcher/Cargo.toml
+++ b/crates/grit-pattern-matcher/Cargo.toml
@@ -18,7 +18,7 @@ rust.unused_crate_dependencies = "warn"
 anyhow = { version = "1.0.70" }
 elsa = { version = "1.9.0" }
 getrandom = { version = "0.2.11", optional = true }
-grit-util = { path = "../grit-util", version = "0.2.0" }
+grit-util = { path = "../grit-util", version = "0.3.0" }
 im = { version = "15.1.0" }
 itertools = { version = "0.10.5" }
 rand = { version = "0.8.5" }

--- a/crates/grit-pattern-matcher/src/context.rs
+++ b/crates/grit-pattern-matcher/src/context.rs
@@ -20,7 +20,7 @@ pub trait QueryContext: Clone + std::fmt::Debug + Sized + 'static {
     type ResolvedPattern<'a>: ResolvedPattern<'a, Self>;
     type Language<'a>: Language<Node<'a> = Self::Node<'a>>;
     type File<'a>: File<'a, Self>;
-    type Tree: Ast + Clone;
+    type Tree<'a>: Ast<Node<'a> = Self::Node<'a>> + Clone;
 }
 
 /// Contains context necessary for query execution.
@@ -53,7 +53,7 @@ pub trait ExecContext<'a, Q: QueryContext> {
     ) -> Result<bool>;
 
     // FIXME: Don't depend on Grit's file handling in Context.
-    fn files(&self) -> &FileOwners<Q::Tree>;
+    fn files(&self) -> &FileOwners<Q::Tree<'a>>;
 
     fn language(&self) -> &Q::Language<'a>;
 

--- a/crates/grit-pattern-matcher/src/effects.rs
+++ b/crates/grit-pattern-matcher/src/effects.rs
@@ -1,10 +1,5 @@
 use crate::context::QueryContext;
-
-#[derive(Debug, Clone)]
-pub enum EffectKind {
-    Rewrite,
-    Insert,
-}
+use grit_util::EffectKind;
 
 #[derive(Debug, Clone)]
 pub struct Effect<'a, Q: QueryContext> {

--- a/crates/grit-pattern-matcher/src/intervals.rs
+++ b/crates/grit-pattern-matcher/src/intervals.rs
@@ -1,4 +1,5 @@
-use crate::{context::QueryContext, effects::EffectKind, pattern::EffectRange};
+use crate::{context::QueryContext, pattern::EffectRange};
+use grit_util::EffectKind;
 use std::{cmp::Ordering, ops::Range};
 
 pub trait Interval {

--- a/crates/grit-pattern-matcher/src/pattern/accumulate.rs
+++ b/crates/grit-pattern-matcher/src/pattern/accumulate.rs
@@ -5,13 +5,9 @@ use super::{
     resolved_pattern::ResolvedPattern,
     State,
 };
-use crate::{
-    context::ExecContext,
-    context::QueryContext,
-    effects::{Effect, EffectKind},
-};
+use crate::{context::ExecContext, context::QueryContext, effects::Effect};
 use anyhow::{bail, Result};
-use grit_util::AnalysisLogs;
+use grit_util::{AnalysisLogs, EffectKind};
 use std::borrow::Cow;
 
 #[derive(Debug, Clone)]

--- a/crates/grit-pattern-matcher/src/pattern/rewrite.rs
+++ b/crates/grit-pattern-matcher/src/pattern/rewrite.rs
@@ -6,13 +6,10 @@ use super::{
     variable_content::VariableContent,
     State,
 };
-use crate::{
-    context::QueryContext,
-    effects::{Effect, EffectKind},
-};
+use crate::{context::QueryContext, effects::Effect};
 use anyhow::{bail, Result};
 use core::fmt::Debug;
-use grit_util::AnalysisLogs;
+use grit_util::{AnalysisLogs, EffectKind};
 use std::borrow::Cow;
 
 #[derive(Debug, Clone)]

--- a/crates/grit-pattern-matcher/src/pattern/state.rs
+++ b/crates/grit-pattern-matcher/src/pattern/state.rs
@@ -34,11 +34,11 @@ pub struct FileRegistry<'a, Q: QueryContext> {
     /// Original file paths, for lazy loading
     file_paths: Vec<&'a PathBuf>,
     /// The actual FileOwner, which has the full file available
-    owners: Vector<Vector<&'a FileOwner<Q::Tree>>>,
+    owners: Vector<Vector<&'a FileOwner<Q::Tree<'a>>>>,
 }
 
 impl<'a, Q: QueryContext> FileRegistry<'a, Q> {
-    pub fn get_file_owner(&self, pointer: FilePtr) -> &'a FileOwner<Q::Tree> {
+    pub fn get_file_owner(&self, pointer: FilePtr) -> &'a FileOwner<Q::Tree<'a>> {
         self.owners[pointer.file as usize][pointer.version as usize]
     }
 
@@ -86,7 +86,7 @@ impl<'a, Q: QueryContext> FileRegistry<'a, Q> {
     }
 
     /// Load a file in
-    pub fn load_file(&mut self, pointer: &FilePtr, file: &'a FileOwner<Q::Tree>) {
+    pub fn load_file(&mut self, pointer: &FilePtr, file: &'a FileOwner<Q::Tree<'a>>) {
         self.push_revision(pointer, file)
     }
 
@@ -108,16 +108,16 @@ impl<'a, Q: QueryContext> FileRegistry<'a, Q> {
         }
     }
 
-    pub fn files(&self) -> &Vector<Vector<&'a FileOwner<Q::Tree>>> {
+    pub fn files(&self) -> &Vector<Vector<&'a FileOwner<Q::Tree<'a>>>> {
         &self.owners
     }
 
-    pub fn push_revision(&mut self, pointer: &FilePtr, file: &'a FileOwner<Q::Tree>) {
+    pub fn push_revision(&mut self, pointer: &FilePtr, file: &'a FileOwner<Q::Tree<'a>>) {
         self.version_count[pointer.file as usize] += 1;
         self.owners[pointer.file as usize].push_back(file)
     }
 
-    pub fn push_new_file(&mut self, file: &'a FileOwner<Q::Tree>) -> FilePtr {
+    pub fn push_new_file(&mut self, file: &'a FileOwner<Q::Tree<'a>>) -> FilePtr {
         self.version_count.push(1);
         self.file_paths.push(&file.name);
         self.owners.push_back(vector![file]);

--- a/crates/grit-util/src/ast_node.rs
+++ b/crates/grit-util/src/ast_node.rs
@@ -42,10 +42,6 @@ pub trait AstNode: std::fmt::Debug + Sized {
     /// Returns the code range of the node.
     fn code_range(&self) -> CodeRange;
 
-    /// Returns the full source code of the parse tree to which the node
-    /// belongs.
-    fn full_source(&self) -> &str;
-
     /// Returns a cursor for traversing the tree, starting at the current node.
     fn walk(&self) -> impl AstCursor<Node = Self>;
 }

--- a/crates/grit-util/src/code_range.rs
+++ b/crates/grit-util/src/code_range.rs
@@ -31,4 +31,9 @@ impl CodeRange {
         let address = thin_ptr as usize;
         self.address == address
     }
+
+    /// Returns whether the given index is contained within the range.
+    pub fn contains(&self, index: u32) -> bool {
+        self.start <= index && self.end > index
+    }
 }

--- a/crates/grit-util/src/effect_kind.rs
+++ b/crates/grit-util/src/effect_kind.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone)]
+pub enum EffectKind {
+    Rewrite,
+    Insert,
+}

--- a/crates/grit-util/src/language.rs
+++ b/crates/grit-util/src/language.rs
@@ -1,4 +1,6 @@
-use crate::{constants::*, traverse, AstNode, ByteRange, CodeRange, Order, Range};
+use std::borrow::Cow;
+
+use crate::{constants::*, ranges::EffectRange, AstNode, ByteRange, CodeRange, Range};
 use regex::Regex;
 
 pub enum GritMetaValue {
@@ -60,29 +62,22 @@ pub trait Language: Sized {
         Some(node.byte_range())
     }
 
-    // in languages we pad such as python or yaml there are
-    // some kinds of nodes we don't want to pad, such as python strings.
-    // this function identifies those nodes.
-    #[allow(unused_variables)]
-    fn should_skip_padding(&self, node: &Self::Node<'_>) -> bool {
-        false
-    }
+    /// Removes the padding from every line in the snippet identified by the
+    /// given `range`, such that the first line of the snippet is left-aligned.
+    fn align_padding<'a>(
+        &self,
+        node: &Self::Node<'a>,
+        range: &CodeRange,
+        skip_ranges: &[CodeRange],
+        new_padding: Option<usize>,
+        offset: usize,
+        substitutions: &mut [(EffectRange, String)],
+    ) -> Cow<'a, str>;
 
-    #[allow(unused_variables)]
-    fn get_skip_padding_ranges_for_snippet(&self, snippet: &str) -> Vec<CodeRange> {
-        Vec::new()
-    }
-
-    #[allow(unused_variables)]
-    fn get_skip_padding_ranges(&self, node: &Self::Node<'_>) -> Vec<CodeRange> {
-        let mut ranges = Vec::new();
-        for n in traverse(node.walk(), Order::Pre) {
-            if self.should_skip_padding(&n) {
-                ranges.push(n.code_range())
-            }
-        }
-        ranges
-    }
+    /// Pads `snippet` by applying the given `padding` to every line.
+    ///
+    /// Takes padding rules for whitespace-significant languages into account.
+    fn pad_snippet<'a>(&self, snippet: &'a str, padding: &str) -> Cow<'a, str>;
 
     fn substitute_metavariable_prefix(&self, src: &str) -> String {
         self.metavariable_regex()
@@ -125,6 +120,8 @@ pub trait Language: Sized {
             None
         }
     }
+
+    fn get_skip_padding_ranges(&self, node: &Self::Node<'_>) -> Vec<CodeRange>;
 
     /// Whether snippets should be padded.
     ///

--- a/crates/grit-util/src/lib.rs
+++ b/crates/grit-util/src/lib.rs
@@ -3,6 +3,7 @@ mod ast_node;
 mod ast_node_traversal;
 mod code_range;
 pub mod constants;
+mod effect_kind;
 mod language;
 mod parser;
 mod position;
@@ -12,10 +13,11 @@ pub use analysis_logs::{AnalysisLog, AnalysisLogBuilder, AnalysisLogs};
 pub use ast_node::AstNode;
 pub use ast_node_traversal::{traverse, AstCursor, Order};
 pub use code_range::CodeRange;
+pub use effect_kind::EffectKind;
 pub use language::{GritMetaValue, Language, Replacement};
 pub use parser::{Ast, FileOrigin, Parser, SnippetTree};
 pub use position::Position;
 pub use ranges::{
-    ByteRange, FileRange, InputRanges, MatchRanges, Range, RangeWithoutByte, UtilRange,
-    VariableBinding, VariableMatch,
+    ByteRange, EffectRange, FileRange, InputRanges, MatchRanges, Range, RangeWithoutByte,
+    UtilRange, VariableBinding, VariableMatch,
 };

--- a/crates/grit-util/src/parser.rs
+++ b/crates/grit-util/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::{AnalysisLogs, AstNode};
-use std::{marker::PhantomData, path::Path};
+use std::{borrow::Cow, marker::PhantomData, path::Path};
 
 /// Information on where a file came from, for the parser to be smarter
 #[derive(Clone, Debug)]
@@ -49,6 +49,9 @@ pub trait Ast: std::fmt::Debug + PartialEq + Sized {
         Self: 'a;
 
     fn root_node(&self) -> Self::Node<'_>;
+
+    /// Returns the full source code of the tree.
+    fn source(&self) -> Cow<str>;
 }
 
 #[derive(Clone, Debug)]

--- a/crates/grit-util/src/ranges.rs
+++ b/crates/grit-util/src/ranges.rs
@@ -1,4 +1,4 @@
-use crate::Position;
+use crate::{EffectKind, Position};
 use serde::{Deserialize, Serialize};
 use std::{ops::Add, path::PathBuf};
 
@@ -345,5 +345,30 @@ mod tests {
         let range = ByteRange::new(15, 17);
         let new_range = range.to_char_range("const [µb, fµa]");
         assert_eq!(new_range, ByteRange::new(13, 15));
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EffectRange {
+    pub kind: EffectKind,
+    pub range: std::ops::Range<usize>,
+}
+
+impl EffectRange {
+    pub fn new(kind: EffectKind, range: std::ops::Range<usize>) -> Self {
+        Self { kind, range }
+    }
+
+    pub fn start(&self) -> usize {
+        self.range.start
+    }
+
+    // The range which is actually edited by this effect
+    // This is used for most operations, but does not account for expansion from deleted commas
+    pub fn effective_range(&self) -> std::ops::Range<usize> {
+        match self.kind {
+            EffectKind::Rewrite => self.range.clone(),
+            EffectKind::Insert => self.range.end..self.range.end,
+        }
     }
 }

--- a/crates/language/src/csharp.rs
+++ b/crates/language/src/csharp.rs
@@ -52,7 +52,7 @@ impl NodeTypes for CSharp {
 }
 
 impl Language for CSharp {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "CSharp"
@@ -60,14 +60,6 @@ impl Language for CSharp {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 }
 

--- a/crates/language/src/css.rs
+++ b/crates/language/src/css.rs
@@ -58,7 +58,7 @@ impl NodeTypes for Css {
 }
 
 impl Language for Css {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "CSS"
@@ -70,14 +70,6 @@ impl Language for Css {
             ("GRIT_BLOCK { ", " }"),
             ("GRIT_BLOCK { GRIT_PROPERTY: ", " }"),
         ]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/go.rs
+++ b/crates/language/src/go.rs
@@ -51,7 +51,7 @@ impl NodeTypes for Go {
 }
 
 impl Language for Go {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "Go"
@@ -65,14 +65,6 @@ impl Language for Go {
             ("func GRIT_FUNC(GRIT_ARG *", ".GRIT_TYPE) {}"),
             ("func GRIT_FUNC(GRIT_ARG *GRIT_PACKAGE.", ") {}"),
         ]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 }
 

--- a/crates/language/src/hcl.rs
+++ b/crates/language/src/hcl.rs
@@ -51,7 +51,7 @@ impl NodeTypes for Hcl {
 }
 
 impl Language for Hcl {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "HCL"
@@ -59,14 +59,6 @@ impl Language for Hcl {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", ""), ("GRIT_VAL = ", ""), ("GRIT_ID = { ", " }")]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -52,7 +52,7 @@ impl NodeTypes for Html {
 }
 
 impl Language for Html {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "HTML"
@@ -60,14 +60,6 @@ impl Language for Html {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/java.rs
+++ b/crates/language/src/java.rs
@@ -53,7 +53,7 @@ impl Java {
     }
 }
 impl Language for Java {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "Java"
@@ -67,14 +67,6 @@ impl Language for Java {
             ("class GRIT_CLASS { ", " GRIT_FUNCTION() {} }"),
             ("class GRIT_CLASS { GRIT_FN(", ") {} }"),
         ]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 }
 

--- a/crates/language/src/javascript.rs
+++ b/crates/language/src/javascript.rs
@@ -77,7 +77,7 @@ impl NodeTypes for JavaScript {
 }
 
 impl Language for JavaScript {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_js_like_delegate!();
 
     fn language_name(&self) -> &'static str {
         "JavaScript"
@@ -105,10 +105,6 @@ impl Language for JavaScript {
         ]
     }
 
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
     fn is_metavariable(&self, node: &NodeWithSource) -> bool {
         js_like_is_metavariable(node, self, &["template_content"])
     }
@@ -129,10 +125,6 @@ impl Language for JavaScript {
         } else {
             None
         }
-    }
-
-    fn check_replacements(&self, n: NodeWithSource<'_>, orphan_ranges: &mut Vec<Replacement>) {
-        jslike_check_replacements(n, orphan_ranges)
     }
 }
 

--- a/crates/language/src/json.rs
+++ b/crates/language/src/json.rs
@@ -51,7 +51,7 @@ impl Json {
 }
 
 impl Language for Json {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "JSON"
@@ -59,14 +59,6 @@ impl Language for Json {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", ""), ("{ ", " }")]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 }
 

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -1,3 +1,61 @@
+macro_rules! use_marzano_base_delegate {
+    () => {
+        type Node<'a> = NodeWithSource<'a>;
+
+        fn align_padding<'a>(
+            &self,
+            node: &Self::Node<'a>,
+            range: &grit_util::CodeRange,
+            skip_ranges: &[grit_util::CodeRange],
+            new_padding: Option<usize>,
+            offset: usize,
+            substitutions: &mut [(grit_util::EffectRange, String)],
+        ) -> std::borrow::Cow<'a, str> {
+            MarzanoLanguage::align_padding(
+                self,
+                node,
+                range,
+                skip_ranges,
+                new_padding,
+                offset,
+                substitutions,
+            )
+        }
+
+        fn pad_snippet<'a>(&self, snippet: &'a str, padding: &str) -> std::borrow::Cow<'a, str> {
+            MarzanoLanguage::pad_snippet(self, snippet, padding)
+        }
+
+        fn get_skip_padding_ranges(&self, node: &Self::Node<'_>) -> Vec<grit_util::CodeRange> {
+            MarzanoLanguage::get_skip_padding_ranges(self, node)
+        }
+
+        fn is_comment(&self, node: &NodeWithSource) -> bool {
+            MarzanoLanguage::is_comment_node(self, node)
+        }
+    };
+}
+
+macro_rules! use_marzano_js_like_delegate {
+    () => {
+        use_marzano_base_delegate!();
+
+        fn check_replacements(&self, n: NodeWithSource<'_>, replacements: &mut Vec<Replacement>) {
+            jslike_check_replacements(n, replacements)
+        }
+    };
+}
+
+macro_rules! use_marzano_delegate {
+    () => {
+        use_marzano_base_delegate!();
+
+        fn is_metavariable(&self, node: &NodeWithSource) -> bool {
+            MarzanoLanguage::is_metavariable_node(self, node)
+        }
+    };
+}
+
 pub mod csharp;
 pub mod css;
 pub mod foreign_language;

--- a/crates/language/src/markdown_block.rs
+++ b/crates/language/src/markdown_block.rs
@@ -50,7 +50,7 @@ impl MarkdownBlock {
 }
 
 impl Language for MarkdownBlock {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "MarkdownBlock"
@@ -58,14 +58,6 @@ impl Language for MarkdownBlock {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/markdown_inline.rs
+++ b/crates/language/src/markdown_inline.rs
@@ -50,7 +50,7 @@ impl NodeTypes for MarkdownInline {
 }
 
 impl Language for MarkdownInline {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "MarkdownInline"
@@ -58,14 +58,6 @@ impl Language for MarkdownInline {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/php.rs
+++ b/crates/language/src/php.rs
@@ -59,7 +59,7 @@ impl NodeTypes for Php {
 }
 
 impl Language for Php {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "PhpWithHTML"
@@ -71,14 +71,6 @@ impl Language for Php {
 
     fn comment_prefix(&self) -> &'static str {
         "//"
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn metavariable_prefix(&self) -> &'static str {

--- a/crates/language/src/php_only.rs
+++ b/crates/language/src/php_only.rs
@@ -60,7 +60,7 @@ impl NodeTypes for PhpOnly {
 }
 
 impl Language for PhpOnly {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "PhpOnly"
@@ -72,14 +72,6 @@ impl Language for PhpOnly {
 
     fn comment_prefix(&self) -> &'static str {
         "//"
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn metavariable_prefix(&self) -> &'static str {

--- a/crates/language/src/python.rs
+++ b/crates/language/src/python.rs
@@ -58,7 +58,7 @@ impl NodeTypes for Python {
 }
 
 impl Language for Python {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "Python"
@@ -75,14 +75,6 @@ impl Language for Python {
 
     fn comment_prefix(&self) -> &'static str {
         "#"
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn check_replacements(&self, n: NodeWithSource<'_>, replacements: &mut Vec<Replacement>) {
@@ -152,17 +144,6 @@ impl Language for Python {
         true
     }
 
-    fn should_skip_padding(&self, node: &NodeWithSource<'_>) -> bool {
-        self.skip_padding_sorts.contains(&node.node.kind_id())
-    }
-
-    fn get_skip_padding_ranges_for_snippet(&self, snippet: &str) -> Vec<CodeRange> {
-        let mut parser = self.get_parser();
-        let snippet = parser.parse_snippet("", snippet, "");
-        let root = snippet.tree.root_node();
-        self.get_skip_padding_ranges(&root)
-    }
-
     fn make_single_line_comment(&self, text: &str) -> String {
         format!("# {}\n", text)
     }
@@ -183,6 +164,17 @@ impl<'a> MarzanoLanguage<'a> for Python {
 
     fn get_parser(&self) -> Box<dyn Parser<Tree = Tree>> {
         Box::new(MarzanoNotebookParser::new(self, "python"))
+    }
+
+    fn should_skip_padding(&self, node: &NodeWithSource<'_>) -> bool {
+        self.skip_padding_sorts.contains(&node.node.kind_id())
+    }
+
+    fn get_skip_padding_ranges_for_snippet(&self, snippet: &str) -> Vec<CodeRange> {
+        let mut parser = self.get_parser();
+        let snippet = parser.parse_snippet("", snippet, "");
+        let root = snippet.tree.root_node();
+        MarzanoLanguage::get_skip_padding_ranges(self, &root)
     }
 }
 

--- a/crates/language/src/ruby.rs
+++ b/crates/language/src/ruby.rs
@@ -63,7 +63,7 @@ lazy_static! {
 }
 
 impl Language for Ruby {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "Ruby"
@@ -80,14 +80,6 @@ impl Language for Ruby {
 
     fn comment_prefix(&self) -> &'static str {
         "#"
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn metavariable_prefix(&self) -> &'static str {

--- a/crates/language/src/rust.rs
+++ b/crates/language/src/rust.rs
@@ -105,7 +105,7 @@ impl NodeTypes for Rust {
 }
 
 impl Language for Rust {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "Rust"
@@ -119,14 +119,6 @@ impl Language for Rust {
             ("fn GRIT_FN(", ") {}"),
             ("fn GRIT_FN(GRIT_ARG:", ") { }"),
         ]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 }
 

--- a/crates/language/src/solidity.rs
+++ b/crates/language/src/solidity.rs
@@ -52,7 +52,7 @@ impl NodeTypes for Solidity {
 }
 
 impl Language for Solidity {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "Solidity"
@@ -64,14 +64,6 @@ impl Language for Solidity {
             ("function GRIT_FUNCTION() { ", " }"),
             ("function GRIT_FUNCTION() { ", "; }"),
         ]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 }
 

--- a/crates/language/src/sql.rs
+++ b/crates/language/src/sql.rs
@@ -51,7 +51,7 @@ impl NodeTypes for Sql {
 }
 
 impl Language for Sql {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "SQL"
@@ -71,14 +71,6 @@ impl Language for Sql {
                 ";",
             ),
         ]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/target_language.rs
+++ b/crates/language/src/target_language.rs
@@ -498,21 +498,43 @@ macro_rules! generate_target_language {
                 }
             }
 
+            fn align_padding<'a>(
+                &self,
+                node: &Self::Node<'a>,
+                range: &CodeRange,
+                skip_ranges: &[CodeRange],
+                new_padding: Option<usize>,
+                offset: usize,
+                substitutions: &mut [(grit_util::EffectRange, String)],
+            ) -> std::borrow::Cow<'a, str> {
+                match self {
+                    $(Self::$language(lang) => Language::align_padding(
+                        lang,
+                        node,
+                        range,
+                        skip_ranges,
+                        new_padding,
+                        offset,
+                        substitutions
+                    )),+
+                }
+            }
+
+            fn pad_snippet<'a>(&self, snippet: &'a str, padding: &str) -> std::borrow::Cow<'a, str> {
+                match self {
+                    $(Self::$language(lang) => Language::pad_snippet(lang, snippet, padding)),+
+                }
+            }
+
+            fn get_skip_padding_ranges(&self, node: &Self::Node<'_>) -> Vec<grit_util::CodeRange> {
+                match self {
+                    $(Self::$language(lang) => Language::get_skip_padding_ranges(lang, node)),+
+                }
+            }
+
             fn should_pad_snippet(&self) -> bool {
                 match self {
                     $(Self::$language(lang) => Language::should_pad_snippet(lang)),+
-                }
-            }
-
-            fn should_skip_padding(&self, node: &NodeWithSource<'_>) -> bool {
-                match self {
-                    $(Self::$language(lang) => Language::should_skip_padding(lang, node)),+
-                }
-            }
-
-            fn get_skip_padding_ranges_for_snippet(&self, snippet: &str) -> Vec<CodeRange> {
-                match self {
-                    $(Self::$language(lang) => Language::get_skip_padding_ranges_for_snippet(lang, snippet)),+
                 }
             }
 

--- a/crates/language/src/toml.rs
+++ b/crates/language/src/toml.rs
@@ -51,7 +51,7 @@ impl NodeTypes for Toml {
 }
 
 impl Language for Toml {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "Toml"
@@ -59,14 +59,6 @@ impl Language for Toml {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/tsx.rs
+++ b/crates/language/src/tsx.rs
@@ -76,7 +76,7 @@ impl NodeTypes for Tsx {
 }
 
 impl Language for Tsx {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_js_like_delegate!();
 
     fn language_name(&self) -> &'static str {
         "TSX"
@@ -105,10 +105,6 @@ impl Language for Tsx {
         ]
     }
 
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
     fn is_metavariable(&self, node: &NodeWithSource) -> bool {
         js_like_is_metavariable(
             node,
@@ -133,10 +129,6 @@ impl Language for Tsx {
         } else {
             None
         }
-    }
-
-    fn check_replacements(&self, n: NodeWithSource<'_>, orphan_ranges: &mut Vec<Replacement>) {
-        jslike_check_replacements(n, orphan_ranges)
     }
 }
 

--- a/crates/language/src/typescript.rs
+++ b/crates/language/src/typescript.rs
@@ -72,7 +72,7 @@ impl NodeTypes for TypeScript {
 }
 
 impl Language for TypeScript {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_js_like_delegate!();
 
     fn language_name(&self) -> &'static str {
         "TypeScript"
@@ -101,10 +101,6 @@ impl Language for TypeScript {
         ]
     }
 
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
     fn is_metavariable(&self, node: &NodeWithSource) -> bool {
         js_like_is_metavariable(
             node,
@@ -129,10 +125,6 @@ impl Language for TypeScript {
         } else {
             None
         }
-    }
-
-    fn check_replacements(&self, n: NodeWithSource<'_>, replacements: &mut Vec<Replacement>) {
-        jslike_check_replacements(n, replacements)
     }
 }
 

--- a/crates/language/src/vue.rs
+++ b/crates/language/src/vue.rs
@@ -53,7 +53,7 @@ impl NodeTypes for Vue {
 }
 
 impl Language for Vue {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "Vue"
@@ -61,14 +61,6 @@ impl Language for Vue {
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[("", "")]
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     fn make_single_line_comment(&self, text: &str) -> String {

--- a/crates/language/src/yaml.rs
+++ b/crates/language/src/yaml.rs
@@ -69,7 +69,7 @@ impl NodeTypes for Yaml {
 }
 
 impl Language for Yaml {
-    type Node<'a> = NodeWithSource<'a>;
+    use_marzano_delegate!();
 
     fn language_name(&self) -> &'static str {
         "YAML"
@@ -81,14 +81,6 @@ impl Language for Yaml {
 
     fn comment_prefix(&self) -> &'static str {
         "#"
-    }
-
-    fn is_comment(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_comment_node(self, node)
-    }
-
-    fn is_metavariable(&self, node: &NodeWithSource) -> bool {
-        MarzanoLanguage::is_metavariable_node(self, node)
     }
 
     // Given a character, return the character that should be used to pad the snippet (if any)

--- a/crates/util/src/node_with_source.rs
+++ b/crates/util/src/node_with_source.rs
@@ -142,10 +142,6 @@ impl<'a> AstNode for NodeWithSource<'a> {
         CodeRange::new(self.node.start_byte(), self.node.end_byte(), self.source)
     }
 
-    fn full_source(&self) -> &str {
-        self.source
-    }
-
     fn walk(&self) -> impl AstCursor<Node = Self> {
         CursorWrapper::new(self.node.walk(), self.source)
     }


### PR DESCRIPTION
This PR removes the `full_source()` from the `AstNode` trait and the `NodeWithSource` implementation. The motivation for this change is that the method proved problematic to implement with Biome's CST. Conceptually the method was of course also a bit strange, since it asks an individual node to retrieve the source of the entire tree.

Fortunately, the method was only used in 2 places:
- Inside `apply_effects()`. This one was relatively easy to update, since the function was only called with the root node anyway. So instead of passing a node, we now pass the tree. A new `source()` method was added to the `Ast` trait, where it makes more sense.
- For grabbing the source to pass to `adjust_padding()`. This one was more tricky to resolve, and the bulk of this PR is in the changes it caused. To resolve it, I removed `adjust_padding()` as it existed and added a new `align_padding()` to the `Language` trait (the semantics remained the same, but the rename seemed more fitting). Apart from moving the method, its signature changed to receive a `Node` instead of `src: &str`. For the Marzano implementation this seems a trivial change, since it simply grabs the source from the `Node` anyway, but it will allow the Biome implementation to use CST traversal to determine the surrounding padding.

Together with `adjust_padding()`, `pad_snippet()` was moved as well. And because of the added methods on the `Language` trait, all the language implementations needed updates as well. I've added a few small macros to streamline their implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method `contains` in the `CodeRange` struct for checking if an index is within a range.
  - Added `EffectKind` enum with variants `Rewrite` and `Insert`.

- **Refactor**
  - Updated version to "0.3.0" and added "Grit Contributors" to authors list.
  - Reorganized imports and method calls for padding snippets.
  - Refactored `MarzanoContext` and `ExecContext` method signatures.
  - Replaced local definitions of `EffectKind` with imports from `grit_util`.
  - Introduced macros for delegate usage in language implementations.

- **Bug Fixes**
  - Removed outdated methods and functions related to padding and effect ranges, ensuring better alignment and processing.

- **Chores**
  - Updated dependencies across multiple crates to ensure compatibility with new versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->