### PR TITLE
feat: add rewritten_text function

### DIFF
--- a/crates/core/src/built_in_functions.rs
+++ b/crates/core/src/built_in_functions.rs
@@ -248,30 +248,25 @@ fn text_fn<'a>(
     let Some(Some(resolved_pattern)) = args.first() else {
         return Err(anyhow!("text takes 1 argument"));
     };
-    let should_linearize = args.get(1);
-    println!("should_linearize: {:?}", should_linearize);
     let should_linearize = match args.get(1) {
-        Some(Some(resolved_pattern)) => true,
+        Some(Some(resolved_pattern)) => resolved_pattern.is_truthy(state, context.language())?,
         _ => false,
     };
-    println!("should_linearize: {:?}", should_linearize);
     if !should_linearize {
-        return Ok(ResolvedPattern::from_string(
-            resolved_pattern.text(&state.files, context.language())?,
-        ));
+        let text = resolved_pattern.text(&state.files, context.language())?;
+        return Ok(ResolvedPattern::from_string(text.to_string()));
     }
-    todo!("Not implemented");
-    // let mut memo: HashMap<CodeRange, Option<String>> = HashMap::new();
-    // let effects: Vec<_> = state.effects.clone().into_iter().collect();
-    // let s = resolved_pattern.linearized_text(
-    //     context.language(),
-    //     &effects,
-    //     &state.files,
-    //     &mut memo,
-    //     false,
-    //     logs,
-    // )?;
-    // Ok(ResolvedPattern::from_string(s.to_string()))
+    let mut memo: HashMap<CodeRange, Option<String>> = HashMap::new();
+    let effects: Vec<_> = state.effects.clone().into_iter().collect();
+    let s = resolved_pattern.linearized_text(
+        context.language(),
+        &effects,
+        &state.files,
+        &mut memo,
+        false,
+        logs,
+    )?;
+    Ok(ResolvedPattern::from_string(s.to_string()))
 }
 
 fn trim_fn<'a>(

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -6541,6 +6541,43 @@ fn even_more_linearized_test() {
 }
 
 #[test]
+fn linearized_text_fn() {
+    run_test_expected({
+        TestArgExpected {
+            pattern: r#"
+                |language js
+                |
+                |function go_to_the_zoo($a) js {
+                |    return $a.text.replaceAll("baz", "bars").replaceAll("zoo", "alexandria")
+                |}
+                |
+                |program() where {
+                |    $program <: contains bubble `foo($a)` => `zoo($a)`,
+                |    $current_text = text($program, true),
+                |    $final_text = go_to_the_zoo($current_text),
+                |    $program => $final_text
+                |}
+                |"#
+            .trim_margin()
+            .unwrap(),
+            source: r#"
+                |foo(bar(baz))
+                |foo(blo, fly)
+                |"#
+            .trim_margin()
+            .unwrap(),
+            expected: r#"
+                |alexandria(bar(bars))
+                |alexandria(blo, fly)
+                |"#
+            .trim_margin()
+            .unwrap(),
+        }
+    })
+    .unwrap();
+}
+
+#[test]
 fn matching_var_snippet_work() {
     run_test_expected({
         TestArgExpected {


### PR DESCRIPTION
Add a second argument to `text()` to determine if we should linearize all current bindings before copying the text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `text` function to include a new `linearize` parameter, allowing for more control over text processing.
	- Introduced a new test function to validate text manipulation functionality.

- **Bug Fixes**
	- Improved functionality of text manipulation to ensure accurate transformations based on the new parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
Added the `rewritten_text` function to enhance text processing capabilities.

- Modified `/crates/util/fixtures/confusing.diff` to replace `keyBy` and `filter` with `groupBy` from lodash.
- Updated `reconstructDiff` function in `/crates/util/fixtures/confusing.diff` to handle `ranges` instead of `files` and added context lines.
- Enhanced error handling and logging in `reconstructDiff` for better debugging.
- Adjusted file reading logic in `/apps/minas/src/sdk/internal.ts` to use `join` from `node:path`.
- Updated type definition in `/packages/api/src/types.ts` to reflect single `range` instead of `ranges`.

<!-- /greptile_comment -->