### PR TITLE
fix: propagate workflow outcomes

### DIFF
--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -162,13 +162,13 @@ pub fn print_file_header(
 fn get_pretty_workflow_message(
     outcome: &marzano_messenger::workflows::PackagedWorkflowOutcome,
 ) -> String {
-    let outcome = match outcome.outcome {
+    let emoji = match outcome.get_outcome() {
         marzano_messenger::workflows::OutcomeKind::Success => "✅",
         marzano_messenger::workflows::OutcomeKind::Failure => "❌",
         marzano_messenger::workflows::OutcomeKind::Skipped => "⚪️",
     };
     let message = outcome.message.as_deref().unwrap_or("Workflow finished");
-    format!("{} {}", outcome, message)
+    format!("{} {}", emoji, message)
 }
 
 impl fmt::Display for FormattedResult {

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -162,20 +162,13 @@ pub fn print_file_header(
 fn get_pretty_workflow_message(
     outcome: &marzano_messenger::workflows::PackagedWorkflowOutcome,
 ) -> String {
-    match outcome.success {
-        true => {
-            format!(
-                "✅ {}",
-                outcome.message.as_deref().unwrap_or("Workflow finished")
-            )
-        }
-        false => {
-            format!(
-                "❌ {}",
-                outcome.message.as_deref().unwrap_or("Workflow failed")
-            )
-        }
-    }
+    let outcome = match outcome.outcome {
+        marzano_messenger::workflows::OutcomeKind::Success => "✅",
+        marzano_messenger::workflows::OutcomeKind::Failure => "❌",
+        marzano_messenger::workflows::OutcomeKind::Skipped => "⚪️",
+    };
+    let message = outcome.message.as_deref().unwrap_or("Workflow finished");
+    format!("{} {}", outcome, message)
 }
 
 impl fmt::Display for FormattedResult {

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -166,10 +166,7 @@ fn get_pretty_workflow_message(
         true => {
             format!(
                 "✅ {}",
-                outcome
-                    .message
-                    .as_deref()
-                    .unwrap_or("Workflow completed successfully")
+                outcome.message.as_deref().unwrap_or("Workflow finished")
             )
         }
         false => {

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -176,6 +176,7 @@ where
             emitter,
             PackagedWorkflowOutcome {
                 message: None,
+                outcome: None,
                 success: true,
                 data: None,
             },
@@ -185,6 +186,7 @@ where
             emitter,
             PackagedWorkflowOutcome {
                 message: None,
+                outcome: None,
                 success: false,
                 data: None,
             },

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -175,7 +175,7 @@ where
         Ok((
             emitter,
             PackagedWorkflowOutcome {
-                message: Some("Workflow completed successfully".to_string()),
+                message: None,
                 success: true,
                 data: None,
             },
@@ -184,7 +184,7 @@ where
         Ok((
             emitter,
             PackagedWorkflowOutcome {
-                message: Some("Workflow failed".to_string()),
+                message: None,
                 success: false,
                 data: None,
             },

--- a/crates/marzano_messenger/src/workflows.rs
+++ b/crates/marzano_messenger/src/workflows.rs
@@ -5,11 +5,36 @@ use serde::{Deserialize, Serialize};
 
 use crate::emit::Messager;
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum OutcomeKind {
+    #[serde(rename = "success")]
+    Success,
+    #[serde(rename = "failure")]
+    Failure,
+    #[serde(rename = "skipped")]
+    Skipped,
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct PackagedWorkflowOutcome {
     pub message: Option<String>,
+    pub outcome: Option<OutcomeKind>,
     pub success: bool,
     pub data: Option<serde_json::Value>,
+}
+
+impl PackagedWorkflowOutcome {
+    pub fn outcome(&self) -> OutcomeKind {
+        if let Some(outcome) = self.outcome.as_ref() {
+            return outcome.clone();
+        }
+
+        if self.success {
+            OutcomeKind::Success
+        } else {
+            OutcomeKind::Failure
+        }
+    }
 }
 
 /// Handle workflow-related messages

--- a/crates/marzano_messenger/src/workflows.rs
+++ b/crates/marzano_messenger/src/workflows.rs
@@ -24,7 +24,7 @@ pub struct PackagedWorkflowOutcome {
 }
 
 impl PackagedWorkflowOutcome {
-    pub fn outcome(&self) -> OutcomeKind {
+    pub fn get_outcome(&self) -> OutcomeKind {
         if let Some(outcome) = self.outcome.as_ref() {
             return outcome.clone();
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified success message for workflow completion to "Workflow finished."
	- Introduced a new outcome categorization with options for `Success`, `Failure`, and `Skipped`.
	- Enhanced reporting of workflow outcomes through the new `OutcomeKind` enum.

- **Bug Fixes**
	- Adjusted logic for handling workflow messages to ensure consistent outcome reporting.  
	- Removed contextual messages for successful and failed workflows, resulting in a more generic reporting approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->