### PR TITLE
fix: simplify the lazy approach

### DIFF
--- a/crates/core/src/built_in_functions.rs
+++ b/crates/core/src/built_in_functions.rs
@@ -1,6 +1,6 @@
 use crate::{
-    lazy::LazyTraversal, marzano_context::MarzanoContext,
-    marzano_resolved_pattern::MarzanoResolvedPattern, paths::resolve, problem::MarzanoQueryContext,
+    marzano_context::MarzanoContext, marzano_resolved_pattern::MarzanoResolvedPattern,
+    paths::resolve, problem::MarzanoQueryContext,
 };
 use anyhow::{anyhow, bail, Result};
 use grit_pattern_matcher::{
@@ -39,8 +39,7 @@ pub type CallbackFn = dyn for<'a, 'b> Fn(
         &'b <crate::problem::MarzanoQueryContext as grit_pattern_matcher::context::QueryContext>::ResolvedPattern<'a>,
         &'a MarzanoContext<'a>,
         &mut State<'a, MarzanoQueryContext>,
-        &mut AnalysisLogs,
-        &mut LazyTraversal<'a, 'b>
+        &mut AnalysisLogs
     ) -> Result<bool>
     + Send
     + Sync;
@@ -126,8 +125,7 @@ impl BuiltIns {
         state: &mut State<'a, MarzanoQueryContext>,
         logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        let mut lazy = LazyTraversal::new(binding);
-        (self.callbacks[call.callback_index])(binding, context, state, logs, &mut lazy)
+        (self.callbacks[call.callback_index])(binding, context, state, logs)
     }
 
     /// Add an anonymous built-in, used for callbacks

--- a/crates/core/src/marzano_resolved_pattern.rs
+++ b/crates/core/src/marzano_resolved_pattern.rs
@@ -50,6 +50,7 @@ impl<'a> MarzanoResolvedPattern<'a> {
     /// Check if a pattern matches a provided pattern
     ///
     /// Note this leaks memory, so should only be used in short-lived programs
+    #[allow(dead_code)]
     pub(crate) fn matches(
         &self,
         pattern: &Pattern<MarzanoQueryContext>,

--- a/crates/core/src/marzano_resolved_pattern.rs
+++ b/crates/core/src/marzano_resolved_pattern.rs
@@ -49,10 +49,7 @@ impl<'a> MarzanoResolvedPattern<'a> {
 
     /// Check if a pattern matches a provided pattern
     ///
-    /// # Safety
-    ///
-    /// This API is experimental and unsafe.
-    /// You should ensure pattern lives as long as possible, since we assume it is 'static
+    /// Note this leaks memory, so should only be used in short-lived programs
     pub(crate) fn matches(
         &self,
         pattern: &Pattern<MarzanoQueryContext>,
@@ -60,10 +57,8 @@ impl<'a> MarzanoResolvedPattern<'a> {
         context: &'a MarzanoContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> GritResult<bool> {
-        // SAFETY: in most cases, matching does not rely on the pattern after matching
-        // ... but this is still very experimental
         let borrowed_pattern: &'static Pattern<MarzanoQueryContext> =
-            unsafe { std::mem::transmute(pattern) };
+            Box::leak(Box::new(pattern.clone()));
 
         let matches = borrowed_pattern.execute(self, state, context, logs)?;
         Ok(matches)

--- a/crates/core/src/pattern_compiler/builder.rs
+++ b/crates/core/src/pattern_compiler/builder.rs
@@ -20,8 +20,8 @@ use grit_pattern_matcher::{
         ABSOLUTE_PATH_INDEX, DEFAULT_FILE_NAME, FILENAME_INDEX, NEW_FILES_INDEX, PROGRAM_INDEX,
     },
     pattern::{
-        And, GritFunctionDefinition, Pattern, PatternDefinition, Predicate, PredicateDefinition,
-        VariableSourceLocations, Where,
+        Accumulate, And, DynamicPattern, GritFunctionDefinition, Pattern, PatternDefinition,
+        Predicate, PredicateDefinition, Rewrite, VariableSourceLocations, Where,
     },
 };
 use grit_util::{AnalysisLogs, Ast, FileRange};
@@ -232,6 +232,18 @@ impl PatternBuilder {
     /// This is the primary way we progressively add patterns to the builder.
     pub fn wrap_with_condition(self, side_condition: Predicate<MarzanoQueryContext>) -> Self {
         let pattern = Pattern::Where(Box::new(Where::new(self.pattern, side_condition)));
+        Self { pattern, ..self }
+    }
+
+    /// Add a rewrite around the pattern
+    pub fn wrap_with_rewrite(self, replacement: DynamicPattern<MarzanoQueryContext>) -> Self {
+        let pattern = Pattern::Rewrite(Box::new(Rewrite::new(self.pattern, replacement, None)));
+        Self { pattern, ..self }
+    }
+
+    /// Wrap with accumulate
+    pub fn wrap_with_accumulate(self, other: Pattern<MarzanoQueryContext>) -> Self {
+        let pattern = Pattern::Accumulate(Box::new(Accumulate::new(self.pattern, other, None)));
         Self { pattern, ..self }
     }
 

--- a/crates/core/src/test_callback.rs
+++ b/crates/core/src/test_callback.rs
@@ -1,11 +1,10 @@
-use grit_pattern_matcher::pattern::{ResolvedPattern};
-use grit_pattern_matcher::{constants::DEFAULT_FILE_NAME};
+use grit_pattern_matcher::constants::DEFAULT_FILE_NAME;
+use grit_pattern_matcher::pattern::ResolvedPattern;
 use marzano_language::{grit_parser::MarzanoGritParser, target_language::TargetLanguage};
 use std::{
     path::Path,
     sync::{atomic::AtomicBool, Arc},
 };
-
 
 use crate::{
     pattern_compiler::{CompilationResult, PatternBuilder},
@@ -27,7 +26,7 @@ fn test_callback() {
     assert!(!callback_called.load(std::sync::atomic::Ordering::SeqCst));
 
     let mut builder = PatternBuilder::start_empty(src, lang).unwrap();
-    builder = builder.matches_callback(Box::new(move |binding, context, state, _, _| {
+    builder = builder.matches_callback(Box::new(move |binding, context, state, logs| {
         let text = binding
             .text(&state.files, context.language)
             .unwrap()

--- a/crates/core/src/test_callback.rs
+++ b/crates/core/src/test_callback.rs
@@ -26,7 +26,7 @@ fn test_callback() {
     assert!(!callback_called.load(std::sync::atomic::Ordering::SeqCst));
 
     let mut builder = PatternBuilder::start_empty(src, lang).unwrap();
-    builder = builder.matches_callback(Box::new(move |binding, context, state, logs| {
+    builder = builder.matches_callback(Box::new(move |binding, context, state, _logs| {
         let text = binding
             .text(&state.files, context.language)
             .unwrap()

--- a/crates/grit-pattern-matcher/src/pattern/accumulate.rs
+++ b/crates/grit-pattern-matcher/src/pattern/accumulate.rs
@@ -58,13 +58,13 @@ impl<Q: QueryContext> Matcher<Q> for Accumulate<Q> {
                 return Ok(false);
             };
             let resolved = context_node;
-            let Some(dynamic_right) = &self.dynamic_right else {
-                return Err(GritPatternError::new(
-                    "Insert right hand side must be a code snippet when LHS is not a variable",
-                ));
-            };
             let left = PatternOrResolved::Resolved(resolved);
-            let right = ResolvedPattern::from_dynamic_pattern(dynamic_right, state, context, logs)?;
+
+            let right = if let Some(dynamic_right) = &self.dynamic_right {
+                ResolvedPattern::from_dynamic_pattern(dynamic_right, state, context, logs)?
+            } else {
+                ResolvedPattern::from_pattern(&self.right, state, context, logs)?
+            };
 
             insert_effect(&left, right, state, context)
         }

--- a/crates/grit-pattern-matcher/src/pattern/dynamic_snippet.rs
+++ b/crates/grit-pattern-matcher/src/pattern/dynamic_snippet.rs
@@ -49,6 +49,12 @@ impl<Q: QueryContext> DynamicPattern<Q> {
         let resolved = Q::ResolvedPattern::from_dynamic_pattern(self, state, context, logs)?;
         Ok(resolved.text(&state.files, context.language())?.to_string())
     }
+
+    /// Create a constant DynamicPattern from a string.
+    pub fn from_str_constant(s: &str) -> GritResult<Self> {
+        let parts = vec![DynamicSnippetPart::String(s.to_string())];
+        Ok(DynamicPattern::Snippet(DynamicSnippet { parts }))
+    }
 }
 
 impl<Q: QueryContext> PatternName for DynamicPattern<Q> {


### PR DESCRIPTION
We don't really need a new struct, and leaking memory is safer than transmuting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `matches` method in `MarzanoResolvedPattern` for enhanced pattern matching capabilities.
	- Added `wrap_with_rewrite` and `wrap_with_accumulate` methods to `PatternBuilder` for improved pattern manipulation.
	- New method `from_str_constant` in `DynamicPattern` allows creation of patterns from string literals.

- **Bug Fixes**
	- Streamlined error handling in `ResolvedPattern` for better readability.

- **Refactor**
	- Removed the `LazyTraversal` struct, simplifying the callback function signatures.
	- Updated test cases to reflect changes in pattern matching logic.

- **Style**
	- Improved organization of import statements for better code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->