### PR TITLE
feat: stream workflow logs

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -120,7 +120,8 @@ server = [
   "remote_pubsub",
   "ai_builtins",
   "dep:cli_server",
-  "grit_tracing"
+  "grit_tracing",
+  "workflow_server",
 ]
 updater = []
 grit_tracing = [

--- a/crates/cli/src/jsonl.rs
+++ b/crates/cli/src/jsonl.rs
@@ -44,4 +44,9 @@ impl<'a> Messager for JSONLineMessenger<'a> {
 
         Ok(())
     }
+
+    fn emit_log(&mut self, log: &marzano_messenger::SimpleLogMessage) -> anyhow::Result<()> {
+        log::debug!("Log received over RPC: {:?}", log);
+        Ok(())
+    }
 }

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -49,6 +49,20 @@ impl<'a> Messager for MessengerVariant<'a> {
         }
     }
 
+    fn emit_log(&mut self, log: &marzano_messenger::SimpleLogMessage) -> anyhow::Result<()> {
+        match self {
+            MessengerVariant::Formatted(m) => m.emit_log(log),
+            MessengerVariant::Transformed(m) => m.emit_log(log),
+            MessengerVariant::JsonLine(m) => m.emit_log(log),
+            #[cfg(feature = "remote_redis")]
+            MessengerVariant::Redis(m) => m.emit_log(log),
+            #[cfg(feature = "remote_pubsub")]
+            MessengerVariant::GooglePubSub(m) => m.emit_log(log),
+            #[cfg(feature = "server")]
+            MessengerVariant::Combined(m) => m.emit_log(log),
+        }
+    }
+
     fn emit_estimate(&mut self, count: usize) -> anyhow::Result<()> {
         match self {
             MessengerVariant::Formatted(m) => m.emit_estimate(count),

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -668,7 +668,7 @@ impl From<GritAnalysisLog> for AnalysisLog {
     }
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug, Copy, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum AnalysisLogLevel {
     Error = 200,

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -668,7 +668,7 @@ impl From<GritAnalysisLog> for AnalysisLog {
     }
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Serialize, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum AnalysisLogLevel {
     Error = 200,

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -16,7 +16,7 @@ use marzano_core::{
 use marzano_language::target_language::TargetLanguage;
 use serde::{Deserialize, Serialize};
 
-use crate::{format::format_result, workflows::PackagedWorkflowOutcome};
+use crate::{format::format_result, workflows::PackagedWorkflowOutcome, SimpleLogMessage};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ApplyDetails {
@@ -244,6 +244,12 @@ pub trait Messager: Send + Sync {
 
     // Write a message to the output
     fn raw_emit(&mut self, message: &MatchResult) -> anyhow::Result<()>;
+
+    // Write a log message
+    fn emit_log(&mut self, _log: &SimpleLogMessage) -> anyhow::Result<()> {
+        // do nothing
+        Ok(())
+    }
 
     // Send the total count
     fn emit_estimate(&mut self, _count: usize) -> anyhow::Result<()> {

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -246,10 +246,7 @@ pub trait Messager: Send + Sync {
     fn raw_emit(&mut self, message: &MatchResult) -> anyhow::Result<()>;
 
     // Write a log message
-    fn emit_log(&mut self, _log: &SimpleLogMessage) -> anyhow::Result<()> {
-        // do nothing
-        Ok(())
-    }
+    fn emit_log(&mut self, _log: &SimpleLogMessage) -> anyhow::Result<()>;
 
     // Send the total count
     fn emit_estimate(&mut self, _count: usize) -> anyhow::Result<()> {

--- a/crates/marzano_messenger/src/lib.rs
+++ b/crates/marzano_messenger/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod emit;
 pub mod format;
+mod logs;
 pub mod output_mode;
 pub mod testing;
 pub mod workflows;
+
+pub use logs::SimpleLogMessage;

--- a/crates/marzano_messenger/src/logs.rs
+++ b/crates/marzano_messenger/src/logs.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct SimpleLogMessage {
+    pub message: String,
+}

--- a/crates/marzano_messenger/src/logs.rs
+++ b/crates/marzano_messenger/src/logs.rs
@@ -1,6 +1,9 @@
+use marzano_core::api::AnalysisLogLevel;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct SimpleLogMessage {
     pub message: String,
+    pub level: AnalysisLogLevel,
+    pub meta: Option<std::collections::HashMap<String, serde_json::Value>>,
 }

--- a/crates/marzano_messenger/src/testing.rs
+++ b/crates/marzano_messenger/src/testing.rs
@@ -8,15 +8,19 @@ use crate::emit::Messager;
 /// This should be used in tests to avoid sending messages to real backends.
 pub struct TestingMessenger {
     message_count: usize,
+    log_count: usize,
 }
 
 impl TestingMessenger {
     pub fn new() -> Self {
-        Self { message_count: 0 }
+        Self {
+            message_count: 0,
+            log_count: 0,
+        }
     }
 
-    pub fn message_count(&self) -> usize {
-        self.message_count
+    pub fn total_count(&self) -> usize {
+        self.log_count + self.message_count
     }
 }
 
@@ -29,6 +33,11 @@ impl Default for TestingMessenger {
 impl Messager for TestingMessenger {
     fn raw_emit(&mut self, _message: &MatchResult) -> Result<()> {
         self.message_count += 1;
+        Ok(())
+    }
+
+    fn emit_log(&mut self, _log: &crate::SimpleLogMessage) -> anyhow::Result<()> {
+        self.log_count += 1;
         Ok(())
     }
 }


### PR DESCRIPTION
Expose hooks for emitting logs from workflows to Grit Cloud.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Added `workflow_server` dependency to `server` feature in `Cargo.toml`
- Introduced `emit_log` method to `JSONLineMessenger` in `jsonl.rs`
- Added `emit_log` method to `MessengerVariant` in `messenger_variant.rs`
- Enhanced `FormattedMessager` and `TransformedMessenger` with new log levels and `emit_log` in `result_formatting.rs`
- Implemented `emit_log` method in `Messager` trait in `emit.rs`

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added logging functionality with various log levels (debug, info, warn, error) to the messaging system.
  - Introduced `SimpleLogMessage` for structured logging with metadata support.
  - Enhanced testing capabilities with new log count tracking in `TestingMessenger`.

- **Improvements**
  - Expanded `AnalysisLogLevel` to include more traits for better serialization and copying.
  - Updated logging methods across different messenger variants to support the new log levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->