### PR TITLE
feat: switch --remote workflows to reuse an existing ID

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -67,13 +67,8 @@ pub(crate) async fn run_apply(
 
         #[cfg(feature = "remote_workflows")]
         if args.apply_migration_args.remote {
-            return crate::workflows::run_remote_workflow(
-                args.pattern_or_workflow,
-                args.apply_migration_args,
-                ranges,
-                flags,
-            )
-            .await;
+            return crate::workflows::run_remote_workflow(args.apply_migration_args, ranges, flags)
+                .await;
         }
 
         let paths = args.paths.clone();

--- a/crates/cli/src/commands/apply_migration.rs
+++ b/crates/cli/src/commands/apply_migration.rs
@@ -26,9 +26,13 @@ pub struct ApplyMigrationArgs {
     #[clap(
         long,
         help_heading = "Workflow options",
-        help = "Run the workflow remotely on Grit Cloud"
+        help = "Run the workflow remotely on Grit Cloud",
+        requires = "workflow_id"
     )]
     pub(crate) remote: bool,
+    /// Workflow ID to set, only applicable when running remotely
+    #[clap(long, help_heading = "Workflow options", requires = "remote")]
+    pub(crate) workflow_id: Option<String>,
     /// Watch the workflow for updates (only applicable when running remotely)
     #[clap(long, help_heading = "Workflow options")]
     pub(crate) watch: bool,

--- a/crates/cli/src/commands/plumbing.rs
+++ b/crates/cli/src/commands/plumbing.rs
@@ -332,6 +332,7 @@ pub(crate) async fn run_plumbing(
                 super::apply_migration::ApplyMigrationArgs {
                     input: Some(buffer),
                     remote: false,
+                    workflow_id: None,
                     verbose: true,
                     watch: false,
                 },

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -255,7 +255,6 @@ where
 
 #[cfg(feature = "remote_workflows")]
 pub async fn run_remote_workflow(
-    workflow_name: String,
     args: crate::commands::apply_migration::ApplyMigrationArgs,
     ranges: Option<Vec<FileDiff>>,
     flags: &crate::flags::GlobalFormatFlags,
@@ -297,8 +296,12 @@ pub async fn run_remote_workflow(
         }
     }
 
+    let Some(workflow_id) = args.workflow_id else {
+        anyhow::bail!("No workflow ID provided");
+    };
+
     let settings =
-        grit_cloud_client::RemoteWorkflowSettings::new(workflow_name, &repo, input.into());
+        grit_cloud_client::RemoteWorkflowSettings::new(&workflow_id, &repo, input.into());
     let result = grit_cloud_client::run_remote_workflow(settings, &auth).await?;
 
     pb.finish_and_clear();


### PR DESCRIPTION
(Avoid populating the UI with many useless one-off instances.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `workflow_id` field for remote migrations, enhancing command usability.
	- Updated command-line help text to clarify dependencies between `remote` and `workflow_id`.

- **Bug Fixes**
	- Improved error handling in remote workflow execution by enforcing the presence of `workflow_id`.

- **Refactor**
	- Streamlined function calls by simplifying parameters, enhancing overall code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->