### PR TITLE
chore: disable releases on GitHub

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,2 +1,3 @@
 [workspace]
 allow_dirty = true
+git_release_enable = false


### PR DESCRIPTION
We use GitHub releases for distributing the Grit binary, so release-plz should not be used for this purpose. Crates are sufficient.