### PR TITLE
fix: Handling Dangling Commas in `delete_hanging_comma` Function

### DIFF
--- a/crates/core/src/inline_snippets.rs
+++ b/crates/core/src/inline_snippets.rs
@@ -348,12 +348,18 @@ fn delete_hanging_comma(
         .iter()
         .map(|r| (r.0.effective_range(), r.1.len()))
         .collect();
-
+    
+    // Flag to track if the last character was a comma
+    let mut last_was_comma = false;
+    
     for (index, c) in chars {
         if Some(&index) != next_comma {
+            if c == ',' && last_was_comma {
+                continue;
+            }
             result.push(c);
+            last_was_comma = c == ',';
         } else {
-            next_comma = to_delete.next();
             // Keep track of ranges we need to expand into, since we deleted code in the range
             // This isn't perfect, but it's good enough for tracking cell boundaries
             for (range, ..) in replacement_ranges.iter_mut().rev() {
@@ -363,6 +369,8 @@ fn delete_hanging_comma(
                 }
             }
             ranges_updates = update_range_shifts(index + offset, &ranges_updates, &ranges);
+            next_comma = to_delete.next();
+            last_was_comma = false;
         }
     }
 

--- a/crates/core/src/inline_snippets.rs
+++ b/crates/core/src/inline_snippets.rs
@@ -350,26 +350,28 @@ fn delete_hanging_comma(
         .collect();
     
     // Flag to track if the last character was a comma
-    let mut previous_char_was_comma = false;
+    let mut last_was_comma = false;
     
     for (index, c) in chars {
         if Some(&index) != next_comma {
-            next_comma = to_delete.next();
-            previous_char_was_comma = false;
-            continue;
-        }
-        if c == ',' {
-            if previous_char_was_comma {
+            if c == ',' && last_was_comma {
                 continue;
             }
-            previous_char_was_comma = true;
+            result.push(c);
+            last_was_comma = c == ',';
         } else {
             // Keep track of ranges we need to expand into, since we deleted code in the range
             // This isn't perfect, but it's good enough for tracking cell boundaries
-            previous_char_was_comma = false;
-
+            for (range, ..) in replacement_ranges.iter_mut().rev() {
+                if range.end >= index {
+                    range.end += 1;
+                    break;
+                }
             }
-        result.push(c);
+            ranges_updates = update_range_shifts(index + offset, &ranges_updates, &ranges);
+            next_comma = to_delete.next();
+            last_was_comma = false;
+        }
     }
 
     for (r, u) in replacements.iter_mut().zip(ranges_updates) {

--- a/crates/core/src/inline_snippets.rs
+++ b/crates/core/src/inline_snippets.rs
@@ -353,6 +353,7 @@ fn delete_hanging_comma(
         if Some(&index) != next_comma {
             result.push(c);
         } else {
+            next_comma = to_delete.next();
             // Keep track of ranges we need to expand into, since we deleted code in the range
             // This isn't perfect, but it's good enough for tracking cell boundaries
             for (range, ..) in replacement_ranges.iter_mut().rev() {
@@ -362,7 +363,6 @@ fn delete_hanging_comma(
                 }
             }
             ranges_updates = update_range_shifts(index + offset, &ranges_updates, &ranges);
-            next_comma = to_delete.next();
         }
     }
 

--- a/crates/core/src/inline_snippets.rs
+++ b/crates/core/src/inline_snippets.rs
@@ -350,28 +350,26 @@ fn delete_hanging_comma(
         .collect();
     
     // Flag to track if the last character was a comma
-    let mut last_was_comma = false;
+    let mut previous_char_was_comma = false;
     
     for (index, c) in chars {
         if Some(&index) != next_comma {
-            if c == ',' && last_was_comma {
+            next_comma = to_delete.next();
+            previous_char_was_comma = false;
+            continue;
+        }
+        if c == ',' {
+            if previous_char_was_comma {
                 continue;
             }
-            result.push(c);
-            last_was_comma = c == ',';
+            previous_char_was_comma = true;
         } else {
             // Keep track of ranges we need to expand into, since we deleted code in the range
             // This isn't perfect, but it's good enough for tracking cell boundaries
-            for (range, ..) in replacement_ranges.iter_mut().rev() {
-                if range.end >= index {
-                    range.end += 1;
-                    break;
-                }
+            previous_char_was_comma = false;
+
             }
-            ranges_updates = update_range_shifts(index + offset, &ranges_updates, &ranges);
-            next_comma = to_delete.next();
-            last_was_comma = false;
-        }
+        result.push(c);
     }
 
     for (r, u) in replacements.iter_mut().zip(ranges_updates) {

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -6331,6 +6331,41 @@ fn inline_list_length() {
 }
 
 #[test]
+fn test_delete_hanging_comma() {
+    run_test_expected(TestArgExpected {
+        pattern: r#"
+            |language python
+            |
+            |`TaskMetadata($args)` => `TaskMetadata($args)`
+            |"#
+        .trim_margin()
+        .unwrap(),
+        source: r#"
+            |TaskMetadata(
+            |    name="TestTask",
+            |    description="This is a test task.",
+            |    type="TestType",
+            |    ,
+            |    reference="https://example.com/test",
+            |)
+            |"#
+        .trim_margin()
+        .unwrap(),
+        expected: r#"
+            |TaskMetadata(
+            |    name="TestTask",
+            |    description="This is a test task.",
+            |    type="TestType",
+            |    reference="https://example.com/test",
+            |)
+            |"#
+        .trim_margin()
+        .unwrap(),
+    })
+    .unwrap();
+}
+
+#[test]
 fn string_length() {
     run_test_expected({
         TestArgExpected {


### PR DESCRIPTION
/claim #416
fixes #416 

Before the Change:

The function iterated through characters in the `code` string, checking and potentially skipping characters marked for deletion `to_delete`. This needed adjustment to handle dangling commas correctly.

 After the Change:

- skips the dangling commas identified in `to_delete`, ensuring they are not included in the final `result` string.


<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Adjusted `delete_hanging_comma` function to correctly skip dangling commas
- Moved `next_comma = to_delete.next();` to the appropriate position within the loop
- Enhanced reliability by preventing unwanted commas in the output
- Added a new test to verify correct deletion of hanging commas

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the control flow in the function managing the deletion of hanging commas, enhancing performance and reliability.

- **Tests**
  - Added a new test function to ensure proper deletion of hanging commas in specific contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->