### PR TITLE
fix: keep workflow code behind flag

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -97,15 +97,15 @@ use tracing::instrument;
 use version::VersionArgs;
 
 #[cfg(feature = "workflows_v2")]
-use workflows_list::run_list_workflows;
-
-#[cfg(feature = "workflows_v2")]
 use crate::commands::workflows::{WorkflowCommands, Workflows};
+#[cfg(feature = "workflows_v2")]
+use workflows_list::run_list_workflows;
+#[cfg(feature = "workflows_v2")]
+use workflows_watch::run_watch_workflow;
 
 #[cfg(feature = "docgen")]
 use crate::commands::docgen::{run_docgen, DocGenArgs};
 
-use self::workflows_watch::run_watch_workflow;
 use self::{
     apply::run_apply,
     auth_login::run_login,


### PR DESCRIPTION
(We don't want to ship this in slim builds.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved organization of import statements for better readability under the `workflows_v2` feature.
	- Minor adjustments in the positioning of workflow-related imports without impacting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->