### PR TITLE
fix: use correct cache dir for grit binaries

### DIFF
--- a/python/gritql/installer.py
+++ b/python/gritql/installer.py
@@ -69,29 +69,17 @@ def find_install() -> Path:
     arch = _get_arch()
     _debug(f"Using architecture {arch}")
 
-    file_name = f"marzano-{platform}-{arch}"
-    meta_url = f"https://api.keygen.sh/v1/accounts/{KEYGEN_ACCOUNT}/artifacts/{file_name}"
+    arch = _get_arch()
+    _debug(f"Using architecture {arch}")
 
-    sys.stdout.write(f"Retrieving Grit CLI metadata from {meta_url}\n")
+    file_name = f"marzano-{arch}-{platform}"
+    download_url = f"https://github.com/getgrit/gritql/releases/latest/download/{file_name}.tar.gz"
 
-    # TODO: remove httpx dependency
+    sys.stdout.write(f"Downloading Grit CLI from {download_url}\n")
     with httpx.Client() as client:
-        response = client.get(meta_url)  # pyright: ignore[reportUnknownMemberType]
-
-        data = response.json()
-        errors = data.get("errors")
-        if errors:
-            for error in errors:
-                sys.stdout.write(f"{error}\n")
-
-            raise CLIError("Could not locate Grit CLI binary - see above errors")
-
-        write_manifest(install_dir, data["data"]["relationships"]["release"]["data"]["id"])
-
-        link = data["data"]["links"]["redirect"]
-        _debug(f"Redirect URL {link}")
-
-        download_response = client.get(link)  # pyright: ignore[reportUnknownMemberType]
+        download_response = client.get(download_url, follow_redirects=True)
+        if download_response.status_code != 200:
+            raise CLIError(f"Failed to download Grit CLI from {download_url}")
         with open(temp_file, "wb") as file:
             for chunk in download_response.iter_bytes():
                 file.write(chunk)
@@ -100,10 +88,12 @@ def find_install() -> Path:
     unpacked_dir.mkdir(parents=True, exist_ok=True)
 
     with tarfile.open(temp_file, "r:gz") as archive:
-        archive.extractall(unpacked_dir, filter="data")
+        if sys.version_info >= (3, 12):
+            archive.extractall(unpacked_dir, filter="data")
+        else:
+            archive.extractall(unpacked_dir)
 
-    for item in unpacked_dir.iterdir():
-        item.rename(target_dir / item.name)
+    _move_files_recursively(unpacked_dir, target_dir)
 
     shutil.rmtree(unpacked_dir)
     os.remove(temp_file)
@@ -113,31 +103,22 @@ def find_install() -> Path:
 
     return target_path
 
+def _move_files_recursively(source_dir: Path, target_dir: Path) -> None:
+    for item in source_dir.iterdir():
+        if item.is_file():
+            item.rename(target_dir / item.name)
+        elif item.is_dir():
+            _move_files_recursively(item, target_dir)
 
 def _get_arch() -> str:
     architecture = platform.machine().lower()
 
-    # Map the architecture names to Node.js equivalents
+    # Map the architecture names to Grit equivalents
     arch_map = {
-        "x86_64": "x64",
-        "amd64": "x64",
-        "armv7l": "arm",
-        "aarch64": "arm64",
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "armv7l": "aarch64",
+        "arm64": "aarch64",
     }
 
     return arch_map.get(architecture, architecture)
-
-
-def write_manifest(install_path: Path, release: str) -> None:
-    manifest = {
-        "installPath": str(install_path),
-        "binaries": {
-            "marzano": {
-                "name": "marzano",
-                "release": release,
-            },
-        },
-    }
-    manifest_path = Path(install_path) / "manifests.json"
-    with open(manifest_path, "w") as f:
-        json.dump(manifest, f, indent=2)

--- a/python/gritql/installer.py
+++ b/python/gritql/installer.py
@@ -47,7 +47,7 @@ def find_install() -> Path:
 
     platform = "macos" if sys.platform == "darwin" else "linux"
 
-    dir_name = _cache_dir() / "openai-python"
+    dir_name = _cache_dir() / "grit"
     install_dir = dir_name / ".install"
     target_dir = install_dir / "bin"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,15 +2,15 @@
 name = "gritql"
 requires-python = ">=3.8"
 classifiers = [
-    "Programming Language :: Rust",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.1.0"
+version = "0.1.3"
 
 [tool.poetry]
 name = "gritql"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python bindings for GritQL"
 authors = ["Grit <developers@grit.io>"]
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,11 +6,11 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry]
 name = "gritql"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python bindings for GritQL"
 authors = ["Grit <developers@grit.io>"]
 license = "MIT"


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchain/pull/22052#issuecomment-2127551093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the directory name for cached installation files to improve clarity and organization.
	- Incremented project version from 0.1.0 to 0.1.4, indicating a minor update.
- **Bug Fixes**
	- Enhanced error handling for download failures in the installation process.
	- Adjusted formatting in the `pyproject.toml` file for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->