### PR TITLE
feat: add more info to match reasons

### DIFF
--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -287,6 +287,7 @@ pub(crate) async fn run_check(
                         let reason = Some(MatchReason {
                             metadata_json: None,
                             source: RewriteSource::Gritql,
+                            title: result.pattern.title().map(|s| s.to_string()),
                             name: Some(result.pattern.local_name.to_string()),
                             level: Some(result.pattern.level()),
                             explanation: None,

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -500,7 +500,11 @@ impl FileMatchResult for Rewrite {
 pub struct MatchReason {
     pub metadata_json: Option<String>,
     pub source: RewriteSource,
+    /// The name of the pattern that matched, or another programmatic identifier
     pub name: Option<String>,
+    /// A human-readable title for the match
+    pub title: Option<String>,
+    /// A human-readable explanation of the match
     pub explanation: Option<String>,
     pub level: Option<EnforcementLevel>,
 }

--- a/crates/gritmodule/src/config.rs
+++ b/crates/gritmodule/src/config.rs
@@ -78,7 +78,7 @@ pub struct GritDefinitionConfig {
     pub name: String,
     pub body: Option<String>,
     #[serde(flatten)]
-    pub(crate) meta: GritPatternMetadata,
+    pub meta: GritPatternMetadata,
     #[serde(skip)]
     pub kind: Option<DefinitionKind>,
     pub samples: Option<Vec<GritPatternSample>>,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced match details with additional `title` and `explanation` fields for better readability and comprehension.

- **Refactor**
  - Improved visibility and access to configuration metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Added `title` field to `MatchReason` struct in `crates/cli/src/commands/check.rs`
- Enhanced `MatchReason` struct with title and explanation in `crates/core/src/api.rs`
- Made 'meta' field of `GritDefinitionConfig` struct public in `crates/gritmodule/src/config.rs`

<!-- /greptile_comment -->