### PR TITLE
feat: add generic metadata emitter

### DIFF
--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -120,7 +120,7 @@ impl<'a> WorkflowMessenger for MessengerVariant<'a> {
             | MessengerVariant::Transformed(_)
             | MessengerVariant::JsonLine(_) => {
                 // These are local, so no need to save metadata
-                log::info!(
+                log::debug!(
                     "Skipping save_metadata for local messenger: {} {:?}",
                     message.kind,
                     message.message

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -4,6 +4,7 @@ use console::style;
 use log::debug;
 use marzano_auth::env::{get_grit_api_url, ENV_VAR_GRIT_API_URL, ENV_VAR_GRIT_AUTH_TOKEN};
 use marzano_gritmodule::{fetcher::LocalRepo, searcher::find_grit_dir_from};
+use marzano_messenger::workflows::WorkflowMessenger;
 use marzano_messenger::{emit::Messager, workflows::PackagedWorkflowOutcome};
 use marzano_util::diff::FileDiff;
 use serde::Serialize;
@@ -53,7 +54,7 @@ pub async fn run_bin_workflow<M>(
     mut arg: WorkflowInputs,
 ) -> Result<(M, PackagedWorkflowOutcome)>
 where
-    M: Messager + Send + 'static,
+    M: Messager + WorkflowMessenger + Send + 'static,
 {
     let cwd = std::env::current_dir()?;
 

--- a/crates/cli_bin/tests/apply.rs
+++ b/crates/cli_bin/tests/apply.rs
@@ -2822,7 +2822,7 @@ fn apply_remote_pattern() -> Result<()> {
     assert!(output.status.success(), "Command should have succeeded");
 
     let test_file = dir.join("test.js");
-    let content: String = fs_err::read_to_string(&test_file)?;
+    let content: String = fs_err::read_to_string(test_file)?;
     assert_snapshot!(content);
 
     Ok(())

--- a/crates/marzano_messenger/src/workflows.rs
+++ b/crates/marzano_messenger/src/workflows.rs
@@ -6,3 +6,15 @@ pub struct PackagedWorkflowOutcome {
     pub success: bool,
     pub data: Option<serde_json::Value>,
 }
+
+/// Handle workflow-related messages
+pub trait WorkflowMessenger {
+    fn save_metadata(&mut self, message: &SimpleWorkflowMessage) -> anyhow::Result<()>;
+}
+
+/// Simple workflow message representation, mainly intended for RPC
+#[derive(Deserialize, Serialize, Debug)]
+pub struct SimpleWorkflowMessage {
+    pub kind: String,
+    pub message: serde_json::Value,
+}


### PR DESCRIPTION
For interacting with Grit cloud, we want to gather metadata generically.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Implemented `WorkflowMessenger` trait for `MessengerVariant`
- Added `save_metadata` method to `MessengerVariant`
- Updated `run_bin_workflow` to use `WorkflowMessenger`
- Introduced `SimpleWorkflowMessage` struct for metadata handling

<!-- /greptile_comment -->