### PR TITLE
feat: search for built-ins inside functions

### DIFF
--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -531,7 +531,7 @@ pub(crate) async fn run_apply_pattern(
     }
 
     let warn_uncommitted = !arg.dry_run && !arg.force && has_uncommitted_changes(cwd.clone()).await;
-    if warn_uncommitted && has_rewrite(&compiled.pattern, &compiled.pattern_definitions) {
+    if warn_uncommitted && has_rewrite(&compiled.pattern, &compiled.definitions()) {
         let term = console::Term::stderr();
         if !term.is_term() {
             bail!("Error: Untracked changes detected. Grit will not proceed with rewriting files in non-TTY environments unless '--force' is used. Please commit all changes or use '--force' to override this safety check.");

--- a/crates/cli_bin/tests/snapshots/parse__correct_variable_ranges_in_snippet_with_multiple_contexts.snap
+++ b/crates/cli_bin/tests/snapshots/parse__correct_variable_ranges_in_snippet_with_multiple_contexts.snap
@@ -34,3 +34,4 @@ variables:
 sourceFile: "`function () { $body }`"
 parsedPattern: "[..]"
 valid: true
+usesAi: false

--- a/crates/cli_bin/tests/snapshots/parse__correct_variable_ranges_multiple_snippets_multiple_contexts.snap
+++ b/crates/cli_bin/tests/snapshots/parse__correct_variable_ranges_multiple_snippets_multiple_contexts.snap
@@ -67,3 +67,4 @@ variables:
 sourceFile: "or { bubble `function ($args) { $body }`, bubble `($args) => { $body }` }"
 parsedPattern: "[..]"
 valid: true
+usesAi: false

--- a/crates/cli_bin/tests/snapshots/parse__parses_foreign_function.snap
+++ b/crates/cli_bin/tests/snapshots/parse__parses_foreign_function.snap
@@ -23,3 +23,4 @@ variables:
 sourceFile: "engine marzano(0.1)\nlanguage js\n\nfunction adder() js {\n  console.log(\"We are in JavaScript now!\");\n  return 10 % 3\n}\n\n`x` => adder()"
 parsedPattern: "[..]"
 valid: true
+usesAi: false

--- a/crates/cli_bin/tests/snapshots/parse__parses_grit_file.snap
+++ b/crates/cli_bin/tests/snapshots/parse__parses_grit_file.snap
@@ -34,3 +34,4 @@ variables:
 sourceFile: "language js\n\n`console.log($msg)`\n"
 parsedPattern: "[..]"
 valid: true
+usesAi: false

--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -462,11 +462,14 @@ mod tests {
     fn test_is_rewrite_with_function_call() {
         let pattern_src = r#"
             pattern pattern_with_rewrite() {
-                `me` => `console.error(me)`
-            }
+                    `me` => `console.error(me)`
+                }
 
             function more_indirection_is_good() {
-                $program <: contains pattern_with_rewrite()
+                if ($program <: contains pattern_with_rewrite()) {
+                    return `console.error($program)`
+                },
+                return `console.error($program)`
             }
 
             predicate predicate_with_function_call() {

--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -457,4 +457,42 @@ mod tests {
 
         assert!(has_rewrite(&problem.pattern, &problem.definitions()));
     }
+
+    #[test]
+    fn test_is_rewrite_with_function_call() {
+        let pattern_src = r#"
+            pattern pattern_with_rewrite() {
+                `me` => `console.error(me)`
+            }
+
+            function more_indirection_is_good() {
+                $program <: contains pattern_with_rewrite()
+            }
+
+            predicate predicate_with_function_call() {
+                $foo = more_indirection_is_good()
+            }
+
+            `you` where {
+                predicate_with_function_call()
+            }
+        "#
+        .to_string();
+        let libs = BTreeMap::new();
+        let problem = src_to_problem_libs(
+            pattern_src.to_string(),
+            &libs,
+            TargetLanguage::default(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+        .problem;
+
+        println!("problem: {:?}", problem);
+
+        assert!(has_rewrite(&problem.pattern, &problem.definitions()));
+    }
 }

--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -364,6 +364,37 @@ mod tests {
     }
 
     #[test]
+    fn test_is_rewrite_with_yaml() {
+        let pattern_src = r#"
+            language yaml
+
+            or {
+            `- $item` where {
+                $item => `nice: car
+            second: detail`
+            }
+            }
+        "#
+        .to_string();
+        let libs = BTreeMap::new();
+        let problem = src_to_problem_libs(
+            pattern_src.to_string(),
+            &libs,
+            TargetLanguage::default(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+        .problem;
+
+        println!("problem: {:?}", problem);
+
+        assert!(has_rewrite(&problem.pattern, &problem.definitions()));
+    }
+
+    #[test]
     fn test_is_rewrite_with_insert() {
         let pattern_src = r#"
             language yaml

--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -209,25 +209,20 @@ fn uses_named_function(
                 return true;
             }
         }
-        // use grit_pattern_matcher::pattern::PatternName;
-        // match pattern {
-        //     PatternOrPredicate::Pattern(p) => {
-        //         println!("pattern {}", p.name());
-        //     }
-        //     PatternOrPredicate::Predicate(p) => {
-        //         println!("predicate {}", p.name());
-        //     }
-        //     PatternOrPredicate::DynamicPattern(p) => {
-        //         println!("dynamic pattern {}", p.name());
-        //     }
-        // }
     }
     false
 }
 
+pub fn uses_ai(
+    root: &Pattern<MarzanoQueryContext>,
+    definitions: &StaticDefinitions<MarzanoQueryContext>,
+) -> bool {
+    uses_named_function(root, definitions, "llm_chat")
+}
+
 #[cfg(test)]
 mod tests {
-    use grit_pattern_matcher::{context::StaticDefinitions, has_rewrite};
+    use grit_pattern_matcher::has_rewrite;
     use marzano_language::target_language::TargetLanguage;
 
     use crate::pattern_compiler::src_to_problem_libs;

--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -13,7 +13,6 @@ use grit_pattern_matcher::{
 };
 
 use crate::{
-    marzano_context::MarzanoContext,
     pattern_compiler::compiler::{defs_to_filenames, DefsToFilenames},
     problem::MarzanoQueryContext,
 };

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -298,6 +298,7 @@ pub struct PatternInfo {
     pub source_file: String,
     pub parsed_pattern: String,
     pub valid: bool,
+    pub uses_ai: bool,
 }
 
 impl PatternInfo {
@@ -310,12 +311,16 @@ impl PatternInfo {
             &grit_node_types,
         ))
         .unwrap();
+
+        let uses_ai = crate::analysis::uses_ai(&compiled.pattern, &compiled.definitions());
+
         Self {
             messages: vec![],
             variables: compiled.compiled_vars(),
             source_file,
             parsed_pattern,
             valid: true,
+            uses_ai,
         }
     }
 }

--- a/crates/core/src/ast_node.rs
+++ b/crates/core/src/ast_node.rs
@@ -32,7 +32,7 @@ impl AstNodePattern<MarzanoQueryContext> for ASTNode {
 
     fn children<'a>(
         &'a self,
-        _definitions: &'a [PatternDefinition<MarzanoQueryContext>],
+        _definitions: &'a grit_pattern_matcher::context::StaticDefinitions<MarzanoQueryContext>,
     ) -> Vec<PatternOrPredicate<'a, MarzanoQueryContext>> {
         self.args
             .iter()

--- a/crates/core/src/ast_node.rs
+++ b/crates/core/src/ast_node.rs
@@ -3,7 +3,7 @@ use crate::{
     problem::MarzanoQueryContext,
 };
 use anyhow::{anyhow, Result};
-use grit_pattern_matcher::pattern::PatternDefinition;
+
 use grit_pattern_matcher::{
     binding::Binding,
     pattern::{

--- a/crates/core/src/built_in_functions.rs
+++ b/crates/core/src/built_in_functions.rs
@@ -85,6 +85,7 @@ impl BuiltIns {
         built_ins: &BuiltIns,
         index: usize,
         lang: &impl Language,
+        name: &str,
     ) -> Result<CallBuiltIn<MarzanoQueryContext>> {
         let params = &built_ins.0[index].params;
         let mut pattern_params = Vec::with_capacity(args.len());
@@ -94,7 +95,7 @@ impl BuiltIns {
                 None => pattern_params.push(None),
             }
         }
-        Ok(CallBuiltIn::new(index, pattern_params))
+        Ok(CallBuiltIn::new(index, name, pattern_params))
     }
 
     /// Add an anonymous built-in, used for callbacks

--- a/crates/core/src/pattern_compiler/builder.rs
+++ b/crates/core/src/pattern_compiler/builder.rs
@@ -289,6 +289,7 @@ impl PatternBuilder {
         let predicate_match = Predicate::Match(Box::new(Match::new(
             Container::FunctionCall(Box::new(CallBuiltIn::new(
                 index,
+                &format!("match_{}", index),
                 vec![Some(grit_pattern_matcher::pattern::Pattern::Variable(
                     match_var,
                 ))],

--- a/crates/core/src/pattern_compiler/call_compiler.rs
+++ b/crates/core/src/pattern_compiler/call_compiler.rs
@@ -100,6 +100,7 @@ impl NodeCompiler for CallCompiler {
                 context.compilation.built_ins,
                 index,
                 lang,
+                kind,
             )?)))
         } else if let Some(info) = context.compilation.function_definition_info.get(kind) {
             let args = match_args_to_params(kind, args, &collect_params(&info.parameters), lang)?;

--- a/crates/core/src/pattern_compiler/not_compiler.rs
+++ b/crates/core/src/pattern_compiler/not_compiler.rs
@@ -4,7 +4,10 @@ use super::{
 };
 use crate::problem::MarzanoQueryContext;
 use anyhow::{anyhow, Result};
-use grit_pattern_matcher::pattern::{Not, Pattern, PatternOrPredicate, PrNot, Predicate};
+use grit_pattern_matcher::{
+    context::StaticDefinitions,
+    pattern::{Not, Pattern, PatternOrPredicate, PrNot, Predicate},
+};
 use grit_util::AnalysisLogBuilder;
 use marzano_util::node_with_source::NodeWithSource;
 
@@ -23,7 +26,7 @@ impl NodeCompiler for NotCompiler {
             .ok_or_else(|| anyhow!("missing pattern of patternNot"))?;
         let range = pattern.range();
         let pattern = PatternCompiler::from_node(&pattern, context)?;
-        if pattern.iter(&[]).any(|p| {
+        if pattern.iter(&StaticDefinitions::default()).any(|p| {
             matches!(
                 p,
                 PatternOrPredicate::Pattern(Pattern::Rewrite(_))
@@ -59,7 +62,7 @@ impl NodeCompiler for PrNotCompiler {
             .ok_or_else(|| anyhow!("predicateNot missing predicate"))?;
         let range = not.range();
         let not = PredicateCompiler::from_node(&not, context)?;
-        if not.iter(&[]).any(|p| {
+        if not.iter(&StaticDefinitions::default()).any(|p| {
             matches!(
                 p,
                 PatternOrPredicate::Pattern(Pattern::Rewrite(_))

--- a/crates/core/src/problem.rs
+++ b/crates/core/src/problem.rs
@@ -68,7 +68,11 @@ impl Problem {
     }
 
     pub fn definitions(&self) -> StaticDefinitions<'_, MarzanoQueryContext> {
-        StaticDefinitions::new(&self.pattern_definitions, &self.predicate_definitions)
+        StaticDefinitions::new(
+            &self.pattern_definitions,
+            &self.predicate_definitions,
+            &self.function_definitions,
+        )
     }
 }
 

--- a/crates/core/src/problem.rs
+++ b/crates/core/src/problem.rs
@@ -12,7 +12,7 @@ use crate::{
 use anyhow::{bail, Result};
 use grit_pattern_matcher::{
     constants::{GLOBAL_VARS_SCOPE_INDEX, NEW_FILES_INDEX},
-    context::QueryContext,
+    context::{QueryContext, StaticDefinitions},
     file_owners::FileOwners,
     pattern::{
         FilePtr, FileRegistry, GritFunctionDefinition, Matcher, Pattern, PatternDefinition,
@@ -65,6 +65,10 @@ pub struct Problem {
 impl Problem {
     pub fn compiled_vars(&self) -> Vec<VariableMatch> {
         self.variables.compiled_vars(&self.tree.source)
+    }
+
+    pub fn definitions(&self) -> StaticDefinitions<'_, MarzanoQueryContext> {
+        StaticDefinitions::new(&self.pattern_definitions, &self.predicate_definitions)
     }
 }
 

--- a/crates/grit-pattern-matcher/src/analysis.rs
+++ b/crates/grit-pattern-matcher/src/analysis.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::{QueryContext, StaticDefinitions},
-    pattern::{Pattern, PatternDefinition, PatternOrPredicate, Predicate},
+    pattern::{Pattern, PatternOrPredicate, Predicate},
 };
 
 /// Determine if a provided pattern has a rewrite anywhere inside of it

--- a/crates/grit-pattern-matcher/src/analysis.rs
+++ b/crates/grit-pattern-matcher/src/analysis.rs
@@ -26,15 +26,6 @@ pub fn has_rewrite<Q: QueryContext>(
         ) {
             return true;
         }
-        use crate::pattern::PatternName;
-        match pattern {
-            PatternOrPredicate::Pattern(p) => {
-                println!("pattern {}", p.name());
-            }
-            PatternOrPredicate::Predicate(p) => {
-                println!("predicate {}", p.name());
-            }
-        }
     }
     false
 }

--- a/crates/grit-pattern-matcher/src/analysis.rs
+++ b/crates/grit-pattern-matcher/src/analysis.rs
@@ -26,14 +26,15 @@ pub fn has_rewrite<Q: QueryContext>(
         ) {
             return true;
         }
-        // match pattern {
-        //     PatternOrPredicate::Pattern(p) => {
-        //         println!("Check {}", p.name());
-        //     }
-        //     PatternOrPredicate::Predicate(p) => {
-        //         println!("Check {}", p.name());
-        //     }
-        // }
+        use crate::pattern::PatternName;
+        match pattern {
+            PatternOrPredicate::Pattern(p) => {
+                println!("pattern {}", p.name());
+            }
+            PatternOrPredicate::Predicate(p) => {
+                println!("predicate {}", p.name());
+            }
+        }
     }
     false
 }

--- a/crates/grit-pattern-matcher/src/analysis.rs
+++ b/crates/grit-pattern-matcher/src/analysis.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::QueryContext,
+    context::{QueryContext, StaticDefinitions},
     pattern::{Pattern, PatternDefinition, PatternOrPredicate, Predicate},
 };
 
@@ -8,7 +8,7 @@ use crate::{
 /// Note this does not yet walk inside predicates and function calls
 pub fn has_rewrite<Q: QueryContext>(
     current_pattern: &Pattern<Q>,
-    definitions: &[PatternDefinition<Q>],
+    definitions: &StaticDefinitions<Q>,
 ) -> bool {
     for pattern in current_pattern.iter(definitions) {
         if matches!(pattern, PatternOrPredicate::Pattern(Pattern::Rewrite(_))) {

--- a/crates/grit-pattern-matcher/src/context.rs
+++ b/crates/grit-pattern-matcher/src/context.rs
@@ -67,3 +67,40 @@ pub trait ExecContext<'a, Q: QueryContext> {
 
     fn name(&self) -> Option<&str>;
 }
+
+/// Static information used for a pattern
+/// This is useful for static analysis of patterns without running the query engine.
+#[derive(Debug)]
+pub struct StaticDefinitions<'a, Q: QueryContext> {
+    pub pattern_definitions: &'a [PatternDefinition<Q>],
+    pub predicate_definitions: &'a [PredicateDefinition<Q>],
+}
+
+impl<'a, Q: QueryContext> StaticDefinitions<'a, Q> {
+    pub fn new(
+        pattern_definitions: &'a [PatternDefinition<Q>],
+        predicate_definitions: &'a [PredicateDefinition<Q>],
+    ) -> Self {
+        StaticDefinitions {
+            pattern_definitions,
+            predicate_definitions,
+        }
+    }
+
+    pub fn get_pattern(&self, index: usize) -> Option<&PatternDefinition<Q>> {
+        self.pattern_definitions.get(index)
+    }
+
+    pub fn get_predicate(&self, index: usize) -> Option<&PredicateDefinition<Q>> {
+        self.predicate_definitions.get(index)
+    }
+}
+
+impl<'a, Q: QueryContext> Default for StaticDefinitions<'a, Q> {
+    fn default() -> Self {
+        Self {
+            pattern_definitions: &[],
+            predicate_definitions: &[],
+        }
+    }
+}

--- a/crates/grit-pattern-matcher/src/context.rs
+++ b/crates/grit-pattern-matcher/src/context.rs
@@ -72,18 +72,21 @@ pub trait ExecContext<'a, Q: QueryContext> {
 /// This is useful for static analysis of patterns without running the query engine.
 #[derive(Debug)]
 pub struct StaticDefinitions<'a, Q: QueryContext> {
-    pub pattern_definitions: &'a [PatternDefinition<Q>],
-    pub predicate_definitions: &'a [PredicateDefinition<Q>],
+    pattern_definitions: &'a [PatternDefinition<Q>],
+    predicate_definitions: &'a [PredicateDefinition<Q>],
+    function_definitions: &'a [GritFunctionDefinition<Q>],
 }
 
 impl<'a, Q: QueryContext> StaticDefinitions<'a, Q> {
     pub fn new(
         pattern_definitions: &'a [PatternDefinition<Q>],
         predicate_definitions: &'a [PredicateDefinition<Q>],
+        function_definitions: &'a [GritFunctionDefinition<Q>],
     ) -> Self {
         StaticDefinitions {
             pattern_definitions,
             predicate_definitions,
+            function_definitions,
         }
     }
 
@@ -94,6 +97,10 @@ impl<'a, Q: QueryContext> StaticDefinitions<'a, Q> {
     pub fn get_predicate(&self, index: usize) -> Option<&PredicateDefinition<Q>> {
         self.predicate_definitions.get(index)
     }
+
+    pub fn get_function(&self, index: usize) -> Option<&GritFunctionDefinition<Q>> {
+        self.function_definitions.get(index)
+    }
 }
 
 impl<'a, Q: QueryContext> Default for StaticDefinitions<'a, Q> {
@@ -101,6 +108,7 @@ impl<'a, Q: QueryContext> Default for StaticDefinitions<'a, Q> {
         Self {
             pattern_definitions: &[],
             predicate_definitions: &[],
+            function_definitions: &[],
         }
     }
 }

--- a/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
@@ -3,7 +3,7 @@ use super::{
     patterns::{Matcher, PatternName},
     PatternDefinition,
 };
-use crate::context::QueryContext;
+use crate::context::{QueryContext, StaticDefinitions};
 
 /// Type of pattern that matches against an individual (non-leaf) AST node.
 pub trait AstNodePattern<Q: QueryContext>:
@@ -15,7 +15,7 @@ pub trait AstNodePattern<Q: QueryContext>:
 
     fn children<'a>(
         &'a self,
-        definitions: &'a [PatternDefinition<Q>],
+        definitions: &'a StaticDefinitions<Q>,
     ) -> Vec<PatternOrPredicate<'a, Q>>;
 
     fn matches_kind_of(&self, node: &Q::Node<'_>) -> bool;

--- a/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/ast_node_pattern.rs
@@ -1,7 +1,6 @@
 use super::{
     iter_pattern::PatternOrPredicate,
     patterns::{Matcher, PatternName},
-    PatternDefinition,
 };
 use crate::context::{QueryContext, StaticDefinitions};
 

--- a/crates/grit-pattern-matcher/src/pattern/call.rs
+++ b/crates/grit-pattern-matcher/src/pattern/call.rs
@@ -45,7 +45,7 @@ impl<Q: QueryContext> Matcher<Q> for Call<Q> {
 
 #[derive(Debug, Clone)]
 pub struct PrCall<Q: QueryContext> {
-    index: usize,
+    pub(crate) index: usize,
     pub args: Vec<Option<Pattern<Q>>>,
 }
 

--- a/crates/grit-pattern-matcher/src/pattern/call_built_in.rs
+++ b/crates/grit-pattern-matcher/src/pattern/call_built_in.rs
@@ -13,12 +13,17 @@ use grit_util::AnalysisLogs;
 #[derive(Debug, Clone)]
 pub struct CallBuiltIn<Q: QueryContext> {
     pub index: usize,
+    pub name: String,
     pub args: Vec<Option<Pattern<Q>>>,
 }
 
 impl<Q: QueryContext> CallBuiltIn<Q> {
-    pub fn new(index: usize, args: Vec<Option<Pattern<Q>>>) -> Self {
-        Self { index, args }
+    pub fn new(index: usize, name: &str, args: Vec<Option<Pattern<Q>>>) -> Self {
+        Self {
+            index,
+            name: name.to_string(),
+            args,
+        }
     }
 }
 

--- a/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
@@ -1,7 +1,6 @@
 use super::{
     accessor::Accessor, container::Container, dynamic_snippet::DynamicPattern,
     list_index::ListIndex, patterns::Pattern, predicates::Predicate, regex::RegexLike,
-    PatternDefinition,
 };
 use crate::{
     context::{QueryContext, StaticDefinitions},

--- a/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
@@ -50,6 +50,7 @@ impl<'a, Q: QueryContext> PatternOrPredicateIterator<'a, Q> {
 pub enum PatternOrPredicate<'a, Q: QueryContext> {
     Pattern(&'a Pattern<Q>),
     Predicate(&'a Predicate<Q>),
+    DynamicPattern(&'a DynamicPattern<Q>),
 }
 
 impl<'a, Q: QueryContext> PatternOrPredicate<'a, Q> {
@@ -57,6 +58,7 @@ impl<'a, Q: QueryContext> PatternOrPredicate<'a, Q> {
         match self {
             PatternOrPredicate::Pattern(p) => p.children(definitions),
             PatternOrPredicate::Predicate(p) => p.children(definitions),
+            PatternOrPredicate::DynamicPattern(p) => p.children(definitions),
         }
     }
 }
@@ -333,9 +335,10 @@ impl<Q: QueryContext> Pattern<Q> {
             }
             Pattern::Variable(_) => Vec::new(),
             Pattern::Rewrite(r) => {
-                let mut res = r.right.children(definitions);
-                res.push(PatternOrPredicate::Pattern(&r.left));
-                res
+                vec![
+                    PatternOrPredicate::Pattern(&r.left),
+                    PatternOrPredicate::DynamicPattern(&r.right),
+                ]
             }
             Pattern::Log(l) => l.message.iter().map(PatternOrPredicate::Pattern).collect(),
             Pattern::Range(_) => Vec::new(),

--- a/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
@@ -286,7 +286,14 @@ impl<Q: QueryContext> Pattern<Q> {
             }
             Pattern::Limit(l) => l.pattern.children(definitions),
             Pattern::CallBuiltIn(c) => args_children(&c.args, definitions),
-            Pattern::CallFunction(c) => args_children(&c.args, definitions),
+            Pattern::CallFunction(c) => {
+                let mut children = args_children(&c.args, definitions);
+                let def = definitions.get_function(c.index);
+                if let Some(def) = def {
+                    children.extend(def.function.children(definitions));
+                }
+                children
+            }
             Pattern::CallForeignFunction(c) => args_children(&c.args, definitions),
             Pattern::Assignment(a) => vec![PatternOrPredicate::Pattern(&a.pattern)],
             Pattern::Accumulate(a) => vec![

--- a/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
@@ -131,7 +131,14 @@ impl<Q: QueryContext> Container<Q> {
             Container::Variable(_) => vec![],
             Container::Accessor(a) => a.children(definitions),
             Container::ListIndex(l) => l.children(definitions),
-            Container::FunctionCall(f) => args_children(&f.args, definitions),
+            Container::FunctionCall(f) => {
+                let mut base = args_children(&f.args, definitions);
+                let def = definitions.get_function(f.index);
+                if let Some(def) = def {
+                    base.push(PatternOrPredicate::Predicate(&def.function));
+                }
+                base
+            }
         }
     }
 }

--- a/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/iter_pattern.rs
@@ -74,7 +74,14 @@ impl<Q: QueryContext> Predicate<Q> {
         definitions: &'a StaticDefinitions<Q>,
     ) -> Vec<PatternOrPredicate<'a, Q>> {
         match self {
-            Predicate::Call(call) => args_children(&call.args, definitions),
+            Predicate::Call(call) => {
+                let mut base = args_children(&call.args, definitions);
+                let def = definitions.get_predicate(call.index);
+                if let Some(def) = def {
+                    base.push(PatternOrPredicate::Predicate(&def.predicate));
+                }
+                base
+            }
             Predicate::Not(not) => vec![PatternOrPredicate::Predicate(&not.predicate)],
             Predicate::If(if_) => vec![
                 PatternOrPredicate::Predicate(&if_.if_),

--- a/crates/wasm-bindings/src/match_pattern.rs
+++ b/crates/wasm-bindings/src/match_pattern.rs
@@ -121,12 +121,15 @@ pub async fn parse_input_files_internal(
                 .iter()
                 .map(|w| MatchResult::AnalysisLog(w.clone().into()));
 
+            let uses_ai = marzano_core::analysis::uses_ai(&c.problem.pattern, &c.problem.definitions());
+
             let pinfo = PatternInfo {
                 messages: vec![],
                 variables: c.problem.compiled_vars(),
                 source_file: pattern,
                 parsed_pattern,
                 valid: true,
+                uses_ai
             };
             let pinfo = MatchResult::PatternInfo(pinfo);
             results.push(pinfo);


### PR DESCRIPTION
Allow us to statically analyze a pattern for llm_chat usage.

The goal is to replace the (very) hacky `isAi` function we currently use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced AI analysis capabilities with the addition of functions to check for AI usage in patterns.
	- Added support for `StaticDefinitions` to improve pattern matching performance and clarity.
	- Enhanced `PatternInfo` structure to include a field indicating AI utilization.
	
- **Bug Fixes**
	- Improved handling of uncommitted changes warnings during command execution.
	
- **Chores**
	- Cleaned up code by removing commented-out sections and streamlining logic for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->