### PR TITLE
fix: strip path prefix in all cases when normalizing

### DIFF
--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -62,18 +62,14 @@ impl MatchResult {
 /// Make a path look the way provolone expects it to
 /// Removes leading "./", or the root path if it's provided
 fn normalize_path_in_project<'a>(path: &'a str, root_path: Option<&'a PathBuf>) -> &'a str {
-    #[cfg(debug_assertions)]
     if let Some(root_path) = root_path {
-        if !root_path.to_str().unwrap_or_default().ends_with('/') {
-            panic!(
-                "root_path '{}' must end with a slash.",
-                root_path.to_str().unwrap_or_default()
-            );
+        if root_path.ends_with("/") {
+            path.strip_prefix(root_path.to_string_lossy().as_ref())
+                .unwrap_or(path)
+        } else {
+            path.strip_prefix(&format!("{}/", root_path.to_string_lossy()))
+                .unwrap_or(path)
         }
-    }
-    if let Some(root_path) = root_path {
-        let root_path = root_path.to_str().unwrap();
-        path.strip_prefix(root_path).unwrap_or(path)
     } else {
         path.strip_prefix("./").unwrap_or(path)
     }

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -63,13 +63,11 @@ impl MatchResult {
 /// Removes leading "./", or the root path if it's provided
 fn normalize_path_in_project<'a>(path: &'a str, root_path: Option<&'a PathBuf>) -> &'a str {
     if let Some(root_path) = root_path {
-        if root_path.ends_with("/") {
-            path.strip_prefix(root_path.to_string_lossy().as_ref())
-                .unwrap_or(path)
-        } else {
-            path.strip_prefix(&format!("{}/", root_path.to_string_lossy()))
-                .unwrap_or(path)
-        }
+        let basic = path
+            .strip_prefix(root_path.to_string_lossy().as_ref())
+            .unwrap_or(path);
+        // Stip the leading / if it's there
+        basic.strip_prefix('/').unwrap_or(basic)
     } else {
         path.strip_prefix("./").unwrap_or(path)
     }
@@ -791,11 +789,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_normalize_path_in_project_with_root_no_slash() {
         let path = "/home/user/project/src/main.rs";
         let root_path = PathBuf::from("/home/user/project");
-        normalize_path_in_project(path, Some(&root_path));
+        assert_eq!(
+            normalize_path_in_project(path, Some(&root_path)),
+            "src/main.rs",
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Enhanced `normalize_path_in_project` in `crates/core/src/api.rs` to handle root paths with or without trailing slashes
- Added test cases to ensure consistent path normalization

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved path normalization to handle scenarios where the root path ends with a trailing slash. This ensures more accurate handling of file paths within projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->