### PR TITLE
chore: use namespace runners for all jobs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on:
-      - ubuntu-latest
+      - nscloud-ubuntu-22.04-amd64-8x32
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   release-plz:
     name: release-plz
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-22.04-amd64-8x32
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
They are cheaper and faster than GitHub runners.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Switched `test-rust` and `test-rust-wasm` jobs to `nscloud-ubuntu-22.04-amd64-8x32` runners
- Switched `test-stdlib` job to `nscloud-ubuntu-22.04-amd64-4x16` runner
- Updated `release-plz` job to use `nscloud-ubuntu-22.04-amd64-8x32` runner

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI/CD workflows to use a more specific operating system configuration for job runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->