### PR TITLE
feat: auto-install workflow binary when required

### DIFF
--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -512,7 +512,7 @@ impl Updater {
 
         pg.finish_and_clear();
 
-        Get the path again, since it may have been moved
+        // Get the path again, since it may have been moved
         let bin_path = self.get_app_bin(&app)?;
         if bin_path.exists() {
             return Ok(bin_path);

--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -512,11 +512,11 @@ impl Updater {
 
         pg.finish_and_clear();
 
-        // Get the path again, since it may have been moved
-        // let bin_path = self.get_app_bin(&app)?;
-        // if bin_path.exists() {
-        //     return Ok(bin_path);
-        // }
+        Get the path again, since it may have been moved
+        let bin_path = self.get_app_bin(&app)?;
+        if bin_path.exists() {
+            return Ok(bin_path);
+        }
         bail!("Attempted to install {} but could not find it", app);
     }
 

--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -412,7 +412,7 @@ impl Updater {
 
     /// Retrieve auth info from the manifest, if available
     pub fn get_auth(&self) -> Option<AuthInfo> {
-        let auth = get_env_auth(false);
+        let auth = get_env_auth(true);
         if let Some(auth) = auth {
             return Some(auth);
         }
@@ -513,10 +513,10 @@ impl Updater {
         pg.finish_and_clear();
 
         // Get the path again, since it may have been moved
-        let bin_path = self.get_app_bin(&app)?;
-        if bin_path.exists() {
-            return Ok(bin_path);
-        }
+        // let bin_path = self.get_app_bin(&app)?;
+        // if bin_path.exists() {
+        //     return Ok(bin_path);
+        // }
         bail!("Attempted to install {} but could not find it", app);
     }
 

--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -506,11 +506,18 @@ impl Updater {
         if bin_path.exists() {
             return Ok(bin_path);
         }
-        bail!(
-            "Please set the {} environment variable to the path of the {} binary",
-            app.get_env_name(),
-            app
-        );
+        let pg = ProgressBar::new_spinner();
+        pg.set_message(format!("Downloading {}...", app));
+        self.install_latest(app).await?;
+
+        pg.finish_and_clear();
+
+        // Get the path again, since it may have been moved
+        let bin_path = self.get_app_bin(&app)?;
+        if bin_path.exists() {
+            return Ok(bin_path);
+        }
+        bail!("Attempted to install {} but could not find it", app);
     }
 
     pub async fn sync_manifest_version(&mut self, app: SupportedApp) -> Result<Option<String>> {

--- a/crates/cli/src/updater.rs
+++ b/crates/cli/src/updater.rs
@@ -497,6 +497,7 @@ impl Updater {
         Ok(bin_path.exists())
     }
 
+    /// Get the path to the app's binary, installing it if necessary
     pub async fn get_app_bin_and_install(&mut self, app: SupportedApp) -> Result<PathBuf> {
         // If the path is overridden, skip checking install
         if let Some(bin_path) = self.get_env_bin(&app)? {

--- a/crates/cli_bin/tests/common/mod.rs
+++ b/crates/cli_bin/tests/common/mod.rs
@@ -8,6 +8,8 @@ use marzano_gritmodule::config::GRIT_GLOBAL_DIR_ENV;
 use tempfile::tempdir;
 
 pub const BIN_NAME: &str = "marzano";
+
+#[allow(dead_code)]
 pub const INSTA_FILTERS: &[(&str, &str)] = &[(
     r"\b[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}\b",
     "[UUID]",

--- a/crates/cli_bin/tests/workflows.rs
+++ b/crates/cli_bin/tests/workflows.rs
@@ -1,0 +1,28 @@
+use crate::common::{get_fixture, get_test_cmd};
+use anyhow::Result;
+
+mod common;
+
+#[test]
+fn run_test_workflow() -> Result<()> {
+    let (_temp_dir, temp_fixtures_root) = get_fixture("grit_modules", true)?;
+
+    let mut cmd = get_test_cmd()?;
+    cmd.arg("apply")
+        .arg("https://storage.googleapis.com/grit-workflows-dev-workflow_definitions/test/hello.js")
+        .current_dir(temp_fixtures_root);
+
+    let output = cmd.output()?;
+    println!("stdout: {:?}", String::from_utf8(output.stdout.clone())?);
+    println!("stderr: {:?}", String::from_utf8(output.stderr.clone())?);
+
+    assert!(
+        output.status.success(),
+        "Command didn't finish successfully"
+    );
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("Running hello workflow"),);
+
+    Ok(())
+}

--- a/crates/cli_bin/tests/workflows.rs
+++ b/crates/cli_bin/tests/workflows.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 mod common;
 
 #[test]
+#[ignore = "No auth token is available in CI"]
 fn run_test_workflow() -> Result<()> {
     let (_temp_dir, temp_fixtures_root) = get_fixture("grit_modules", true)?;
 


### PR DESCRIPTION
If we attempt to run a workflow without previously installing the workflow runner, it should be auto-installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced application installation process with progress indication.
	- Improved error handling for binary location failures during installation.
	- Introduced automated testing for CLI workflows, ensuring correct application of workflow definitions.

- **Bug Fixes**
	- Modified authentication retrieval logic to improve user experience.

- **Documentation**
	- Added clarifying comments for the application's binary retrieval method.

- **Chores**
	- Suppressed unused code warnings for a constant in the test module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->