### PR TITLE
feat: allow running workflows with input from stdin

### DIFF
--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -22,7 +22,7 @@ pub struct ApplyMigrationArgs {
         help_heading = "Workflow options",
         help = "JSON input parameter to pass to the workflow"
     )]
-    input: Option<String>,
+    pub(crate) input: Option<String>,
     #[clap(
         long,
         help_heading = "Workflow options",
@@ -31,7 +31,7 @@ pub struct ApplyMigrationArgs {
     pub(crate) remote: bool,
     /// Print verbose output
     #[clap(long)]
-    verbose: bool,
+    pub(crate) verbose: bool,
 }
 
 impl ApplyMigrationArgs {

--- a/crates/cli/src/commands/plumbing.rs
+++ b/crates/cli/src/commands/plumbing.rs
@@ -296,6 +296,8 @@ pub(crate) async fn run_plumbing(
             shared_args,
             definition,
         } => {
+            let buffer = read_input(&shared_args)?;
+
             let current_dir = current_dir()?;
 
             let custom_workflow = marzano_gritmodule::searcher::find_workflow_file_from(
@@ -305,13 +307,12 @@ pub(crate) async fn run_plumbing(
             .await
             .unwrap();
 
-            println!("custom_workflow: {:?}", custom_workflow);
             super::apply_migration::run_apply_migration(
                 custom_workflow,
                 vec![current_dir],
                 None,
                 ApplyMigrationArgs {
-                    input: None,
+                    input: Some(buffer),
                     remote: false,
                     verbose: true,
                 },

--- a/crates/cli/src/commands/plumbing.rs
+++ b/crates/cli/src/commands/plumbing.rs
@@ -21,7 +21,6 @@ use crate::lister::list_applyables;
 use crate::resolver::{get_grit_files_from, resolve_from, Source};
 
 use super::super::analytics::AnalyticsArgs;
-use super::apply_migration::ApplyMigrationArgs;
 use super::apply_pattern::{run_apply_pattern, ApplyPatternArgs};
 use super::check::{run_check, CheckArg};
 use super::filters::SharedFilterArgs;
@@ -311,7 +310,7 @@ pub(crate) async fn run_plumbing(
                 custom_workflow,
                 vec![current_dir],
                 None,
-                ApplyMigrationArgs {
+                super::apply_migration::ApplyMigrationArgs {
                     input: Some(buffer),
                     remote: false,
                     verbose: true,

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -75,6 +75,9 @@ where
         (server_addr, handle, shutdown_tx)
     };
 
+    println!("I DID GET HERE!");
+    log::info!("WHAT IS GOING ON?");
+
     let root = std::env::var(ENV_GRIT_WORKSPACE_ROOT).unwrap_or_else(|_| {
         repo.as_ref().and_then(|r| r.root().ok()).map_or_else(
             || cwd.to_string_lossy().into_owned(),

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -75,9 +75,6 @@ where
         (server_addr, handle, shutdown_tx)
     };
 
-    println!("I DID GET HERE!");
-    log::info!("WHAT IS GOING ON?");
-
     let root = std::env::var(ENV_GRIT_WORKSPACE_ROOT).unwrap_or_else(|_| {
         repo.as_ref().and_then(|r| r.root().ok()).map_or_else(
             || cwd.to_string_lossy().into_owned(),


### PR DESCRIPTION
Now input can be in a file, allowing arbitrarily large input params.

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Made `input` and `verbose` fields of `ApplyMigrationArgs` public in `/crates/cli/src/commands/apply_migration.rs`
- Added new `Run` subcommand to `PlumbingArgs` enum in `/crates/cli/src/commands/plumbing.rs`
- Integrated new subcommand to read input from stdin and run workflows
- Utilized `run_apply_migration` function for executing workflows with stdin input
- Ensured compatibility with existing `SharedPlumbingArgs` for input handling

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new command variant for executing workflows from a file, enhancing the flexibility of workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->