### PR TITLE
build: give the grit cli a prettier display name in releases

### DIFF
--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -71,3 +71,4 @@ formula = "grit"
 [package.metadata.dist.bin-aliases]
 # all installers should ensure marzano can also be run as "grit"
 marzano = ["grit"]
+display-name = "grit"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced package metadata for the `grit` package with a user-friendly display name.
  
This improvement allows for clearer representation in package managers and installation scripts, improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->