### PR TITLE
feat: send user name with workflow requests

### DIFF
--- a/crates/auth/src/info.rs
+++ b/crates/auth/src/info.rs
@@ -81,13 +81,13 @@ mod tests {
     #[test]
     fn test_get_user_name() {
         // This token is safe, it isn't signed by a real authority - only use for testing
-        let jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2F1dGgwLmdyaXQuaW8vIiwic3ViIjoiZ2l0aHVifDE2Mjc4MDEiLCJhdWQiOiJodHRwczovL2FwaTIuZ3JpdC5pbyIsImlhdCI6MTcxODcyNjM1MywiZXhwIjoxNzE4ODEyNzUzLCJzY29wZSI6Im9mZmxpbmVfYWNjZXNzIiwiaHR0cHM6Ly9oYXN1cmEuaW8vand0L2NsYWltcyI6eyJ4LWhhc3VyYS1kZWZhdWx0LXJvbGUiOiJ1c2VyIiwieC1oYXN1cmEtYWxsb3dlZC1yb2xlcyI6WyJ1c2VyIl0sIngtaGFzdXJhLXVzZXItaWQiOiJnaXRodWJ8MTYyNzgwMSIsIngtaGFzdXJhLXJhdy1uaWNrbmFtZSI6Im5hbmN5IiwieC1oYXN1cmEtdXNlci10ZW5hbnQiOiJnaXRodWIiLCJ4LWhhc3VyYS1hdXRoLXByb3ZpZGVyIjoiZ2l0aHViIiwieC1oYXN1cmEtdXNlci1uaWNrbmFtZSI6ImdpdGh1YnxuYW5jeSJ9fQ.UNiKbUgbITr4aKhZuwEwXzmjeH6kyHxQjQiL4YODGWY";
+        let jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2hhc3VyYS5pby9qd3QvY2xhaW1zIjp7IngtaGFzdXJhLWRlZmF1bHQtcm9sZSI6InVzZXIiLCJ4LWhhc3VyYS1hbGxvd2VkLXJvbGVzIjpbInVzZXIiXSwieC1oYXN1cmEtdXNlci1pZCI6ImdpdGh1YnwxNjI3ODAxIiwieC1oYXN1cmEtcmF3LW5pY2tuYW1lIjoibW9yZ2FudGUiLCJ4LWhhc3VyYS11c2VyLXRlbmFudCI6ImdpdGh1YiIsIngtaGFzdXJhLWF1dGgtcHJvdmlkZXIiOiJnaXRodWIiLCJ4LWhhc3VyYS11c2VyLW5pY2tuYW1lIjoiZ2l0aHVifG1vcmdhbnRlIn0sImlzcyI6Imh0dHBzOi8vYXV0aDAuZ3JpdC5pby8iLCJzdWIiOiJnaXRodWJ8MTYyNzgwMSIsImF1ZCI6Imh0dHBzOi8vYXBpMi5ncml0LmlvIiwiaWF0IjoxNzE4NzI2MzUzLCJleHAiOjE3MTg4MTI3NTN9.eEU0bSldfdxuWpXAKfWAuJBqTMR5BAdnAEhFu-hVlI4";
         let auth_info = AuthInfo {
             access_token: jwt.to_string(),
         };
 
         match auth_info.get_user_name() {
-            Ok(Some(username)) => assert_eq!(username, "nancy"),
+            Ok(Some(username)) => assert_eq!(username, "morgante"),
             Ok(None) => panic!("Username not found"),
             Err(e) => panic!("Error occurred: {}", e),
         }

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -86,10 +86,14 @@ pub(crate) async fn run_doctor(_arg: DoctorArgs) -> Result<()> {
                 (auth.get_user_id()?).to_string().yellow()
             );
 
+            if let Some(username) = auth.get_user_name()? {
+                info!("  Auth user name: {}", username.yellow());
+            }
+
             if auth.is_expired()? {
                 info!(
                     "  Auth token expired: {}.",
-                    format!("{}", auth.get_expiry()?).yellow()
+                    format!("{}", auth.get_expiry()?).red().bold()
                 );
             } else {
                 info!(


### PR DESCRIPTION
This allows (light) personalization in workflows.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Introduced `HasuraClaims` struct to handle additional JWT claims
- Added `get_user_name` method to `AuthInfo` struct
- Included user's VCS username in workflow requests
- Added log statement to display authenticated user's name in `doctor.rs`
- Refactored authentication token retrieval for better error handling

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added nickname support in authentication payloads.
  - Introduced user-friendly logging of authentication usernames in doctor checks.
  
- **Style**
  - Improved visibility of expired authentication token messages with red and bold formatting.

- **Refactor**
  - Streamlined authentication handling by encapsulating token access and integrating usernames conditionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->