### PR TITLE
fix: move option within cargo-dist config

### DIFF
--- a/crates/cli_bin/Cargo.toml
+++ b/crates/cli_bin/Cargo.toml
@@ -67,8 +67,9 @@ features = ["marzano-cli/grit_beta"]
 npm-package = "cli"
 # the homebrew package should have this name
 formula = "grit"
+# Custom display name to use for this app in release bodies
+display-name = "grit"
 
 [package.metadata.dist.bin-aliases]
 # all installers should ensure marzano can also be run as "grit"
 marzano = ["grit"]
-display-name = "grit"


### PR DESCRIPTION
This places the display-name field within the main dist config.

Refs #458.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `display-name` configuration option for a custom application name in release notes and package listings.
- **Improvements**
	- Restructured `display-name` for better clarity and context within package metadata under `[package.metadata.dist.bin-aliases]`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->