### PR TITLE
fix: properly set exit code for workflows

### DIFF
--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -82,7 +82,7 @@ pub(crate) async fn run_apply_migration(
 
     emitter.start_workflow()?;
 
-    let (mut emitter, outcome) = run_bin_workflow(
+    let mut emitter = run_bin_workflow(
         emitter,
         WorkflowInputs {
             verbose: arg.verbose,
@@ -94,9 +94,14 @@ pub(crate) async fn run_apply_migration(
     )
     .await?;
 
-    // Note the workflow may have already emitted its own conclusion - this is a fallback
-    emitter.finish_workflow(&outcome)?;
     emitter.flush().await?;
+
+    // Get the final workflow status from the emitter
+    if let Some(workflow_status) = emitter.get_workflow_status()? {
+        if !workflow_status.success {
+            bail!(GoodError::new());
+        }
+    }
 
     Ok(())
 }

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -66,6 +66,8 @@ pub(crate) async fn run_apply_migration(
     flags: &GlobalFormatFlags,
     min_level: marzano_messenger::emit::VisibilityLevels,
 ) -> Result<()> {
+    use crate::error::GoodError;
+
     let input = arg.get_payload()?;
 
     let format = OutputFormat::from(flags);
@@ -99,7 +101,7 @@ pub(crate) async fn run_apply_migration(
     // Get the final workflow status from the emitter
     if let Some(workflow_status) = emitter.get_workflow_status()? {
         if !workflow_status.success {
-            bail!(GoodError::new());
+            anyhow::bail!(GoodError::new());
         }
     }
 

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -103,6 +103,8 @@ pub(crate) async fn run_apply_migration(
         if !workflow_status.success {
             anyhow::bail!(GoodError::new());
         }
+    } else {
+        anyhow::bail!("Final workflow status not found");
     }
 
     Ok(())

--- a/crates/cli/src/jsonl.rs
+++ b/crates/cli/src/jsonl.rs
@@ -9,12 +9,14 @@ use marzano_core::{api::MatchResult, compact_api::compact};
 use marzano_messenger::{
     emit::{Messager, VisibilityLevels},
     output_mode::OutputMode,
+    workflows::StatusManager,
 };
 
 pub struct JSONLineMessenger<'a> {
     writer: Arc<Mutex<Box<dyn Write + Send + 'a>>>,
     mode: OutputMode,
     min_level: VisibilityLevels,
+    status: StatusManager,
 }
 
 impl<'a> JSONLineMessenger<'a> {
@@ -27,6 +29,7 @@ impl<'a> JSONLineMessenger<'a> {
             writer: Arc::new(Mutex::new(Box::new(writer))),
             mode,
             min_level,
+            status: StatusManager::new(),
         }
     }
 }
@@ -34,6 +37,20 @@ impl<'a> JSONLineMessenger<'a> {
 impl<'a> Messager for JSONLineMessenger<'a> {
     fn get_min_level(&self) -> VisibilityLevels {
         self.min_level
+    }
+
+    fn get_workflow_status(
+        &mut self,
+    ) -> anyhow::Result<Option<&marzano_messenger::workflows::PackagedWorkflowOutcome>> {
+        self.status.get_workflow_status()
+    }
+
+    fn finish_workflow(
+        &mut self,
+        outcome: &marzano_messenger::workflows::PackagedWorkflowOutcome,
+    ) -> anyhow::Result<()> {
+        self.status.upsert(outcome);
+        Ok(())
     }
 
     fn raw_emit(&mut self, item: &MatchResult) -> anyhow::Result<()> {

--- a/crates/cli/src/messenger_variant.rs
+++ b/crates/cli/src/messenger_variant.rs
@@ -122,6 +122,20 @@ impl<'a> Messager for MessengerVariant<'a> {
             MessengerVariant::Combined(m) => m.finish_workflow(outcome),
         }
     }
+
+    fn get_workflow_status(&mut self) -> anyhow::Result<Option<&PackagedWorkflowOutcome>> {
+        match self {
+            MessengerVariant::Formatted(m) => m.get_workflow_status(),
+            MessengerVariant::Transformed(m) => m.get_workflow_status(),
+            MessengerVariant::JsonLine(m) => m.get_workflow_status(),
+            #[cfg(feature = "remote_redis")]
+            MessengerVariant::Redis(m) => m.get_workflow_status(),
+            #[cfg(feature = "remote_pubsub")]
+            MessengerVariant::GooglePubSub(m) => m.get_workflow_status(),
+            #[cfg(feature = "server")]
+            MessengerVariant::Combined(m) => m.get_workflow_status(),
+        }
+    }
 }
 
 impl<'a> WorkflowMessenger for MessengerVariant<'a> {

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -9,6 +9,7 @@ use marzano_core::api::{
 };
 use marzano_core::constants::DEFAULT_FILE_NAME;
 use marzano_messenger::output_mode::OutputMode;
+use marzano_messenger::workflows::StatusManager;
 use std::fmt::Display;
 use std::{
     io::Write,
@@ -303,7 +304,7 @@ pub struct FormattedMessager<'a> {
     total_supressed: usize,
     input_pattern: String,
     min_level: VisibilityLevels,
-    workflow_done: bool,
+    status_manager: StatusManager,
 }
 
 impl<'a> FormattedMessager<'_> {
@@ -323,7 +324,7 @@ impl<'a> FormattedMessager<'_> {
             total_supressed: 0,
             input_pattern,
             min_level,
-            workflow_done: false,
+            status_manager: StatusManager::default(),
         }
     }
 }
@@ -382,11 +383,17 @@ impl Messager for FormattedMessager<'_> {
         Ok(())
     }
 
+    fn get_workflow_status(
+        &mut self,
+    ) -> anyhow::Result<Option<&marzano_messenger::workflows::PackagedWorkflowOutcome>> {
+        self.status_manager.get_workflow_status()
+    }
+
     fn finish_workflow(
         &mut self,
         outcome: &marzano_messenger::workflows::PackagedWorkflowOutcome,
     ) -> anyhow::Result<()> {
-        if self.workflow_done {
+        if !self.status_manager.upsert(outcome) {
             // If we already finished once, short-circuit it
             return Ok(());
         }
@@ -397,8 +404,6 @@ impl Messager for FormattedMessager<'_> {
         } else {
             log::info!("{}", get_pretty_workflow_message(outcome));
         }
-
-        self.workflow_done = true;
 
         Ok(())
     }

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -439,6 +439,7 @@ pub struct TransformedMessenger<'a> {
     total_accepted: usize,
     total_rejected: usize,
     total_supressed: usize,
+    status: StatusManager,
 }
 
 impl<'a> TransformedMessenger<'_> {
@@ -448,6 +449,7 @@ impl<'a> TransformedMessenger<'_> {
             total_accepted: 0,
             total_rejected: 0,
             total_supressed: 0,
+            status: StatusManager::new(),
         }
     }
 }
@@ -455,6 +457,20 @@ impl<'a> TransformedMessenger<'_> {
 impl Messager for TransformedMessenger<'_> {
     fn get_min_level(&self) -> VisibilityLevels {
         VisibilityLevels::Primary
+    }
+
+    fn finish_workflow(
+        &mut self,
+        outcome: &marzano_messenger::workflows::PackagedWorkflowOutcome,
+    ) -> anyhow::Result<()> {
+        self.status.upsert(outcome);
+        Ok(())
+    }
+
+    fn get_workflow_status(
+        &mut self,
+    ) -> anyhow::Result<Option<&marzano_messenger::workflows::PackagedWorkflowOutcome>> {
+        self.status.get_workflow_status()
     }
 
     fn raw_emit(&mut self, message: &MatchResult) -> anyhow::Result<()> {

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -49,7 +49,8 @@ pub struct WorkflowInputs {
     pub verbose: bool,
 }
 
-pub async fn run_bin_workflow<M>(mut emitter: M, mut arg: WorkflowInputs) -> Result<(M)>
+#[allow(unused_mut)]
+pub async fn run_bin_workflow<M>(mut emitter: M, mut arg: WorkflowInputs) -> Result<M>
 where
     M: Messager + WorkflowMessenger + Send + 'static,
 {
@@ -162,7 +163,7 @@ where
 
     // Stop the embedded server
     #[cfg(feature = "workflow_server")]
-    let emitter = {
+    let mut emitter = {
         shutdown_tx.send(()).unwrap();
         handle.await?
     };

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -49,10 +49,7 @@ pub struct WorkflowInputs {
     pub verbose: bool,
 }
 
-pub async fn run_bin_workflow<M>(
-    emitter: M,
-    mut arg: WorkflowInputs,
-) -> Result<(M, PackagedWorkflowOutcome)>
+pub async fn run_bin_workflow<M>(mut emitter: M, mut arg: WorkflowInputs) -> Result<(M)>
 where
     M: Messager + WorkflowMessenger + Send + 'static,
 {
@@ -170,28 +167,25 @@ where
         handle.await?
     };
 
-    // TODO: pass along outcome message
-    if status.success() {
-        Ok((
-            emitter,
-            PackagedWorkflowOutcome {
-                message: None,
-                outcome: None,
-                success: true,
-                data: None,
-            },
-        ))
+    // Note the workflow may have already emitted its own conclusion - this is a fallback
+    let fallback_outcome = if status.success() {
+        PackagedWorkflowOutcome {
+            message: None,
+            outcome: None,
+            success: true,
+            data: None,
+        }
     } else {
-        Ok((
-            emitter,
-            PackagedWorkflowOutcome {
-                message: None,
-                outcome: None,
-                success: false,
-                data: None,
-            },
-        ))
-    }
+        PackagedWorkflowOutcome {
+            message: None,
+            outcome: None,
+            success: false,
+            data: None,
+        }
+    };
+    emitter.finish_workflow(&fallback_outcome)?;
+
+    Ok(emitter)
 }
 
 #[cfg(feature = "remote_workflows")]

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -264,6 +264,9 @@ pub trait Messager: Send + Sync {
         Ok(())
     }
 
+    // Get the current workflow outcome, if one has been set
+    fn get_workflow_status(&mut self) -> anyhow::Result<Option<PackagedWorkflowOutcome>>;
+
     // Handle state
     fn track_accept(&mut self, _accepted: &MatchResult) -> anyhow::Result<()> {
         // do nothing

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -259,15 +259,10 @@ pub trait Messager: Send + Sync {
 
     // Called when a workflow finishes processing, with the outcome
     // Note that this *may* be called multiple times. The *first* time it is called should be considered the "true" outcome.
-    fn finish_workflow(&mut self, _outcome: &PackagedWorkflowOutcome) -> anyhow::Result<()> {
-        // do nothing
-        Ok(())
-    }
+    fn finish_workflow(&mut self, _outcome: &PackagedWorkflowOutcome) -> anyhow::Result<()>;
 
     // Get the current workflow outcome, if one has been set
-    fn get_workflow_status(&mut self) -> anyhow::Result<Option<&PackagedWorkflowOutcome>> {
-        Ok(None)
-    }
+    fn get_workflow_status(&mut self) -> anyhow::Result<Option<&PackagedWorkflowOutcome>>;
 
     // Handle state
     fn track_accept(&mut self, _accepted: &MatchResult) -> anyhow::Result<()> {

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -265,7 +265,9 @@ pub trait Messager: Send + Sync {
     }
 
     // Get the current workflow outcome, if one has been set
-    fn get_workflow_status(&mut self) -> anyhow::Result<Option<PackagedWorkflowOutcome>>;
+    fn get_workflow_status(&mut self) -> anyhow::Result<Option<&PackagedWorkflowOutcome>> {
+        Ok(None)
+    }
 
     // Handle state
     fn track_accept(&mut self, _accepted: &MatchResult) -> anyhow::Result<()> {

--- a/crates/marzano_messenger/src/testing.rs
+++ b/crates/marzano_messenger/src/testing.rs
@@ -34,6 +34,23 @@ impl Default for TestingMessenger {
 }
 
 impl Messager for TestingMessenger {
+    fn start_workflow(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn finish_workflow(
+        &mut self,
+        _outcome: &crate::workflows::PackagedWorkflowOutcome,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn get_workflow_status(
+        &mut self,
+    ) -> anyhow::Result<Option<&crate::workflows::PackagedWorkflowOutcome>> {
+        Ok(None)
+    }
+
     fn get_min_level(&self) -> VisibilityLevels {
         VisibilityLevels::Debug
     }

--- a/crates/marzano_messenger/src/workflows.rs
+++ b/crates/marzano_messenger/src/workflows.rs
@@ -60,3 +60,34 @@ pub struct WorkflowMatchResult {
     pub workspace_path: Option<PathBuf>,
     pub step_id: String,
 }
+
+/// Status manager makes it easier to implement the required parts of the workflow status API
+/// It sets the status of the workflow the first time it's updated, and then ignores all further updates
+pub struct StatusManager {
+    status: Option<PackagedWorkflowOutcome>,
+}
+
+impl StatusManager {
+    pub fn new() -> Self {
+        Self { status: None }
+    }
+
+    pub fn upsert(&mut self, outcome: &PackagedWorkflowOutcome) -> bool {
+        if self.status.is_none() {
+            self.status = Some(outcome.clone());
+            return true;
+        }
+
+        false
+    }
+
+    fn get_workflow_status(&mut self) -> anyhow::Result<Option<&PackagedWorkflowOutcome>> {
+        Ok(self.status.as_ref())
+    }
+}
+
+impl Default for StatusManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/marzano_messenger/src/workflows.rs
+++ b/crates/marzano_messenger/src/workflows.rs
@@ -15,7 +15,7 @@ pub enum OutcomeKind {
     Skipped,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct PackagedWorkflowOutcome {
     pub message: Option<String>,
     pub outcome: Option<OutcomeKind>,
@@ -81,7 +81,7 @@ impl StatusManager {
         false
     }
 
-    fn get_workflow_status(&mut self) -> anyhow::Result<Option<&PackagedWorkflowOutcome>> {
+    pub fn get_workflow_status(&mut self) -> anyhow::Result<Option<&PackagedWorkflowOutcome>> {
         Ok(self.status.as_ref())
     }
 }


### PR DESCRIPTION
Even for remote workflows, we should exit 1 if it was not successful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced workflow management with a new `StatusManager` struct for tracking workflow status.
	- Added methods `get_workflow_status`, `start_workflow`, and `finish_workflow` across various messenger implementations.

- **Bug Fixes**
	- Improved error handling in the `run_plumbing` function, allowing for more graceful management of specific error scenarios.

- **Refactor**
	- Simplified the return values of workflow functions for clearer output.
	- Streamlined workflow management logic in messenger implementations.

- **Documentation**
	- Updated documentation to reflect new methods and their functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->