### PR TITLE
feat: apply local rewrites from workflows

### DIFF
--- a/crates/marzano_messenger/src/workflows.rs
+++ b/crates/marzano_messenger/src/workflows.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use marzano_core::api::MatchResult;
 use serde::{Deserialize, Serialize};
 
-use crate::emit::{Messager};
+use crate::emit::Messager;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct PackagedWorkflowOutcome {


### PR DESCRIPTION
When running workflows locally, we also want to apply changes to the local file system.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Added functionality to apply local rewrites in `crates/cli/src/messenger_variant.rs`
- Introduced `WorkflowMessenger` trait in `crates/marzano_messenger/src/workflows.rs`
- Added `SimpleWorkflowMessage` and `WorkflowMatchResult` structs in `crates/marzano_messenger/src/workflows.rs`
- Extended `Messager` trait with methods for saving metadata and emitting match results in `crates/marzano_messenger/src/workflows.rs`

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of JSON line messages in the messenger to ensure more reliable message emission and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->