### PR TITLE
fix: avoid using serde(flatten) in serializable object

### DIFF
--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -154,7 +154,7 @@ impl fmt::Display for FormattedResult {
                     MatchResult::AllDone(r) => {
                         print_all_done(r, f)?;
                     }
-                    MatchResult::Match(r) => print_file_ranges(&mut r.file.clone(), f)?,
+                    MatchResult::Match(r) => print_file_ranges(&mut r.clone(), f)?,
                     MatchResult::Rewrite(r) => print_file_ranges(&mut r.clone(), f)?,
                     MatchResult::CreateFile(r) => print_file_ranges(&mut r.clone(), f)?,
                     MatchResult::RemoveFile(r) => print_file_ranges(&mut r.clone(), f)?,
@@ -166,16 +166,16 @@ impl fmt::Display for FormattedResult {
                 Ok(())
             }
             FormattedResult::Match(m) => {
-                let path_title = m.file.file_name().bold();
+                let path_title = m.file_name().bold();
                 writeln!(f, "{}", path_title)?;
-                let source = read_to_string(m.file.file_name());
+                let source = read_to_string(m.file_name());
                 match source {
                     Err(e) => {
                         writeln!(f, "Could not read file: {}", e)?;
                         return Ok(());
                     }
                     Ok(source) => {
-                        let ranges = &mut m.file.ranges.iter();
+                        let ranges = &mut m.ranges.iter();
                         // Iterate through the lines of the file
                         let mut line_number = 0;
                         let mut next_range = ranges.next();
@@ -395,7 +395,7 @@ impl Messager for TransformedMessenger<'_> {
                 // ignore these
             }
             MatchResult::Match(message) => {
-                info!("Matched file {}", message.file.file_name());
+                info!("Matched file {}", message.file_name());
             }
             MatchResult::Rewrite(file) => {
                 // Write the file contents to the output

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -351,8 +351,8 @@ impl From<Match> for FileMatch {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub struct Match {
-    /// Do *NOT* use serde(flatten) in wasm-serializable items
-    /// Due to https://github.com/RReverser/serde-wasm-bindgen/issues/49, they will end up as maps.
+    // Do *NOT* use serde(flatten) in wasm-serializable items
+    // Due to https://github.com/RReverser/serde-wasm-bindgen/issues/49, they will end up as maps.
     #[serde(default)]
     pub messages: Vec<Message>,
     #[serde(default)]

--- a/crates/core/src/compact_api.rs
+++ b/crates/core/src/compact_api.rs
@@ -60,8 +60,8 @@ pub struct CompactMatch {
 impl From<Match> for CompactMatch {
     fn from(m: Match) -> Self {
         CompactMatch {
-            source_file: m.file.source_file,
-            ranges: m.file.ranges,
+            source_file: m.source_file,
+            ranges: m.ranges,
             reason: m.reason,
         }
     }

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -52,7 +52,7 @@ pub fn apply_rewrite(result: &MatchResult) -> Result<()> {
 pub fn extract_ranges(result: &MatchResult) -> Option<&Vec<Range>> {
     match result {
         MatchResult::AnalysisLog(_) => None,
-        MatchResult::Match(m) => Some(&m.file.ranges),
+        MatchResult::Match(m) => Some(&m.ranges),
         MatchResult::InputFile(_) => None,
         MatchResult::CreateFile(_) => None,
         MatchResult::RemoveFile(r) => Some(&r.original.ranges),

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -110,10 +110,10 @@ fn match_pattern_libs(
             }
             MatchResult::Match(m) => {
                 execution_result.the_match = Some(ExecutionMatch {
-                    ranges: m.file.ranges,
-                    variables: m.file.variables,
+                    ranges: m.ranges,
+                    variables: m.variables,
                     rewrite: None,
-                    filename: m.file.source_file,
+                    filename: m.source_file,
                     new_files: HashMap::new(),
                 });
             }

--- a/crates/gritmodule/src/testing.rs
+++ b/crates/gritmodule/src/testing.rs
@@ -231,7 +231,7 @@ pub fn test_pattern_sample(
                     continue;
                 }
                 raw_actual_outputs.push(RichFile {
-                    path: r.file.source_file.clone(),
+                    path: r.source_file.clone(),
                     content: sample.input.clone(),
                 });
             }

--- a/crates/gritmodule/src/utils.rs
+++ b/crates/gritmodule/src/utils.rs
@@ -10,7 +10,7 @@ use crate::fetcher::ModuleRepo;
 pub fn extract_path(result: &MatchResult) -> Option<&String> {
     match result {
         MatchResult::AnalysisLog(_) => None,
-        MatchResult::Match(m) => Some(&m.file.source_file),
+        MatchResult::Match(m) => Some(&m.source_file),
         MatchResult::InputFile(i) => Some(&i.source_file),
         MatchResult::CreateFile(c) => Some(&c.rewritten.source_file),
         MatchResult::RemoveFile(r) => Some(&r.original.source_file),

--- a/crates/lsp/src/testing.rs
+++ b/crates/lsp/src/testing.rs
@@ -178,7 +178,7 @@ pub async fn maybe_test_pattern(
         for mut result in outcome.matches {
             match result {
                 MatchResult::Match(ref mut m) => {
-                    m.file.ranges.iter_mut().for_each(|r| {
+                    m.ranges.iter_mut().for_each(|r| {
                         r.add(offset_position, offset_bytes);
                     });
                 }


### PR DESCRIPTION
Unfortunately structs that use flatten() become objects [when serialized](https://github.com/RReverser/serde-wasm-bindgen/issues/59#issuecomment-1924261824) so I switched to an explicit representation.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Modified `MatchResult` handling in `crates/cli/src/result_formatting.rs` for direct field access.
- Replaced `serde(flatten)` with explicit representation in `crates/core/src/api.rs`.
- Updated `CompactMatch` in `crates/core/src/compact_api.rs` to avoid `serde(flatten)`.
- Adjusted `extract_ranges` in `crates/core/src/fs.rs` for direct `ranges` access.
- Changed `RichFile` serialization in `crates/gritmodule/src/testing.rs` to avoid `serde(flatten)`.
- Updated `extract_path` in `crates/gritmodule/src/utils.rs` for direct `source_file` access.
- Modified `MatchResult::Match` handling in `crates/lsp/src/testing.rs` for direct `ranges` iteration.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved data handling and struct interactions by streamlining path normalization and adjusting access to file attributes across multiple modules.

- **Chores**
  - Updated internal references and function implementations to enhance code maintainability and readability. 

These changes should not affect user-facing functionality but will improve the efficiency and maintainability of the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->