### PR TITLE
fix: avoid overriding vcs user name

### DIFF
--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -109,8 +109,10 @@ where
     })?;
 
     if let Some(username) = auth.get_user_name()? {
-        arg.input
-            .insert(GRIT_VCS_USER_NAME.to_string(), username.into());
+        if !arg.input.contains_key(GRIT_VCS_USER_NAME) {
+            arg.input
+                .insert(GRIT_VCS_USER_NAME.to_string(), username.into());
+        }
     }
 
     let runner_path = updater
@@ -231,7 +233,9 @@ pub async fn run_remote_workflow(
     let mut input = args.get_payload()?;
 
     if let Some(username) = auth.get_user_name()? {
-        input.insert(GRIT_VCS_USER_NAME.to_string(), username.into());
+        if !input.contains_key(GRIT_VCS_USER_NAME) {
+            input.insert(GRIT_VCS_USER_NAME.to_string(), username.into());
+        }
     }
 
     let settings =


### PR DESCRIPTION
Fix an oversight in https://github.com/getgrit/gritql/pull/373 where we accidentally overwrite input data.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Prevented VCS user name from being overwritten in input data
- Ensured VCS user name is only inserted if not already present

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved logic for handling key-value pairs in workflows to ensure only necessary updates are made, enhancing performance and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->