### PR TITLE
feat: send local ranges to remote when running in cloud

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -68,6 +68,7 @@ pub(crate) async fn run_apply(
             return crate::workflows::run_remote_workflow(
                 args.pattern_or_workflow,
                 args.apply_migration_args,
+                ranges,
             )
             .await;
         }

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -209,6 +209,7 @@ pub fn display_workflow_outcome(outcome: PackagedWorkflowOutcome) -> Result<()> 
 pub async fn run_remote_workflow(
     workflow_name: String,
     args: crate::commands::apply_migration::ApplyMigrationArgs,
+    ranges: Option<Vec<FileDiff>>,
 ) -> Result<()> {
     use colored::Colorize;
     use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -238,9 +239,9 @@ pub async fn run_remote_workflow(
         }
     }
 
-    if let Some(ranges) = arg.ranges {
+    if let Some(ranges) = ranges {
         if !input.contains_key(GRIT_TARGET_RANGES) {
-            arg.input.insert(
+            input.insert(
                 GRIT_TARGET_RANGES.to_string(),
                 serde_json::to_value(ranges)?,
             );

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -1,7 +1,7 @@
 use crate::updater::{SupportedApp, Updater};
 use anyhow::Result;
 use console::style;
-use log::debug;
+use log::{debug, info};
 use marzano_auth::env::{get_grit_api_url, ENV_VAR_GRIT_API_URL, ENV_VAR_GRIT_AUTH_TOKEN};
 use marzano_gritmodule::{fetcher::LocalRepo, searcher::find_grit_dir_from};
 use marzano_messenger::{emit::Messager, workflows::PackagedWorkflowOutcome};
@@ -67,9 +67,10 @@ where
     #[cfg(feature = "workflow_server")]
     let (server_addr, handle, shutdown_tx) = {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-        let socket = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let socket = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
         let server_addr = format!("http://{}", socket.local_addr()?);
         let handle = grit_cloud_client::spawn_server_tasks(emitter, shutdown_rx, socket);
+        info!("Started local server at {}", server_addr);
         (server_addr, handle, shutdown_tx)
     };
 

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -68,7 +68,7 @@ where
     let (server_addr, handle, shutdown_tx) = {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let socket = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
-        let server_addr = format!("http://{}", socket.local_addr()?);
+        let server_addr = format!("http://{}", socket.local_addr()?).to_string();
         let handle = grit_cloud_client::spawn_server_tasks(emitter, shutdown_rx, socket);
         info!("Started local server at {}", server_addr);
         (server_addr, handle, shutdown_tx)

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -1,7 +1,7 @@
 use crate::updater::{SupportedApp, Updater};
 use anyhow::Result;
 use console::style;
-use log::{debug, info};
+use log::debug;
 use marzano_auth::env::{get_grit_api_url, ENV_VAR_GRIT_API_URL, ENV_VAR_GRIT_AUTH_TOKEN};
 use marzano_gritmodule::{fetcher::LocalRepo, searcher::find_grit_dir_from};
 use marzano_messenger::{emit::Messager, workflows::PackagedWorkflowOutcome};
@@ -70,7 +70,7 @@ where
         let socket = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
         let server_addr = format!("http://{}", socket.local_addr()?).to_string();
         let handle = grit_cloud_client::spawn_server_tasks(emitter, shutdown_rx, socket);
-        info!("Started local server at {}", server_addr);
+        log::info!("Started local server at {}", server_addr);
         (server_addr, handle, shutdown_tx)
     };
 

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -238,6 +238,15 @@ pub async fn run_remote_workflow(
         }
     }
 
+    if let Some(ranges) = arg.ranges {
+        if !input.contains_key(GRIT_TARGET_RANGES) {
+            arg.input.insert(
+                GRIT_TARGET_RANGES.to_string(),
+                serde_json::to_value(ranges)?,
+            );
+        }
+    }
+
     let settings =
         grit_cloud_client::RemoteWorkflowSettings::new(workflow_name, &repo, input.into());
     let url = grit_cloud_client::run_remote_workflow(settings, &auth).await?;


### PR DESCRIPTION
Allow offloading the `--only-in-diff` to cloud workflows too.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Added `ranges` parameter to `run_remote_workflow` in `apply.rs`
- Modified `workflows.rs` to support sending local ranges to remote workflows
- Enabled `--only-in-diff` option for cloud workflows

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced remote workflow capabilities with the ability to specify and apply file ranges, offering more granular control over changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->