### PR TITLE
fix: correctly handle repos with multiple origins

### DIFF
--- a/crates/gritmodule/src/fetcher.rs
+++ b/crates/gritmodule/src/fetcher.rs
@@ -574,6 +574,48 @@ mod tests {
         assert_eq!(repo.remote().unwrap(), remote);
     }
 
+    #[tokio::test]
+    async fn module_repo_from_dir_with_renamed_origins() {
+        let dir = tempdir().unwrap().into_path();
+
+        // Clone the repository using the git command
+        let remote = "https://github.com/getgrit/stdlib.git";
+        let output = std::process::Command::new("git")
+            .arg("clone")
+            .arg(remote)
+            .arg(&dir)
+            .output()
+            .expect("Failed to execute git clone command");
+
+        if !output.status.success() {
+            panic!(
+                "Git clone failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        // Rename the origin to "alpha"
+        let output2 = std::process::Command::new("git")
+            .arg("remote")
+            .arg("rename")
+            .arg("origin")
+            .arg("alpha")
+            .current_dir(&dir)
+            .output()
+            .expect("Failed to execute git remote rename command");
+
+        if !output2.status.success() {
+            panic!(
+                "Git remote rename failed: {}",
+                String::from_utf8_lossy(&output2.stderr)
+            );
+        }
+
+        let repo = LocalRepo::from_dir(&dir).await.unwrap();
+
+        assert_eq!(repo.remote().unwrap(), remote);
+    }
+
     #[test]
     fn fails_if_attempting_to_prep_grit_modules_from_executable_ancestor() {
         let exe = current_exe().unwrap();

--- a/crates/gritmodule/src/fetcher.rs
+++ b/crates/gritmodule/src/fetcher.rs
@@ -111,7 +111,7 @@ impl LocalRepo {
                         }
                     }
                 } else {
-                    log::error!("Head is not a branch");
+                    log::debug!("Head is not a branch");
                     None
                 }
             }

--- a/crates/gritmodule/src/fetcher.rs
+++ b/crates/gritmodule/src/fetcher.rs
@@ -124,6 +124,16 @@ impl LocalRepo {
 
     /// Return the remote url for the repo, if any is set
     pub fn remote(&self) -> Option<String> {
+        let Ok(remotes) = self.repo.remotes() else {
+            log::error!("No remotes found");
+            return None;
+        };
+
+        // If the length of remotes is 1, return the first remote
+        if remotes.len() == 1 {
+            return Some(remotes.get(0).unwrap().to_string());
+        }
+
         // First, try to get the upstream of the current branch
         if let Some(branch) = self.branch() {
             if let Ok(upstream) = self.repo.branch_upstream_remote(&branch) {
@@ -145,12 +155,10 @@ impl LocalRepo {
         }
 
         // If upstream not found, fall back to the first remote listed
-        if let Ok(remotes) = self.repo.remotes() {
-            if let Some(r) = remotes.get(0) {
-                if let Ok(remote_obj) = Repository::find_remote(&self.repo, r) {
-                    if let Some(url) = remote_obj.url() {
-                        return Some(url.to_string());
-                    }
+        if let Some(r) = remotes.get(0) {
+            if let Ok(remote_obj) = Repository::find_remote(&self.repo, r) {
+                if let Some(url) = remote_obj.url() {
+                    return Some(url.to_string());
                 }
             }
         }

--- a/crates/gritmodule/src/fetcher.rs
+++ b/crates/gritmodule/src/fetcher.rs
@@ -131,7 +131,7 @@ impl LocalRepo {
 
         // If the length of remotes is 1, return the first remote
         if remotes.len() == 1 {
-            if let Ok(remote_obj) = Repository::find_remote(&self.repo, remotes.get(0).unwrap()) {
+            if let Ok(remote_obj) = self.repo.find_remote(remotes.get(0).unwrap()) {
                 if let Some(url) = remote_obj.url() {
                     return Some(url.to_string());
                 }
@@ -160,7 +160,7 @@ impl LocalRepo {
 
         // If upstream not found, fall back to the first remote listed
         if let Some(r) = remotes.get(0) {
-            if let Ok(remote_obj) = Repository::find_remote(&self.repo, r) {
+            if let Ok(remote_obj) = self.repo.find_remote(r) {
                 if let Some(url) = remote_obj.url() {
                     return Some(url.to_string());
                 }

--- a/crates/gritmodule/src/fetcher.rs
+++ b/crates/gritmodule/src/fetcher.rs
@@ -131,7 +131,11 @@ impl LocalRepo {
 
         // If the length of remotes is 1, return the first remote
         if remotes.len() == 1 {
-            return Some(remotes.get(0).unwrap().to_string());
+            if let Ok(remote_obj) = Repository::find_remote(&self.repo, remotes.get(0).unwrap()) {
+                if let Some(url) = remote_obj.url() {
+                    return Some(url.to_string());
+                }
+            }
         }
 
         // First, try to get the upstream of the current branch


### PR DESCRIPTION
We previously naively grabbed the first remote listed, now we do something smarter:

- First prefer the tracking remote for current branch
- Then look for a repo named origin
- Fall back to first one