### PR TITLE
feat: make a minimum match of 1 for counting

### DIFF
--- a/crates/auth/src/env.rs
+++ b/crates/auth/src/env.rs
@@ -5,7 +5,7 @@ use crate::{info::AuthInfo, testing::get_testing_auth_info};
 pub static ENV_VAR_GRIT_LOCAL_SERVER: &str = "GRIT_LOCAL_SERVER";
 pub static ENV_VAR_GRIT_AUTH_TOKEN: &str = "GRIT_AUTH_TOKEN";
 pub static ENV_VAR_GRIT_API_URL: &str = "GRIT_API_URL";
-pub static DEFAULT_GRIT_API_URL: &str = "https://api-gateway-prod-6et7uue.uc.gateway.dev";
+pub static DEFAULT_GRIT_API_URL: &str = "https://api2.grit.io";
 pub static ENV_VAR_GRAPHQL_API_URL: &str = "GRAPHQL_API_URL";
 pub static DEFAULT_GRAPHQL_API_URL: &str = "https://grit-prod-central.hasura.app/v1";
 pub static ENV_VAR_GRIT_APP_URL: &str = "GRIT_APP_URL";

--- a/crates/cli_bin/tests/snapshots/apply__multifile_terraform_apply.snap
+++ b/crates/cli_bin/tests/snapshots/apply__multifile_terraform_apply.snap
@@ -9,4 +9,4 @@ expression: "String::from_utf8(output.stdout)?"
      }
     
 
-Processed 1 files and found 0 matches
+Processed 1 files and found 1 matches

--- a/crates/cli_bin/tests/snapshots/apply__terraform_complex.snap
+++ b/crates/cli_bin/tests/snapshots/apply__terraform_complex.snap
@@ -90,4 +90,4 @@ Log in PlaygroundPattern: Warning: sequential matches at the top of the file. If
      module "test_module3" {
     
 
-Processed 4 files and found 0 matches
+Processed 4 files and found 4 matches

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -106,9 +106,8 @@ pub trait Messager: Send + Sync {
     ) -> anyhow::Result<bool> {
         for r in execution_result {
             if is_match(&r) {
-                if let Some(ranges) = r.get_ranges() {
-                    details.matched += ranges.len() as i32;
-                }
+                let count = r.get_ranges().map(|ranges| ranges.len()).unwrap_or(0);
+                details.matched += count.max(1) as i32;
             }
             if let MatchResult::Rewrite(_) = r {
                 details.rewritten += 1;


### PR DESCRIPTION
Otherwise results look very odd, follow up to https://github.com/getgrit/gritql/pull/446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved the calculation of matched details to enhance accuracy and efficiency.
	- Ensured that `details.matched` always reflects at least one match when no ranges are found. 

- **New Features**
	- Updated the API endpoint for backend interactions, improving connectivity with services.
	
- **Refactor**
	- Streamlined logic for determining matched ranges, improving code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->