### PR TITLE
chore: strip workspace in relayed messages

### DIFF
--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use marzano_core::api::AnalysisLog;
 use marzano_messenger::{
-    emit::{FlushableMessenger, Messager},
+    emit::{FlushableMessenger, Messager, VisibilityLevels},
     output_mode::OutputMode,
     workflows::{PackagedWorkflowOutcome, WorkflowMessenger},
 };
@@ -133,6 +133,25 @@ impl<'a> WorkflowMessenger for MessengerVariant<'a> {
             MessengerVariant::GooglePubSub(m) => m.save_metadata(message),
             #[cfg(feature = "server")]
             MessengerVariant::Combined(m) => m.save_metadata(message),
+        }
+    }
+
+    fn emit_from_workflow(
+        &mut self,
+        message: &marzano_messenger::workflows::WorkflowMatchResult,
+    ) -> anyhow::Result<()> {
+        // This is meant to match what we do in the CLI server
+        let level = VisibilityLevels::Debug;
+        match self {
+            MessengerVariant::Formatted(_)
+            | MessengerVariant::Transformed(_)
+            | MessengerVariant::JsonLine(_) => self.emit(&message.result, &level),
+            #[cfg(feature = "remote_redis")]
+            MessengerVariant::Redis(m) => m.emit_from_workflow(message),
+            #[cfg(feature = "remote_pubsub")]
+            MessengerVariant::GooglePubSub(m) => m.emit_from_workflow(message),
+            #[cfg(feature = "server")]
+            MessengerVariant::Combined(m) => m.emit_from_workflow(message),
         }
     }
 }

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -65,7 +65,10 @@ fn normalize_path_in_project<'a>(path: &'a str, root_path: Option<&'a PathBuf>) 
     #[cfg(debug_assertions)]
     if let Some(root_path) = root_path {
         if !root_path.to_str().unwrap_or_default().ends_with('/') {
-            panic!("root_path must end with a slash.");
+            panic!(
+                "root_path '{}' must end with a slash.",
+                root_path.to_str().unwrap_or_default()
+            );
         }
     }
     if let Some(root_path) = root_path {

--- a/crates/marzano_messenger/src/testing.rs
+++ b/crates/marzano_messenger/src/testing.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use marzano_core::api::MatchResult;
 
-use crate::emit::{FlushableMessenger, Messager};
+use crate::{
+    emit::{FlushableMessenger, Messager},
+    workflows::{WorkflowMessenger},
+};
 
 /// A testing messenger that doesn't actually send messages anywhere.
 ///
@@ -45,5 +48,21 @@ impl Messager for TestingMessenger {
 impl FlushableMessenger for TestingMessenger {
     async fn flush(&mut self) -> Result<()> {
         Ok(())
+    }
+}
+
+impl WorkflowMessenger for TestingMessenger {
+    fn save_metadata(
+        &mut self,
+        _metadata: &crate::workflows::SimpleWorkflowMessage,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn emit_from_workflow(
+        &mut self,
+        message: &crate::workflows::WorkflowMatchResult,
+    ) -> anyhow::Result<()> {
+        self.emit(&message.result, &crate::emit::VisibilityLevels::Debug)
     }
 }

--- a/crates/marzano_messenger/src/workflows.rs
+++ b/crates/marzano_messenger/src/workflows.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use marzano_core::api::MatchResult;
 use serde::{Deserialize, Serialize};
 
@@ -15,13 +17,7 @@ pub trait WorkflowMessenger: Messager {
     fn save_metadata(&mut self, message: &SimpleWorkflowMessage) -> anyhow::Result<()>;
 
     /// Emit a match result from a workflow, which has some additional metadata around workspace and paths
-    fn emit_from_workflow(&mut self, message: &WorkflowMatchResult) -> anyhow::Result<()> {
-        self.emit(
-            &message.result,
-            // This is meant to match what we do in the CLI server
-            &VisibilityLevels::Debug,
-        )
-    }
+    fn emit_from_workflow(&mut self, message: &WorkflowMatchResult) -> anyhow::Result<()>;
 }
 
 /// Simple workflow message representation, mainly intended for RPC
@@ -35,5 +31,5 @@ pub struct SimpleWorkflowMessage {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WorkflowMatchResult {
     pub result: MatchResult,
-    pub workspace_path: Option<String>,
+    pub workspace_path: Option<PathBuf>,
 }

--- a/crates/marzano_messenger/src/workflows.rs
+++ b/crates/marzano_messenger/src/workflows.rs
@@ -1,4 +1,7 @@
+use marzano_core::api::MatchResult;
 use serde::{Deserialize, Serialize};
+
+use crate::emit::{Messager, VisibilityLevels};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct PackagedWorkflowOutcome {
@@ -8,8 +11,17 @@ pub struct PackagedWorkflowOutcome {
 }
 
 /// Handle workflow-related messages
-pub trait WorkflowMessenger {
+pub trait WorkflowMessenger: Messager {
     fn save_metadata(&mut self, message: &SimpleWorkflowMessage) -> anyhow::Result<()>;
+
+    /// Emit a match result from a workflow, which has some additional metadata around workspace and paths
+    fn emit_from_workflow(&mut self, message: &WorkflowMatchResult) -> anyhow::Result<()> {
+        self.emit(
+            &message.result,
+            // This is meant to match what we do in the CLI server
+            &VisibilityLevels::Debug,
+        )
+    }
 }
 
 /// Simple workflow message representation, mainly intended for RPC
@@ -17,4 +29,11 @@ pub trait WorkflowMessenger {
 pub struct SimpleWorkflowMessage {
     pub kind: String,
     pub message: serde_json::Value,
+}
+
+/// Wrap match results to account for workflow logic and path normalization
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkflowMatchResult {
+    pub result: MatchResult,
+    pub workspace_path: Option<String>,
 }

--- a/crates/marzano_messenger/src/workflows.rs
+++ b/crates/marzano_messenger/src/workflows.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use marzano_core::api::MatchResult;
 use serde::{Deserialize, Serialize};
 
-use crate::emit::{Messager, VisibilityLevels};
+use crate::emit::{Messager};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct PackagedWorkflowOutcome {


### PR DESCRIPTION
We don't want to include workspace prefixes when relaying messages between services.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Added `emit_from_workflow` method to `WorkflowMessenger` in `crates/cli/src/messenger_variant.rs`
- Introduced `VisibilityLevels` to imports in `crates/cli/src/messenger_variant.rs`
- Modified panic message in `normalize_path_in_project` in `crates/core/src/api.rs` to include `root_path`
- Extended `WorkflowMessenger` trait in `crates/marzano_messenger/src/workflows.rs` with methods for saving metadata and emitting match results
- Introduced `WorkflowMatchResult` struct in `crates/marzano_messenger/src/workflows.rs` for workflow logic and path normalization

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to handle emitting messages for different messaging systems, including Redis, Google PubSub, and server messaging.

- **Improvements**
  - Enhanced error messages to include detailed diagnostic information, improving debugging for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->