### PR TITLE
feat: add utilities for streaming paths

### DIFF
--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -1,5 +1,6 @@
 use crate::flags::GlobalFormatFlags;
 use crate::{flags::OutputFormat, messenger_variant::create_emitter};
+use marzano_messenger::emit::FlushableMessenger;
 
 #[cfg(not(feature = "workflows_v2"))]
 use anyhow::bail;

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -22,6 +22,7 @@ use marzano_gritmodule::markdown::get_body_from_md_content;
 use marzano_gritmodule::searcher::{find_global_grit_dir, find_grit_modules_dir};
 use marzano_gritmodule::utils::{infer_pattern, is_pattern_name, parse_remote_name};
 use marzano_language::target_language::PatternLanguage;
+use marzano_messenger::emit::FlushableMessenger as _;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::env;

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -13,6 +13,7 @@ use marzano_core::{
 };
 use marzano_gritmodule::{config::ResolvedGritDefinition, utils::extract_path};
 use marzano_language::target_language::{expand_paths, PatternLanguage};
+use marzano_messenger::emit::FlushableMessenger as _;
 use marzano_util::cache::GritCache;
 use marzano_util::rich_path::RichPath;
 use marzano_util::{finder::get_input_files, rich_path::RichFile};

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use marzano_core::api::AnalysisLog;
 use marzano_messenger::{
-    emit::Messager,
+    emit::{FlushableMessenger, Messager},
     output_mode::OutputMode,
     workflows::{PackagedWorkflowOutcome, WorkflowMessenger},
 };
@@ -186,8 +186,10 @@ impl<'a> MessengerVariant<'a> {
             _ => None,
         }
     }
+}
 
-    pub async fn flush(&mut self) -> anyhow::Result<()> {
+impl FlushableMessenger for MessengerVariant<'_> {
+    async fn flush(&mut self) -> anyhow::Result<()> {
         match self {
             #[cfg(feature = "remote_redis")]
             MessengerVariant::Redis(ref mut redis) => redis.flush().await,

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -152,7 +152,7 @@ impl fmt::Display for FormattedResult {
                         // These are not shown in compact mode
                     }
                     MatchResult::AllDone(r) => {
-                        print_all_done(r, f)?;
+                        // print_all_done(r, f)?;
                     }
                     MatchResult::Match(r) => print_file_ranges(&mut r.clone(), f)?,
                     MatchResult::Rewrite(r) => print_file_ranges(&mut r.clone(), f)?,

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -152,7 +152,7 @@ impl fmt::Display for FormattedResult {
                         // These are not shown in compact mode
                     }
                     MatchResult::AllDone(r) => {
-                        // print_all_done(r, f)?;
+                        print_all_done(r, f)?;
                     }
                     MatchResult::Match(r) => print_file_ranges(&mut r.clone(), f)?,
                     MatchResult::Rewrite(r) => print_file_ranges(&mut r.clone(), f)?,

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -43,6 +43,20 @@ impl MatchResult {
     pub fn is_error(&self) -> bool {
         matches!(self, MatchResult::AnalysisLog(log) if log.level < 400)
     }
+
+    pub fn kind(&self) -> &'static str {
+        match self {
+            MatchResult::PatternInfo(_) => "PatternInfo",
+            MatchResult::AllDone(_) => "AllDone",
+            MatchResult::Match(_) => "Match",
+            MatchResult::InputFile(_) => "InputFile",
+            MatchResult::Rewrite(_) => "Rewrite",
+            MatchResult::CreateFile(_) => "CreateFile",
+            MatchResult::RemoveFile(_) => "RemoveFile",
+            MatchResult::DoneFile(_) => "DoneFile",
+            MatchResult::AnalysisLog(_) => "AnalysisLog",
+        }
+    }
 }
 
 /// Make a path look the way provolone expects it to

--- a/crates/core/src/problem.rs
+++ b/crates/core/src/problem.rs
@@ -360,7 +360,7 @@ impl Problem {
         incoming_rx: Receiver<Vec<MatchResult>>,
         context: &ExecutionContext,
         outgoing_tx: Sender<Vec<MatchResult>>,
-        cache: &impl GritCache,
+        _cache: &impl GritCache,
     ) -> Result<()> {
         if self.is_multifile {
             bail!("Streaming is not supported for multifile patterns");

--- a/crates/core/src/problem.rs
+++ b/crates/core/src/problem.rs
@@ -34,6 +34,7 @@ use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 use sha2::{Digest, Sha256};
 
+use crate::api::FileMatchResult;
 use std::{
     collections::HashMap,
     path::PathBuf,
@@ -388,9 +389,7 @@ impl Problem {
                     for m in res.into_iter() {
                         match m {
                             MatchResult::Match(m) => {
-                                if let Some(name) = m.file_name() {
-                                    paths.push(PathBuf::from(name));
-                                }
+                                paths.push(PathBuf::from(m.file_name()));
                             }
                             MatchResult::PatternInfo(_)
                             | MatchResult::AllDone(_)

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -282,7 +282,7 @@ pub trait Messager: Send + Sync {
 }
 
 pub trait FlushableMessenger {
-    async fn flush(&mut self) -> Result<()>;
+    fn flush(&mut self) -> impl std::future::Future<Output = Result<()>> + Send;
 }
 
 /// Visibility levels dictate *which* objects we show (ex. just rewrites, or also every file analyzed)

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -281,6 +281,10 @@ pub trait Messager: Send + Sync {
     }
 }
 
+pub trait FlushableMessenger {
+    async fn flush(&mut self) -> Result<()>;
+}
+
 /// Visibility levels dictate *which* objects we show (ex. just rewrites, or also every file analyzed)
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy, ValueEnum, Serialize, Default)]
 pub enum VisibilityLevels {

--- a/crates/marzano_messenger/src/testing.rs
+++ b/crates/marzano_messenger/src/testing.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use marzano_core::api::MatchResult;
 
-use crate::emit::Messager;
+use crate::emit::{FlushableMessenger, Messager};
 
 /// A testing messenger that doesn't actually send messages anywhere.
 ///
@@ -38,6 +38,12 @@ impl Messager for TestingMessenger {
 
     fn emit_log(&mut self, _log: &crate::SimpleLogMessage) -> anyhow::Result<()> {
         self.log_count += 1;
+        Ok(())
+    }
+}
+
+impl FlushableMessenger for TestingMessenger {
+    async fn flush(&mut self) -> Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
We want to be able to chain different queries together, even across different enginers. This adds a basic pipe (unoptimized, single-threaded).

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Added `execute_streaming_child` method for streaming paths
- Modified existing methods to support streaming functionality
- Introduced `FlushableMessenger` trait with async `flush` method
- Implemented `FlushableMessenger` for `TestingMessenger`
- Enhanced error handling and tracing capabilities

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new streaming capabilities for handling problem executions.
  - Added a new trait `FlushableMessenger` for asynchronous message flushing.
  - Extended `MatchResult` with a method to return the variant type.

- **Improvements**
  - Enhanced tool reliability and efficiency through refined message handling and streaming logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->