### PR TITLE
feat: move pattern files to the main patterns array

### DIFF
--- a/crates/gritmodule/fixtures/pattern_files/.grit/grit.yaml
+++ b/crates/gritmodule/fixtures/pattern_files/.grit/grit.yaml
@@ -1,5 +1,7 @@
 version: 0.0.1
 patterns:
+  - file: ../docs/guides/version_5_upgrade.md
+  - file: ../docs/guides/something.md
   - name: remove_console_error
     level: error
     body: |
@@ -7,6 +9,3 @@ patterns:
       language js
 
       `console.error($_)` => .
-pattern_files:
-  - docs/guides/version_5_upgrade.md
-  - docs/guides/something.md

--- a/crates/gritmodule/src/config.rs
+++ b/crates/gritmodule/src/config.rs
@@ -34,8 +34,8 @@ pub struct GritGitHubConfig {
 
 /// Represents a reference to an external pattern file
 #[derive(Debug, Deserialize)]
-struct GritPatternFile {
-    file: PathBuf,
+pub struct GritPatternFile {
+    pub path: PathBuf,
 }
 
 /// Pure in-memory representation of the grit config

--- a/crates/gritmodule/src/config.rs
+++ b/crates/gritmodule/src/config.rs
@@ -35,7 +35,7 @@ pub struct GritGitHubConfig {
 /// Represents a reference to an external pattern file
 #[derive(Debug, Deserialize)]
 pub struct GritPatternFile {
-    pub path: PathBuf,
+    pub file: PathBuf,
 }
 
 /// Pure in-memory representation of the grit config

--- a/crates/gritmodule/src/config.rs
+++ b/crates/gritmodule/src/config.rs
@@ -32,17 +32,31 @@ pub struct GritGitHubConfig {
     pub reviewers: Vec<String>,
 }
 
+/// Represents a reference to an external pattern file
 #[derive(Debug, Deserialize)]
+struct GritPatternFile {
+    file: PathBuf,
+}
+
+/// Pure in-memory representation of the grit config
+#[derive(Debug)]
 pub struct GritConfig {
     pub patterns: Vec<GritDefinitionConfig>,
-    pub pattern_files: Option<Vec<String>>,
+    pub pattern_files: Option<Vec<GritPatternFile>>,
     pub github: Option<GritGitHubConfig>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum GritPatternConfig {
+    File(GritPatternFile),
+    Pattern(GritSerializedDefinitionConfig),
+}
+
+/// Compacted / serialized version of the GritConfig
+#[derive(Debug, Deserialize)]
 pub struct SerializedGritConfig {
-    pub patterns: Vec<GritSerializedDefinitionConfig>,
-    pub pattern_files: Option<Vec<String>>,
+    pub patterns: Vec<GritPatternConfig>,
     pub github: Option<GritGitHubConfig>,
 }
 

--- a/crates/gritmodule/src/snapshots/marzano_gritmodule__resolver__tests__finds_patterns_from_custom_pattern_files.snap
+++ b/crates/gritmodule/src/snapshots/marzano_gritmodule__resolver__tests__finds_patterns_from_custom_pattern_files.snap
@@ -12,7 +12,7 @@ expression: resolved_patterns
     samples: ~
     path: ".grit/grit.yaml"
     position:
-      line: 3
+      line: 5
       column: 11
     raw: ~
   module:
@@ -136,7 +136,7 @@ expression: resolved_patterns
           startByte: 1220
           endByte: 1262
         output_range: ~
-    path: fixtures/pattern_files/docs/guides/something.md
+    path: ".grit/../docs/guides/something.md"
     position:
       line: 10
       column: 1
@@ -264,7 +264,7 @@ expression: resolved_patterns
           startByte: 1220
           endByte: 1262
         output_range: ~
-    path: fixtures/pattern_files/docs/guides/version_5_upgrade.md
+    path: ".grit/../docs/guides/version_5_upgrade.md"
     position:
       line: 10
       column: 1

--- a/crates/gritmodule/src/yaml.rs
+++ b/crates/gritmodule/src/yaml.rs
@@ -64,7 +64,8 @@ pub async fn get_patterns_from_yaml(
     root: &Option<String>,
     repo_dir: &str,
 ) -> Result<Vec<ModuleGritPattern>> {
-    let mut config = get_grit_config(&file.content, &extract_relative_file_path(file, root))?;
+    let grit_path = extract_relative_file_path(file, root);
+    let mut config = get_grit_config(&file.content, &grit_path)?;
 
     for pattern in config.patterns.iter_mut() {
         pattern.kind = Some(DefinitionKind::Pattern);
@@ -86,7 +87,9 @@ pub async fn get_patterns_from_yaml(
     let mut file_readers = Vec::new();
 
     for pattern_file in config.pattern_files.unwrap() {
-        let pattern_file = PathBuf::from(repo_dir).join(&pattern_file.path);
+        let pattern_file = PathBuf::from(repo_dir)
+            .join(REPO_CONFIG_DIR_NAME)
+            .join(&pattern_file.file);
         let extension = PatternFileExt::from_path(&pattern_file);
         if extension.is_none() {
             continue;


### PR DESCRIPTION
Instead of a separate list we just include them like so:

```
patterns:
- file: ../elsewhere/foo.txt
```

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- **File:** `crates/gritmodule/fixtures/pattern_files/.grit/grit.yaml`
  - Moved pattern files from 'pattern_files' list to main 'patterns' array

- **File:** `crates/gritmodule/src/config.rs`
  - Integrated pattern files into main patterns array
  - Introduced `GritPatternFile` struct and `GritPatternConfig` enum
  - Updated `SerializedGritConfig` to use new enum

- **File:** `crates/gritmodule/src/yaml.rs`
  - Refactored `get_grit_config` to handle pattern files and patterns
  - Updated `get_patterns_from_yaml` for new structure

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reorganized configuration structures for improved pattern file management.
  - Enhanced pattern file path handling for better validation and extension recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->