### PR TITLE
feat: pipe workflow output to emitter

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -76,7 +76,7 @@ tracing = { version = "0.1.40", default-features = false, features = [] }
 notify = "6.1.1"
 notify-debouncer-mini = "0.4.1"
 tracing-subscriber = { version = "0.3", default-features = false, optional = true }
-tracing-log = "0.2.0"
+tracing-log = { version = "0.2.0", optional = true }
 
 fs-err = { version = "2.11.0" }
 
@@ -129,6 +129,7 @@ grit_tracing = [
   "dep:opentelemetry_sdk",
   "dep:tracing-opentelemetry",
   "dep:tracing-subscriber",
+  "dep:tracing-log",
   "marzano-core/grit_tracing",
 ]
 external_functions = ["marzano-core/external_functions"]

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -88,8 +88,8 @@ pub(crate) async fn run_apply_migration(
 
     emitter.start_workflow()?;
 
-    run_bin_workflow(
-        &mut emitter,
+    let mut emitter = run_bin_workflow(
+        emitter,
         WorkflowInputs {
             execution_id,
             verbose: arg.verbose,

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -88,8 +88,8 @@ pub(crate) async fn run_apply_migration(
 
     emitter.start_workflow()?;
 
-    let mut emitter = run_bin_workflow(
-        emitter,
+    run_bin_workflow(
+        &mut emitter,
         WorkflowInputs {
             execution_id,
             verbose: arg.verbose,

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -328,7 +328,7 @@ fn setup_env_logger(app: &App, multi: &MultiProgress) {
     }
 }
 
-async fn run_command(use_tracing: bool) -> Result<()> {
+async fn run_command(_use_tracing: bool) -> Result<()> {
     let app = App::parse();
     // Use this *only* for analytics, not for any other purpose.
     let analytics_args = std::env::args().collect::<Vec<_>>();
@@ -353,7 +353,7 @@ async fn run_command(use_tracing: bool) -> Result<()> {
     #[cfg(not(feature = "grit_tracing"))]
     setup_env_logger(&app, &multi);
     #[cfg(feature = "grit_tracing")]
-    if !use_tracing {
+    if !_use_tracing {
         setup_env_logger(&app, &multi);
     } else if let Err(e) = tracing_log::LogTracer::init() {
         eprintln!("Failed to initialize LogTracer: {:?}", e);

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -4,7 +4,6 @@ use console::style;
 use log::debug;
 use marzano_auth::env::{get_grit_api_url, ENV_VAR_GRIT_API_URL, ENV_VAR_GRIT_AUTH_TOKEN};
 use marzano_auth::info::AuthInfo;
-use marzano_core::api::AnalysisLogLevel;
 use marzano_gritmodule::config::REPO_CONFIG_DIR_NAME;
 use marzano_gritmodule::searcher::WorkflowInfo;
 use marzano_gritmodule::{fetcher::LocalRepo, searcher::find_grit_dir_from};
@@ -57,7 +56,7 @@ pub struct WorkflowInputs {
 }
 
 #[allow(unused_mut)]
-pub async fn run_bin_workflow<M>(emitter: &'static mut M, mut arg: WorkflowInputs) -> Result<()>
+pub async fn run_bin_workflow<M>(mut emitter: M, mut arg: WorkflowInputs) -> Result<M>
 where
     M: Messager + WorkflowMessenger + Send + 'static,
 {
@@ -173,18 +172,12 @@ where
     let stdout_reader = BufReader::new(stdout).lines();
     let stderr_reader = BufReader::new(stderr).lines();
 
-    // let stdout_handler = tokio::spawn(async move {
-    //     let mut stdout_reader = stdout_reader;
-    //     while let Some(line) = stdout_reader.next_line().await.unwrap() {
-    //         let log = marzano_messenger::SimpleLogMessage {
-    //             message: line,
-    //             level: AnalysisLogLevel::Info,
-    //             meta: None,
-    //             step_id: None,
-    //         };
-    //         emitter_mut.emit_log(&log);
-    //     }
-    // });
+    tokio::spawn(async move {
+        let mut stdout_reader = stdout_reader;
+        while let Some(line) = stdout_reader.next_line().await.unwrap() {
+            log::info!("stdout: {}", line);
+        }
+    });
 
     // tokio::select! {
     //     res = stdout_reader.for_each(|line| async {
@@ -207,7 +200,7 @@ where
 
     // Stop the embedded server
     #[cfg(feature = "workflow_server")]
-    {
+    let mut emitter = {
         shutdown_tx.send(()).unwrap();
         handle.await?
     };


### PR DESCRIPTION
If a workflow has output that doesn't use our SDK, we still want it to be visible so it doesn't disappear into the ether.

It's a subpar approach today (reusing the server messages channel) because we can't currently copy Emitter between threads. I would like to refactor Emitter to support cloning at some point, but that will be a bigger change and has some complications with connection sharing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities during workflow execution by capturing and processing standard output and error streams in real-time.
	- Introduced a messages channel for improved communication of log messages, including log levels and metadata.

- **Bug Fixes**
	- Improved control flow to ensure all log messages are processed before workflow completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->