### PR TITLE
fix: remove min_level spread throughout the codebase

### DIFF
--- a/crates/cli/src/analyze.rs
+++ b/crates/cli/src/analyze.rs
@@ -133,7 +133,7 @@ macro_rules! emit_error {
                     range: None,
                     source: None,
                 });
-                $emitter.emit(&log, $min_level).unwrap();
+                $emitter.emit(&log).unwrap();
                 return $emitter;
             }
         }
@@ -240,7 +240,6 @@ where
                             vec![log, done_file],
                             details,
                             arg.dry_run,
-                            min_level,
                             arg.format,
                             &mut interactive,
                             None,
@@ -312,7 +311,6 @@ where
                     message,
                     details,
                     arg.dry_run,
-                    min_level,
                     arg.format,
                     &mut interactive,
                     pg,

--- a/crates/cli/src/analyze.rs
+++ b/crates/cli/src/analyze.rs
@@ -189,7 +189,6 @@ where
     let cache_ref = &cache;
 
     let mut interactive = arg.interactive;
-    let min_level = &arg.visibility;
 
     let (found_count, disk_paths) = match my_input {
         ApplyInput::Disk(ref my_input) => {

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -81,6 +81,7 @@ pub(crate) async fn run_apply(
                 ranges,
                 args.apply_migration_args,
                 flags,
+                args.apply_pattern_args.visibility,
             )
             .await;
         }

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -65,6 +65,8 @@ pub(crate) async fn run_apply_migration(
     arg: ApplyMigrationArgs,
     flags: &GlobalFormatFlags,
 ) -> Result<()> {
+    use marzano_messenger::emit::VisibilityLevels;
+
     let input = arg.get_payload()?;
 
     let format = OutputFormat::from(flags);
@@ -75,6 +77,7 @@ pub(crate) async fn run_apply_migration(
         false,
         None,
         None,
+        VisibilityLevels::default(),
     )
     .await?;
 

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -64,9 +64,8 @@ pub(crate) async fn run_apply_migration(
     ranges: Option<Vec<marzano_util::diff::FileDiff>>,
     arg: ApplyMigrationArgs,
     flags: &GlobalFormatFlags,
+    min_level: marzano_messenger::emit::VisibilityLevels,
 ) -> Result<()> {
-    use marzano_messenger::emit::VisibilityLevels;
-
     let input = arg.get_payload()?;
 
     let format = OutputFormat::from(flags);
@@ -77,7 +76,7 @@ pub(crate) async fn run_apply_migration(
         false,
         None,
         None,
-        VisibilityLevels::default(),
+        min_level,
     )
     .await?;
 

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -255,6 +255,7 @@ pub(crate) async fn run_apply_pattern(
         interactive,
         Some(&pattern),
         root_path.as_ref(),
+        *min_level,
     )
     .await?;
 

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -380,7 +380,7 @@ pub(crate) async fn run_apply_pattern(
                             range: None,
                             source: None,
                         });
-                        emitter.emit(&log, min_level).unwrap();
+                        emitter.emit(&log ).unwrap();
                         emitter.flush().await?;
                         if format.is_always_ok().0 {
                             return Ok(());
@@ -463,7 +463,7 @@ pub(crate) async fn run_apply_pattern(
             found: 0,
             reason: AllDoneReason::NoInputPaths,
         });
-        emitter.emit(&all_done, min_level).unwrap();
+        emitter.emit(&all_done ).unwrap();
         emitter.flush().await?;
 
         return Ok(());
@@ -511,7 +511,7 @@ pub(crate) async fn run_apply_pattern(
                 },
             };
             emitter
-                .emit(&MatchResult::AnalysisLog(log.clone()), min_level)
+                .emit(&MatchResult::AnalysisLog(log.clone()), )
                 .unwrap();
             emitter.flush().await?;
             match format.is_always_ok() {
@@ -526,7 +526,7 @@ pub(crate) async fn run_apply_pattern(
     };
     for warn in compilation_warnings.clone().into_iter() {
         emitter
-            .emit(&MatchResult::AnalysisLog(warn.into()), min_level)
+            .emit(&MatchResult::AnalysisLog(warn.into()), )
             .unwrap();
     }
 
@@ -568,7 +568,7 @@ pub(crate) async fn run_apply_pattern(
         reason: AllDoneReason::AllMatchesFound,
     });
 
-    emitter.emit(&all_done, min_level).unwrap();
+    emitter.emit(&all_done, ).unwrap();
 
     emitter.flush().await?;
 

--- a/crates/cli/src/commands/apply_pattern.rs
+++ b/crates/cli/src/commands/apply_pattern.rs
@@ -380,7 +380,7 @@ pub(crate) async fn run_apply_pattern(
                             range: None,
                             source: None,
                         });
-                        emitter.emit(&log ).unwrap();
+                        emitter.emit(&log).unwrap();
                         emitter.flush().await?;
                         if format.is_always_ok().0 {
                             return Ok(());
@@ -463,7 +463,7 @@ pub(crate) async fn run_apply_pattern(
             found: 0,
             reason: AllDoneReason::NoInputPaths,
         });
-        emitter.emit(&all_done ).unwrap();
+        emitter.emit(&all_done).unwrap();
         emitter.flush().await?;
 
         return Ok(());
@@ -511,7 +511,7 @@ pub(crate) async fn run_apply_pattern(
                 },
             };
             emitter
-                .emit(&MatchResult::AnalysisLog(log.clone()), )
+                .emit(&MatchResult::AnalysisLog(log.clone()))
                 .unwrap();
             emitter.flush().await?;
             match format.is_always_ok() {
@@ -526,7 +526,7 @@ pub(crate) async fn run_apply_pattern(
     };
     for warn in compilation_warnings.clone().into_iter() {
         emitter
-            .emit(&MatchResult::AnalysisLog(warn.into()), )
+            .emit(&MatchResult::AnalysisLog(warn.into()))
             .unwrap();
     }
 
@@ -568,7 +568,7 @@ pub(crate) async fn run_apply_pattern(
         reason: AllDoneReason::AllMatchesFound,
     });
 
-    emitter.emit(&all_done, ).unwrap();
+    emitter.emit(&all_done).unwrap();
 
     emitter.flush().await?;
 

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -13,7 +13,7 @@ use marzano_core::{
 };
 use marzano_gritmodule::{config::ResolvedGritDefinition, utils::extract_path};
 use marzano_language::target_language::{expand_paths, PatternLanguage};
-use marzano_messenger::emit::FlushableMessenger as _;
+use marzano_messenger::emit::{FlushableMessenger as _, VisibilityLevels};
 use marzano_util::cache::GritCache;
 use marzano_util::rich_path::RichPath;
 use marzano_util::{finder::get_input_files, rich_path::RichFile};
@@ -251,6 +251,7 @@ pub(crate) async fn run_check(
             false,
             None,
             root_path.as_ref(),
+            VisibilityLevels::Supplemental,
         )
         .await?;
 

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -300,9 +300,7 @@ pub(crate) async fn run_check(
                 };
                 let rewrite_with_reason = rewrite_with_reason.as_ref();
                 let message = rewrite_with_reason.unwrap_or(&result.result);
-                emitter
-                    .emit(message )
-                    .unwrap();
+                emitter.emit(message).unwrap();
             }
         }
         let safe_total_file_count = std::cmp::min(total_file_count, i32::MAX as usize) as i32;
@@ -311,9 +309,7 @@ pub(crate) async fn run_check(
             found: 0,
             reason: AllDoneReason::AllMatchesFound,
         });
-        emitter
-            .emit(&all_done )
-            .unwrap();
+        emitter.emit(&all_done).unwrap();
 
         emitter.flush().await?;
 

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -301,7 +301,7 @@ pub(crate) async fn run_check(
                 let rewrite_with_reason = rewrite_with_reason.as_ref();
                 let message = rewrite_with_reason.unwrap_or(&result.result);
                 emitter
-                    .emit(message, &VisibilityLevels::Supplemental)
+                    .emit(message )
                     .unwrap();
             }
         }
@@ -312,7 +312,7 @@ pub(crate) async fn run_check(
             reason: AllDoneReason::AllMatchesFound,
         });
         emitter
-            .emit(&all_done, &VisibilityLevels::Supplemental)
+            .emit(&all_done )
             .unwrap();
 
         emitter.flush().await?;

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -25,7 +25,7 @@ use std::{
 };
 use tokio::try_join;
 
-use marzano_messenger::emit::{Messager, VisibilityLevels};
+use marzano_messenger::emit::Messager;
 
 #[cfg(feature = "server")]
 use cli_server::check::CheckMessenger;

--- a/crates/cli/src/commands/parse.rs
+++ b/crates/cli/src/commands/parse.rs
@@ -43,7 +43,9 @@ pub(crate) async fn run_parse(
         bail!("Only JSONL output is supported for parse command");
     }
 
-    let mut emitter = JSONLineMessenger::new(io::stdout(), OutputMode::default());
+    let visibility = VisibilityLevels::Hidden;
+
+    let mut emitter = JSONLineMessenger::new(io::stdout(), OutputMode::default(), visibility);
 
     let parse_input = ParseInput {
         pattern_body: pattern_body.to_owned().unwrap_or_default(),
@@ -54,7 +56,6 @@ pub(crate) async fn run_parse(
     let lang: TargetLanguage = PatternLanguage::get_language(&parse_input.pattern_body)
         .unwrap_or_default()
         .try_into()?;
-    let visibility = VisibilityLevels::Hidden;
 
     if let Some(body) = pattern_body {
         let result = parse_one_pattern(body, None).await?;

--- a/crates/cli/src/commands/parse.rs
+++ b/crates/cli/src/commands/parse.rs
@@ -58,7 +58,7 @@ pub(crate) async fn run_parse(
 
     if let Some(body) = pattern_body {
         let result = parse_one_pattern(body, None).await?;
-        emitter.emit(&result )?;
+        emitter.emit(&result)?;
     }
 
     for path in parse_input.paths {
@@ -75,7 +75,7 @@ pub(crate) async fn run_parse(
             };
             MatchResult::InputFile(input_file)
         };
-        emitter.emit(&match_result )?;
+        emitter.emit(&match_result)?;
     }
 
     Ok(())

--- a/crates/cli/src/commands/parse.rs
+++ b/crates/cli/src/commands/parse.rs
@@ -58,7 +58,7 @@ pub(crate) async fn run_parse(
 
     if let Some(body) = pattern_body {
         let result = parse_one_pattern(body, None).await?;
-        emitter.emit(&result, &visibility)?;
+        emitter.emit(&result )?;
     }
 
     for path in parse_input.paths {
@@ -75,7 +75,7 @@ pub(crate) async fn run_parse(
             };
             MatchResult::InputFile(input_file)
         };
-        emitter.emit(&match_result, &visibility)?;
+        emitter.emit(&match_result )?;
     }
 
     Ok(())

--- a/crates/cli/src/commands/plumbing.rs
+++ b/crates/cli/src/commands/plumbing.rs
@@ -8,7 +8,7 @@ use marzano_gritmodule::fetcher::KeepFetcherKind;
 use marzano_gritmodule::patterns_directory::PatternsDirectory;
 use marzano_gritmodule::searcher::find_grit_modules_dir;
 use marzano_gritmodule::utils::is_pattern_name;
-use marzano_messenger::emit::ApplyDetails;
+use marzano_messenger::emit::{ApplyDetails, VisibilityLevels};
 use serde::{Deserialize, Serialize};
 use std::env::current_dir;
 use std::io::{stdin, Read};
@@ -316,6 +316,7 @@ pub(crate) async fn run_plumbing(
                     verbose: true,
                 },
                 &parent,
+                VisibilityLevels::default(),
             )
             .await
         }

--- a/crates/cli/src/jsonl.rs
+++ b/crates/cli/src/jsonl.rs
@@ -23,6 +23,11 @@ impl<'a> JSONLineMessenger<'a> {
 }
 
 impl<'a> Messager for JSONLineMessenger<'a> {
+    fn get_min_level(&self) -> VisibilityLevels {
+        // You'll need to decide on a default level or store it in the struct
+        VisibilityLevels::Supplemental
+    }
+
     fn raw_emit(&mut self, item: &MatchResult) -> anyhow::Result<()> {
         let mut writer = self
             .writer

--- a/crates/cli/src/jsonl.rs
+++ b/crates/cli/src/jsonl.rs
@@ -6,7 +6,10 @@ use std::{
 use anyhow::anyhow;
 use marzano_core::{api::MatchResult, compact_api::compact};
 
-use marzano_messenger::{emit::Messager, output_mode::OutputMode};
+use marzano_messenger::{
+    emit::{Messager, VisibilityLevels},
+    output_mode::OutputMode,
+};
 
 pub struct JSONLineMessenger<'a> {
     writer: Arc<Mutex<Box<dyn Write + Send + 'a>>>,

--- a/crates/cli/src/jsonl.rs
+++ b/crates/cli/src/jsonl.rs
@@ -14,21 +14,26 @@ use marzano_messenger::{
 pub struct JSONLineMessenger<'a> {
     writer: Arc<Mutex<Box<dyn Write + Send + 'a>>>,
     mode: OutputMode,
+    min_level: VisibilityLevels,
 }
 
 impl<'a> JSONLineMessenger<'a> {
-    pub fn new<W: Write + Send + 'static>(writer: W, mode: OutputMode) -> Self {
+    pub fn new<W: Write + Send + 'static>(
+        writer: W,
+        mode: OutputMode,
+        min_level: VisibilityLevels,
+    ) -> Self {
         Self {
             writer: Arc::new(Mutex::new(Box::new(writer))),
             mode,
+            min_level,
         }
     }
 }
 
 impl<'a> Messager for JSONLineMessenger<'a> {
     fn get_min_level(&self) -> VisibilityLevels {
-        // You'll need to decide on a default level or store it in the struct
-        VisibilityLevels::Supplemental
+        self.min_level
     }
 
     fn raw_emit(&mut self, item: &MatchResult) -> anyhow::Result<()> {

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -260,12 +260,15 @@ pub async fn create_emitter<'a>(
         None
     };
 
+    let min_level = &arg.visibility;
+
     let emitter: MessengerVariant = match format {
         OutputFormat::Standard => FormattedMessager::new(
             writer,
             mode,
             interactive,
             pattern.unwrap_or_default().to_string(),
+            min_level,
         )
         .into(),
         OutputFormat::Json => {
@@ -273,8 +276,11 @@ pub async fn create_emitter<'a>(
         }
         OutputFormat::Transformed => TransformedMessenger::new(writer).into(),
         OutputFormat::Jsonl => {
-            let jsonl =
-                JSONLineMessenger::new(writer.unwrap_or_else(|| Box::new(io::stdout())), mode);
+            let jsonl = JSONLineMessenger::new(
+                writer.unwrap_or_else(|| Box::new(io::stdout())),
+                mode,
+                min_level,
+            );
             jsonl.into()
         }
         #[cfg(feature = "remote_redis")]

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -162,7 +162,7 @@ impl<'a> WorkflowMessenger for MessengerVariant<'a> {
             | MessengerVariant::Transformed(_)
             | MessengerVariant::JsonLine(_) => {
                 // For local emitters,, we will also apply rewrites
-                self.emit(&message.result, &level)?;
+                self.emit(&message.result )?;
                 self.apply_rewrite(&message.result, &level)?;
                 Ok(())
             }

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -154,9 +154,6 @@ impl<'a> WorkflowMessenger for MessengerVariant<'a> {
         &mut self,
         message: &marzano_messenger::workflows::WorkflowMatchResult,
     ) -> anyhow::Result<()> {
-        // This is meant to match what we do in the CLI server
-        let level = VisibilityLevels::Debug;
-
         match self {
             MessengerVariant::Formatted(_)
             | MessengerVariant::Transformed(_)

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -251,6 +251,7 @@ pub async fn create_emitter<'a>(
     interactive: bool,
     pattern: Option<&str>,
     _root_path: Option<&PathBuf>,
+    min_level: VisibilityLevels,
 ) -> Result<MessengerVariant<'a>> {
     let writer: Option<Box<dyn Write + Send>> = if let Some(output_file) = output_file {
         let file = fs_err::File::create(output_file)?;
@@ -259,8 +260,6 @@ pub async fn create_emitter<'a>(
     } else {
         None
     };
-
-    let min_level = &arg.visibility;
 
     let emitter: MessengerVariant = match format {
         OutputFormat::Standard => FormattedMessager::new(

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -39,6 +39,20 @@ pub enum MessengerVariant<'a> {
 }
 
 impl<'a> Messager for MessengerVariant<'a> {
+    fn get_min_level(&self) -> VisibilityLevels {
+        match self {
+            MessengerVariant::Formatted(m) => m.get_min_level(),
+            MessengerVariant::Transformed(m) => m.get_min_level(),
+            MessengerVariant::JsonLine(m) => m.get_min_level(),
+            #[cfg(feature = "remote_redis")]
+            MessengerVariant::Redis(m) => m.get_min_level(),
+            #[cfg(feature = "remote_pubsub")]
+            MessengerVariant::GooglePubSub(m) => m.get_min_level(),
+            #[cfg(feature = "server")]
+            MessengerVariant::Combined(m) => m.get_min_level(),
+        }
+    }
+
     fn raw_emit(&mut self, message: &marzano_core::api::MatchResult) -> anyhow::Result<()> {
         match self {
             MessengerVariant::Formatted(m) => m.raw_emit(message),

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -163,7 +163,7 @@ impl<'a> WorkflowMessenger for MessengerVariant<'a> {
             | MessengerVariant::JsonLine(_) => {
                 // For local emitters,, we will also apply rewrites
                 self.emit(&message.result)?;
-                self.apply_rewrite(&message.result, &level)?;
+                self.apply_rewrite(&message.result)?;
                 Ok(())
             }
             #[cfg(feature = "remote_redis")]

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -162,7 +162,7 @@ impl<'a> WorkflowMessenger for MessengerVariant<'a> {
             | MessengerVariant::Transformed(_)
             | MessengerVariant::JsonLine(_) => {
                 // For local emitters,, we will also apply rewrites
-                self.emit(&message.result )?;
+                self.emit(&message.result)?;
                 self.apply_rewrite(&message.result, &level)?;
                 Ok(())
             }

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use crate::ux::{format_result_diff, indent};
-use marzano_messenger::emit::Messager;
+use marzano_messenger::emit::{Messager, VisibilityLevels};
 
 #[derive(Debug)]
 pub enum FormattedResult {
@@ -188,7 +188,7 @@ impl fmt::Display for FormattedResult {
                         print_all_done(r, f)?;
                     }
                     MatchResult::Match(r) => print_file_ranges(&mut r.clone(), f)?,
-                    MatchResult::Rewritten(r) => print_file_ranges(&mut r.clone(), f)?,
+                    MatchResult::Rewrite(r) => print_file_ranges(&mut r.clone(), f)?,
                     MatchResult::CreateFile(r) => print_file_ranges(&mut r.clone(), f)?,
                     MatchResult::RemoveFile(r) => print_file_ranges(&mut r.clone(), f)?,
                 }
@@ -257,7 +257,7 @@ impl fmt::Display for FormattedResult {
             }
             FormattedResult::AllDone(item) => print_all_done(item, f),
             FormattedResult::DoneFile(_) => Ok(()),
-            FormattedResult::Rewritten(item) => {
+            FormattedResult::Rewrite(item) => {
                 let path_name = if item.original.source_file == item.rewritten.source_file {
                     item.file_name().to_string()
                 } else {
@@ -462,7 +462,7 @@ impl Messager for TransformedMessenger<'_> {
             MatchResult::Match(message) => {
                 info!("Matched file {}", message.file_name());
             }
-            MatchResult::Rewritten(file) => {
+            MatchResult::Rewrite(file) => {
                 // Write the file contents to the output
                 if let Some(writer) = &mut self.writer {
                     let mut writer = writer.lock().map_err(|_| anyhow!("Output lock poisoned"))?;

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -302,7 +302,7 @@ pub struct FormattedMessager<'a> {
     total_rejected: usize,
     total_supressed: usize,
     input_pattern: String,
-
+    min_level: VisibilityLevels,
     workflow_done: bool,
 }
 
@@ -312,6 +312,7 @@ impl<'a> FormattedMessager<'_> {
         mode: OutputMode,
         interactive: bool,
         input_pattern: String,
+        min_level: VisibilityLevels,
     ) -> FormattedMessager<'a> {
         FormattedMessager {
             writer: writer.map(|w| Arc::new(Mutex::new(w))),
@@ -321,6 +322,7 @@ impl<'a> FormattedMessager<'_> {
             total_rejected: 0,
             total_supressed: 0,
             input_pattern,
+            min_level,
             workflow_done: false,
         }
     }
@@ -328,8 +330,7 @@ impl<'a> FormattedMessager<'_> {
 
 impl Messager for FormattedMessager<'_> {
     fn get_min_level(&self) -> VisibilityLevels {
-        // You'll need to decide on a default level or store it in the struct
-        VisibilityLevels::Supplemental
+        self.min_level
     }
 
     fn raw_emit(&mut self, message: &MatchResult) -> anyhow::Result<()> {
@@ -447,8 +448,7 @@ impl<'a> TransformedMessenger<'_> {
 
 impl Messager for TransformedMessenger<'_> {
     fn get_min_level(&self) -> VisibilityLevels {
-        // You'll need to decide on a default level or store it in the struct
-        VisibilityLevels::Supplemental
+        VisibilityLevels::Primary
     }
 
     fn raw_emit(&mut self, message: &MatchResult) -> anyhow::Result<()> {

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -188,7 +188,7 @@ impl fmt::Display for FormattedResult {
                         print_all_done(r, f)?;
                     }
                     MatchResult::Match(r) => print_file_ranges(&mut r.clone(), f)?,
-                    MatchResult::Rewrite(r) => print_file_ranges(&mut r.clone(), f)?,
+                    MatchResult::Rewritten(r) => print_file_ranges(&mut r.clone(), f)?,
                     MatchResult::CreateFile(r) => print_file_ranges(&mut r.clone(), f)?,
                     MatchResult::RemoveFile(r) => print_file_ranges(&mut r.clone(), f)?,
                 }
@@ -257,7 +257,7 @@ impl fmt::Display for FormattedResult {
             }
             FormattedResult::AllDone(item) => print_all_done(item, f),
             FormattedResult::DoneFile(_) => Ok(()),
-            FormattedResult::Rewrite(item) => {
+            FormattedResult::Rewritten(item) => {
                 let path_name = if item.original.source_file == item.rewritten.source_file {
                     item.file_name().to_string()
                 } else {
@@ -327,6 +327,11 @@ impl<'a> FormattedMessager<'_> {
 }
 
 impl Messager for FormattedMessager<'_> {
+    fn get_min_level(&self) -> VisibilityLevels {
+        // You'll need to decide on a default level or store it in the struct
+        VisibilityLevels::Supplemental
+    }
+
     fn raw_emit(&mut self, message: &MatchResult) -> anyhow::Result<()> {
         if self.interactive && !(self.mode == OutputMode::None) {
             if let MatchResult::AllDone(item) = message {
@@ -441,6 +446,11 @@ impl<'a> TransformedMessenger<'_> {
 }
 
 impl Messager for TransformedMessenger<'_> {
+    fn get_min_level(&self) -> VisibilityLevels {
+        // You'll need to decide on a default level or store it in the struct
+        VisibilityLevels::Supplemental
+    }
+
     fn raw_emit(&mut self, message: &MatchResult) -> anyhow::Result<()> {
         match message {
             MatchResult::PatternInfo(_)
@@ -452,7 +462,7 @@ impl Messager for TransformedMessenger<'_> {
             MatchResult::Match(message) => {
                 info!("Matched file {}", message.file_name());
             }
-            MatchResult::Rewrite(file) => {
+            MatchResult::Rewritten(file) => {
                 // Write the file contents to the output
                 if let Some(writer) = &mut self.writer {
                     let mut writer = writer.lock().map_err(|_| anyhow!("Output lock poisoned"))?;

--- a/crates/cli/src/ux.rs
+++ b/crates/cli/src/ux.rs
@@ -7,11 +7,9 @@ use marzano_core::{
     api::{EnforcementLevel, MatchResult},
     fs::extract_ranges,
 };
-use marzano_gritmodule::{
-    config::ResolvedGritDefinition, testing::SampleTestResult,
-};
+use marzano_gritmodule::{config::ResolvedGritDefinition, testing::SampleTestResult};
 use similar::{ChangeTag, TextDiff};
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
 use crate::analyze::{extract_rewritten_content, group_checks};
 

--- a/crates/core/src/test_files.rs
+++ b/crates/core/src/test_files.rs
@@ -3,7 +3,7 @@ use marzano_language::target_language::TargetLanguage;
 use self::pattern_compiler::src_to_problem_libs;
 use crate::api::FileMatchResult;
 use crate::{
-    api::{MatchResult},
+    api::MatchResult,
     test_utils::{run_on_test_files, SyntheticFile},
 };
 

--- a/crates/grit-pattern-matcher/src/pattern/variable.rs
+++ b/crates/grit-pattern-matcher/src/pattern/variable.rs
@@ -9,7 +9,7 @@ use crate::{
     constants::{ABSOLUTE_PATH_INDEX, FILENAME_INDEX, GLOBAL_VARS_SCOPE_INDEX},
     context::{ExecContext, QueryContext},
 };
-use anyhow::{Result};
+use anyhow::Result;
 use core::fmt::Debug;
 use grit_util::{constants::GRIT_METAVARIABLE_PREFIX, AnalysisLogs, ByteRange, Language};
 use std::{borrow::Cow, collections::BTreeSet};

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -27,20 +27,18 @@ pub struct ApplyDetails {
 }
 
 pub trait Messager: Send + Sync {
+    fn get_min_level(&self) -> VisibilityLevels;
+
     // Write a message to the output
-    fn emit(&mut self, message: &MatchResult, min_level: &VisibilityLevels) -> anyhow::Result<()> {
-        if get_visibility(message) >= *min_level {
+    fn emit(&mut self, message: &MatchResult) -> anyhow::Result<()> {
+        if get_visibility(message) >= self.get_min_level() {
             self.raw_emit(message)
         } else {
             Ok(())
         }
     }
 
-    fn apply_rewrite(
-        &mut self,
-        result: &MatchResult,
-        min_level: &VisibilityLevels,
-    ) -> anyhow::Result<()> {
+    fn apply_rewrite(&mut self, result: &MatchResult) -> anyhow::Result<()> {
         if let Err(e) = apply_rewrite(result) {
             let err_string = format!("Failed to apply rewrite: {}", e);
             let err_log = if let Some(file_name) = result.file_name() {
@@ -49,7 +47,7 @@ pub trait Messager: Send + Sync {
                 AnalysisLog::floating_error(err_string)
             };
 
-            self.emit(&MatchResult::AnalysisLog(err_log), min_level)
+            self.emit(&MatchResult::AnalysisLog(err_log))
         } else {
             Ok(())
         }
@@ -65,7 +63,6 @@ pub trait Messager: Send + Sync {
         execution_result: Vec<MatchResult>,
         details: &mut ApplyDetails,
         dry_run: bool,
-        min_level: &VisibilityLevels,
         should_format: bool,
         interactive: &mut bool,
         pg: Option<&ProgressBar>,
@@ -77,7 +74,6 @@ pub trait Messager: Send + Sync {
             execution_result,
             details,
             dry_run,
-            min_level,
             should_format,
             interactive,
             pg,
@@ -88,7 +84,7 @@ pub trait Messager: Send + Sync {
             Ok(val) => val,
             Err(err) => {
                 let err_log = AnalysisLog::new_error(err.to_string(), "unknown");
-                self.emit(&MatchResult::AnalysisLog(err_log), min_level)
+                self.emit(&MatchResult::AnalysisLog(err_log))
                     .expect("Failed to emit error log");
                 true
             }
@@ -101,7 +97,6 @@ pub trait Messager: Send + Sync {
         execution_result: Vec<MatchResult>,
         details: &mut ApplyDetails,
         dry_run: bool,
-        min_level: &VisibilityLevels,
         should_format: bool,
         interactive: &mut bool,
         pg: Option<&ProgressBar>,
@@ -150,7 +145,7 @@ pub trait Messager: Send + Sync {
                 }
             }
 
-            self.emit(&r, min_level)?;
+            self.emit(&r)?;
 
             if !dry_run {
                 if is_match(&r) {
@@ -218,7 +213,7 @@ pub trait Messager: Send + Sync {
                                         details.named_pattern.as_deref(),
                                     )
                                     .ok_or(anyhow::anyhow!("Failed to suppress rewrite"))?;
-                                self.apply_rewrite(&suppress_rewrite, min_level)?;
+                                self.apply_rewrite(&suppress_rewrite)?;
                                 continue;
                             }
                             "a" => {
@@ -236,7 +231,7 @@ pub trait Messager: Send + Sync {
                         self.track_accept(&r)?;
                     }
                 }
-                self.apply_rewrite(&r, min_level)?;
+                self.apply_rewrite(&r)?;
                 if should_format {
                     format_result(r)?;
                 }

--- a/crates/marzano_messenger/src/testing.rs
+++ b/crates/marzano_messenger/src/testing.rs
@@ -3,7 +3,7 @@ use marzano_core::api::MatchResult;
 
 use crate::{
     emit::{FlushableMessenger, Messager},
-    workflows::{WorkflowMessenger},
+    workflows::WorkflowMessenger,
 };
 
 /// A testing messenger that doesn't actually send messages anywhere.
@@ -63,6 +63,6 @@ impl WorkflowMessenger for TestingMessenger {
         &mut self,
         message: &crate::workflows::WorkflowMatchResult,
     ) -> anyhow::Result<()> {
-        self.emit(&message.result )
+        self.emit(&message.result)
     }
 }

--- a/crates/marzano_messenger/src/testing.rs
+++ b/crates/marzano_messenger/src/testing.rs
@@ -63,6 +63,6 @@ impl WorkflowMessenger for TestingMessenger {
         &mut self,
         message: &crate::workflows::WorkflowMatchResult,
     ) -> anyhow::Result<()> {
-        self.emit(&message.result, &crate::emit::VisibilityLevels::Debug)
+        self.emit(&message.result )
     }
 }

--- a/crates/marzano_messenger/src/testing.rs
+++ b/crates/marzano_messenger/src/testing.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use marzano_core::api::MatchResult;
 
 use crate::{
-    emit::{FlushableMessenger, Messager},
+    emit::{FlushableMessenger, Messager, VisibilityLevels},
     workflows::WorkflowMessenger,
 };
 
@@ -34,6 +34,10 @@ impl Default for TestingMessenger {
 }
 
 impl Messager for TestingMessenger {
+    fn get_min_level(&self) -> VisibilityLevels {
+        VisibilityLevels::Debug
+    }
+
     fn raw_emit(&mut self, _message: &MatchResult) -> Result<()> {
         self.message_count += 1;
         Ok(())

--- a/crates/wasm-bindings/src/match_pattern.rs
+++ b/crates/wasm-bindings/src/match_pattern.rs
@@ -121,7 +121,8 @@ pub async fn parse_input_files_internal(
                 .iter()
                 .map(|w| MatchResult::AnalysisLog(w.clone().into()));
 
-            let uses_ai = marzano_core::analysis::uses_ai(&c.problem.pattern, &c.problem.definitions());
+            let uses_ai =
+                marzano_core::analysis::uses_ai(&c.problem.pattern, &c.problem.definitions());
 
             let pinfo = PatternInfo {
                 messages: vec![],
@@ -129,7 +130,7 @@ pub async fn parse_input_files_internal(
                 source_file: pattern,
                 parsed_pattern,
                 valid: true,
-                uses_ai
+                uses_ai,
             };
             let pinfo = MatchResult::PatternInfo(pinfo);
             results.push(pinfo);


### PR DESCRIPTION
Instead of needing to check the visibility level every time we emit a diagnostic, now it is the responsibility of the messenger to determine the level it wants to use for all messages.

This significantly simplifies state and processing and fixes a bug where workflows were showing excessive debug messages even in normal mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visibility management in various functions, allowing for more refined control over message emissions based on visibility levels.
	- Introduced new methods to retrieve minimum visibility levels in several messenger implementations.

- **Refactor**
	- Simplified function signatures by removing unnecessary parameters, improving readability and maintainability.
	- Streamlined the internal logic for message handling, reducing complexity in method calls.

- **Bug Fixes**
	- Corrected issues with unnecessary parameters in multiple function calls, enhancing the overall clarity and usability of the code. 

- **Documentation**
	- Improved comments and documentation for new functionality related to visibility levels and message emission. 

- **Style**
	- Minor adjustments to import formatting for better code organization and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->