### PR TITLE
feat: allow overriding name for file patterns

### DIFF
--- a/crates/gritmodule/fixtures/pattern_files/.grit/.gitignore
+++ b/crates/gritmodule/fixtures/pattern_files/.grit/.gitignore
@@ -1,0 +1,2 @@
+.gritmodules*
+*.log

--- a/crates/gritmodule/fixtures/pattern_files/.grit/grit.yaml
+++ b/crates/gritmodule/fixtures/pattern_files/.grit/grit.yaml
@@ -2,6 +2,8 @@ version: 0.0.1
 patterns:
   - file: ../docs/guides/version_5_upgrade.md
   - file: ../docs/guides/something.md
+  - file: ../docs/guides/new-name.md
+    name: renamed_pattern
   - name: remove_console_error
     level: error
     body: |

--- a/crates/gritmodule/fixtures/pattern_files/docs/guides/new-name.md
+++ b/crates/gritmodule/fixtures/pattern_files/docs/guides/new-name.md
@@ -1,0 +1,9 @@
+# This pattern has a different name in the config.
+
+It still works though!
+
+```grit
+
+`foo` => `bar`
+
+```

--- a/crates/gritmodule/src/config.rs
+++ b/crates/gritmodule/src/config.rs
@@ -13,12 +13,12 @@ use std::{env, fmt, io::ErrorKind, str::FromStr};
 use tokio::{fs, io::AsyncWriteExt};
 use tracing::instrument;
 
-use crate::fetcher::GritModuleFetcher;
 use crate::installer::install_default_stdlib;
 use crate::resolver::fetch_modules;
 use crate::searcher::{
     find_git_dir_from, find_global_grit_dir, find_global_grit_modules_dir, find_grit_dir_from,
 };
+use crate::{fetcher::GritModuleFetcher, markdown::GritDefinitionOverrides};
 use crate::{
     fetcher::{FetcherType, ModuleRepo},
     parser::PatternFileExt,
@@ -36,6 +36,8 @@ pub struct GritGitHubConfig {
 #[derive(Debug, Deserialize)]
 pub struct GritPatternFile {
     pub file: PathBuf,
+    #[serde(flatten)]
+    pub overrides: GritDefinitionOverrides,
 }
 
 /// Pure in-memory representation of the grit config

--- a/crates/gritmodule/src/markdown.rs
+++ b/crates/gritmodule/src/markdown.rs
@@ -15,6 +15,7 @@ use marzano_language::language::MarzanoLanguage as _;
 use marzano_util::cursor_wrapper::CursorWrapper;
 use marzano_util::node_with_source::NodeWithSource;
 use marzano_util::rich_path::RichFile;
+use serde::{Deserialize, Serialize};
 use std::io::{Read, Seek, Write};
 use std::path::Path;
 use tokio::io::SeekFrom;
@@ -47,10 +48,17 @@ pub fn make_md_parser() -> Result<Parser> {
     Ok(parser)
 }
 
+/// Allow overriding fields when constructing a pattern from a file
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
+pub struct GritDefinitionOverrides {
+    pub name: Option<String>,
+}
+
 pub fn get_patterns_from_md(
     file: &mut RichFile,
     source_module: &Option<ModuleRepo>,
     root: &Option<String>,
+    overrides: GritDefinitionOverrides,
 ) -> Result<Vec<ModuleGritPattern>> {
     // Tree sitter has weird problems if we are missing a newline at the end of the file
     if !file.content.ends_with('\n') {
@@ -64,9 +72,6 @@ pub fn get_patterns_from_md(
         .file_stem()
         .and_then(|stem| stem.to_str())
         .unwrap_or_else(|| file.path.trim_end_matches(".md"));
-    if !is_pattern_name(name) {
-        bail!("Invalid pattern name: '{}'. Grit patterns must match the regex /^[A-Za-z_][A-Za-z0-9_]*$/. For more info, consult the docs at https://docs.grit.io/guides/patterns#pattern-definitions.", name);
-    }
 
     let relative_path = extract_relative_file_path(file, root);
 
@@ -246,6 +251,7 @@ pub fn get_body_from_md_content(content: &str) -> Result<String> {
         },
         &None,
         &None,
+        GritDefinitionOverrides::default(),
     )?;
 
     if let Some(pattern) = patterns.first() {
@@ -340,7 +346,13 @@ function isTruthy(x) {
 }
 ```
 "#.to_string()};
-        let patterns = get_patterns_from_md(&mut rich_file, &module, &None).unwrap();
+        let patterns = get_patterns_from_md(
+            &mut rich_file,
+            &module,
+            &None,
+            GritDefinitionOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(patterns.len(), 1);
         println!("{:?}", patterns);
         assert_yaml_snapshot!(patterns);
@@ -407,7 +419,13 @@ function isTruthy(x) {
 }
 ```
 "#.to_string()};
-        let patterns = get_patterns_from_md(&mut rich_file, &module, &None).unwrap();
+        let patterns = get_patterns_from_md(
+            &mut rich_file,
+            &module,
+            &None,
+            GritDefinitionOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(patterns.len(), 1);
         println!("{:?}", patterns);
         assert_eq!(patterns[0].config.samples.as_ref().unwrap().len(), 3);
@@ -496,7 +514,13 @@ function isTruthy(x) {
 "#
             .to_string(),
         };
-        let patterns = get_patterns_from_md(&mut rich_file, &module, &None).unwrap();
+        let patterns = get_patterns_from_md(
+            &mut rich_file,
+            &module,
+            &None,
+            GritDefinitionOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(patterns.len(), 2);
         println!("{:?}", patterns);
         assert_yaml_snapshot!(patterns);
@@ -657,7 +681,13 @@ jobs:
 "#
             .to_string(),
         };
-        let patterns = get_patterns_from_md(&mut rich_file, &module, &None).unwrap();
+        let patterns = get_patterns_from_md(
+            &mut rich_file,
+            &module,
+            &None,
+            GritDefinitionOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(patterns.len(), 1);
         println!("{:?}", patterns);
         let sample_input = &patterns[0].config.samples.as_ref().unwrap()[0].input;
@@ -691,7 +721,13 @@ language js
 "#
             .to_string(),
         };
-        let patterns = get_patterns_from_md(&mut rich_file, &module, &None).unwrap();
+        let patterns = get_patterns_from_md(
+            &mut rich_file,
+            &module,
+            &None,
+            GritDefinitionOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(patterns.len(), 1);
         println!("{:?}", patterns);
         assert_eq!(patterns[0].config.meta.level, Some(EnforcementLevel::Error));
@@ -781,7 +817,13 @@ while (val !== null) {
 ```
 "#.to_string(),
         };
-        let patterns = get_patterns_from_md(&mut rich_file, &module, &None).unwrap();
+        let patterns = get_patterns_from_md(
+            &mut rich_file,
+            &module,
+            &None,
+            GritDefinitionOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(patterns.len(), 1);
         assert_yaml_snapshot!(patterns);
     }
@@ -818,7 +860,13 @@ multifile {
 }
 ```
 "#.to_string(),};
-        let patterns = get_patterns_from_md(&mut rich_file, &Some(module), &None).unwrap();
+        let patterns = get_patterns_from_md(
+            &mut rich_file,
+            &Some(module),
+            &None,
+            GritDefinitionOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(patterns.len(), 1);
         assert_yaml_snapshot!(patterns);
     }
@@ -875,7 +923,13 @@ $$ LANGUAGE plpgsql;
 "#
             .to_string(),
         };
-        let patterns = get_patterns_from_md(&mut rich_file, &Some(module), &None).unwrap();
+        let patterns = get_patterns_from_md(
+            &mut rich_file,
+            &Some(module),
+            &None,
+            GritDefinitionOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(patterns.len(), 1);
         assert_yaml_snapshot!(patterns);
 

--- a/crates/gritmodule/src/parser.rs
+++ b/crates/gritmodule/src/parser.rs
@@ -100,6 +100,7 @@ pub async fn get_patterns_from_file(
     path: PathBuf,
     source_module: Option<ModuleRepo>,
     ext: PatternFileExt,
+    overides: GritDefinitionOverrides,
 ) -> Result<Vec<ModuleGritPattern>> {
     let repo_root = find_repo_root_from(path.clone()).await?;
     let content = fs::read_to_string(&path).await?;

--- a/crates/gritmodule/src/parser.rs
+++ b/crates/gritmodule/src/parser.rs
@@ -53,6 +53,7 @@ impl PatternFileExt {
         file: &mut RichFile,
         source_module: &Option<ModuleRepo>,
         root: &Option<String>,
+        overrides: GritDefinitionOverrides,
     ) -> Result<Vec<ModuleGritPattern>, anyhow::Error> {
         match self {
             PatternFileExt::Grit => {
@@ -63,18 +64,13 @@ impl PatternFileExt {
                     )
                 })
             }
-            PatternFileExt::Md => get_patterns_from_md(
-                file,
-                source_module,
-                root,
-                GritDefinitionOverrides::default(),
-            )
-            .with_context(|| {
-                format!(
-                    "Failed to parse markdown pattern {}",
-                    extract_relative_file_path(file, root)
-                )
-            }),
+            PatternFileExt::Md => get_patterns_from_md(file, source_module, root, overrides)
+                .with_context(|| {
+                    format!(
+                        "Failed to parse markdown pattern {}",
+                        extract_relative_file_path(file, root)
+                    )
+                }),
             PatternFileExt::Yaml => {
                 let res = get_patterns_from_yaml(file, source_module.as_ref(), root, "").await;
                 res.with_context(|| {
@@ -100,7 +96,7 @@ pub async fn get_patterns_from_file(
     path: PathBuf,
     source_module: Option<ModuleRepo>,
     ext: PatternFileExt,
-    overides: GritDefinitionOverrides,
+    overrides: GritDefinitionOverrides,
 ) -> Result<Vec<ModuleGritPattern>> {
     let repo_root = find_repo_root_from(path.clone()).await?;
     let content = fs::read_to_string(&path).await?;
@@ -108,7 +104,7 @@ pub async fn get_patterns_from_file(
         path: path.to_string_lossy().to_string(),
         content,
     };
-    ext.get_patterns(&mut file, &source_module, &repo_root)
+    ext.get_patterns(&mut file, &source_module, &repo_root, overrides)
         .await
 }
 

--- a/crates/gritmodule/src/parser.rs
+++ b/crates/gritmodule/src/parser.rs
@@ -7,7 +7,7 @@ use crate::{
     config::{ModuleGritPattern, REPO_CONFIG_DIR_NAME},
     dot_grit::get_patterns_from_grit,
     fetcher::ModuleRepo,
-    markdown::get_patterns_from_md,
+    markdown::{get_patterns_from_md, GritDefinitionOverrides},
     searcher::find_repo_root_from,
     yaml::get_patterns_from_yaml,
 };
@@ -63,14 +63,18 @@ impl PatternFileExt {
                     )
                 })
             }
-            PatternFileExt::Md => {
-                get_patterns_from_md(file, source_module, root).with_context(|| {
-                    format!(
-                        "Failed to parse markdown pattern {}",
-                        extract_relative_file_path(file, root)
-                    )
-                })
-            }
+            PatternFileExt::Md => get_patterns_from_md(
+                file,
+                source_module,
+                root,
+                GritDefinitionOverrides::default(),
+            )
+            .with_context(|| {
+                format!(
+                    "Failed to parse markdown pattern {}",
+                    extract_relative_file_path(file, root)
+                )
+            }),
             PatternFileExt::Yaml => {
                 let res = get_patterns_from_yaml(file, source_module.as_ref(), root, "").await;
                 res.with_context(|| {

--- a/crates/gritmodule/src/resolver.rs
+++ b/crates/gritmodule/src/resolver.rs
@@ -944,7 +944,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        assert_eq!(resolved_patterns.len(), 3);
+        assert_eq!(resolved_patterns.len(), 4);
         assert_eq!(errored_patterns.len(), 0);
 
         resolved_patterns.sort_by(|a, b| a.local_name.cmp(&b.local_name));

--- a/crates/gritmodule/src/searcher.rs
+++ b/crates/gritmodule/src/searcher.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use tokio::fs;
 
+use crate::markdown::GritDefinitionOverrides;
 use crate::{
     config::{
         ModuleGritPattern, GRIT_GLOBAL_DIR_ENV, GRIT_MODULE_DIR, REPO_CONFIG_DIR_NAME,
@@ -25,7 +26,13 @@ pub async fn collect_from_file(
             path.to_string_lossy()
         )
     })?;
-    get_patterns_from_file(path.to_path_buf(), source_module.clone(), ext).await
+    get_patterns_from_file(
+        path.to_path_buf(),
+        source_module.clone(),
+        ext,
+        GritDefinitionOverrides::default(),
+    )
+    .await
 }
 
 pub async fn collect_patterns(
@@ -65,6 +72,7 @@ pub async fn collect_patterns(
                         path.to_path_buf(),
                         source_module.clone(),
                         ext,
+                        GritDefinitionOverrides::default(),
                     )));
                 }
             }

--- a/crates/gritmodule/src/snapshots/marzano_gritmodule__resolver__tests__finds_patterns_from_custom_pattern_files.snap
+++ b/crates/gritmodule/src/snapshots/marzano_gritmodule__resolver__tests__finds_patterns_from_custom_pattern_files.snap
@@ -12,7 +12,7 @@ expression: resolved_patterns
     samples: ~
     path: ".grit/grit.yaml"
     position:
-      line: 5
+      line: 7
       column: 11
     raw: ~
   module:
@@ -23,6 +23,32 @@ expression: resolved_patterns
     providerName: github.com/getgrit/rewriter
   localName: remove_console_error
   body: "engine marzano(0.1)\nlanguage js\n\n`console.error($_)` => .\n"
+  kind: pattern
+  language: js
+  visibility: public
+- config:
+    name: renamed_pattern
+    body: "\n`foo` => `bar`\n\n"
+    level: info
+    title: This pattern has a different name in the config.
+    description: It still works though!
+    tags: ~
+    samples: []
+    path: ".grit/../docs/guides/new-name.md"
+    position:
+      line: 6
+      column: 1
+    raw:
+      format: markdown
+      content: "# This pattern has a different name in the config.\n\nIt still works though!\n\n```grit\n\n`foo` => `bar`\n\n```\n"
+  module:
+    type: Module
+    host: github.com
+    fullName: getgrit/rewriter
+    remote: "https://github.com/getgrit/rewriter.git"
+    providerName: github.com/getgrit/rewriter
+  localName: renamed_pattern
+  body: "\n`foo` => `bar`\n\n"
   kind: pattern
   language: js
   visibility: public

--- a/crates/gritmodule/src/yaml.rs
+++ b/crates/gritmodule/src/yaml.rs
@@ -87,16 +87,24 @@ pub fn get_patterns_from_yaml<'a>(
         }
 
         for pattern_file in config.pattern_files.unwrap() {
-            let pattern_file = PathBuf::from(repo_dir)
+            let pattern_file_path = PathBuf::from(repo_dir)
                 .join(REPO_CONFIG_DIR_NAME)
                 .join(&pattern_file.file);
-            let extension = PatternFileExt::from_path(&pattern_file);
+            let extension = PatternFileExt::from_path(&pattern_file_path);
             if extension.is_none() {
                 continue;
             }
             let extension = extension.unwrap();
             let source_module = source_module.cloned();
-            patterns.extend(get_patterns_from_file(pattern_file, source_module, extension).await?);
+            patterns.extend(
+                get_patterns_from_file(
+                    pattern_file_path,
+                    source_module,
+                    extension,
+                    pattern_file.overrides,
+                )
+                .await?,
+            );
         }
 
         Ok(patterns)

--- a/crates/lsp/src/testing.rs
+++ b/crates/lsp/src/testing.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use grit_util::Position;
 use marzano_core::{api::MatchResult, pattern_compiler::src_to_problem_libs};
 use marzano_gritmodule::{
-    markdown::get_patterns_from_md,
+    markdown::{get_patterns_from_md, GritDefinitionOverrides},
     resolver::get_grit_files,
     testing::{get_sample_name, test_pattern_sample, GritTestResultState},
 };
@@ -73,7 +73,12 @@ pub async fn maybe_test_pattern(
     } else {
         None
     };
-    let found_patterns = get_patterns_from_md(&mut rich_file, &Some(module_repo), &root)?;
+    let found_patterns = get_patterns_from_md(
+        &mut rich_file,
+        &Some(module_repo),
+        &root,
+        GritDefinitionOverrides::default(),
+    )?;
 
     let our_pattern = match found_patterns.first() {
         Some(pattern) => pattern,


### PR DESCRIPTION
Fixes https://github.com/getgrit/gritql/issues/421

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
- Added new pattern file with overridden name in `crates/gritmodule/fixtures/pattern_files/.grit/grit.yaml`
- Introduced `GritDefinitionOverrides` struct in `crates/gritmodule/src/markdown.rs` and updated `get_patterns_from_md`
- Enhanced `GritPatternFile` struct with `overrides` field in `crates/gritmodule/src/config.rs`
- Updated `get_patterns` function in `crates/gritmodule/src/parser.rs` to accept `overrides` parameter
- Modified pattern resolution logic in `crates/gritmodule/src/resolver.rs` to support name overrides

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new pattern entry and configuration changes in `grit.yaml` to support renamed patterns.
  - Enhanced pattern handling in various functions to support overrides.

- **Bug Fixes**
  - Robust handling of pattern file paths and extensions in YAML processing.

- **Tests**
  - Added test for pattern creation with overrides.
  - Modified test assertions to align with new expected behavior.

- **Chores**
  - Updated `.gitignore` to exclude `.gritmodules` and `.log` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->