### PR TITLE
fix: make emitter Clone

### DIFF
--- a/crates/cli/src/jsonl.rs
+++ b/crates/cli/src/jsonl.rs
@@ -12,6 +12,7 @@ use marzano_messenger::{
     workflows::StatusManager,
 };
 
+#[derive(Clone)]
 pub struct JSONLineMessenger<'a> {
     writer: Arc<Mutex<Box<dyn Write + Send + 'a>>>,
     mode: OutputMode,
@@ -45,7 +46,7 @@ impl<'a> Messager for JSONLineMessenger<'a> {
         self.status.get_workflow_status()
     }
 
-    fn finish_workflow(
+    async fn finish_workflow(
         &mut self,
         outcome: &marzano_messenger::workflows::PackagedWorkflowOutcome,
     ) -> anyhow::Result<()> {

--- a/crates/cli/src/result_formatting.rs
+++ b/crates/cli/src/result_formatting.rs
@@ -300,6 +300,7 @@ impl fmt::Display for FormattedResult {
     }
 }
 
+#[derive(Clone)]
 pub struct FormattedMessager<'a> {
     writer: Option<Arc<Mutex<Box<dyn Write + Send + 'a>>>>,
     mode: OutputMode,
@@ -394,7 +395,7 @@ impl Messager for FormattedMessager<'_> {
         self.status_manager.get_workflow_status()
     }
 
-    fn finish_workflow(
+    async fn finish_workflow(
         &mut self,
         outcome: &marzano_messenger::workflows::PackagedWorkflowOutcome,
     ) -> anyhow::Result<()> {
@@ -439,6 +440,7 @@ impl Messager for FormattedMessager<'_> {
 }
 
 /// Prints the transformed files themselves, with no metadata
+#[derive(Clone)]
 pub struct TransformedMessenger<'a> {
     writer: Option<Arc<Mutex<Box<dyn Write + Send + 'a>>>>,
     total_accepted: usize,
@@ -464,7 +466,7 @@ impl Messager for TransformedMessenger<'_> {
         VisibilityLevels::Primary
     }
 
-    fn finish_workflow(
+    async fn finish_workflow(
         &mut self,
         outcome: &marzano_messenger::workflows::PackagedWorkflowOutcome,
     ) -> anyhow::Result<()> {

--- a/crates/cli/src/workflows.rs
+++ b/crates/cli/src/workflows.rs
@@ -190,6 +190,7 @@ where
             }
         }
     });
+    let mut stderr_emitter = emitter.clone();
     let stderr_handle = tokio::spawn(async move {
         while let Some(line) = stderr_reader.next_line().await.unwrap() {
             let log = marzano_messenger::SimpleLogMessage {
@@ -201,7 +202,7 @@ where
                     serde_json::Value::String("stderr".to_string()),
                 )])),
             };
-            if let Err(e) = emitter.emit_log(&log) {
+            if let Err(e) = stderr_emitter.emit_log(&log) {
                 log::error!("Error emitting log: {}", e);
             }
         }

--- a/crates/marzano_messenger/src/emit.rs
+++ b/crates/marzano_messenger/src/emit.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::future::Future;
 use std::{
     collections::HashMap,
     sync::atomic::{AtomicI32, Ordering},
@@ -259,7 +260,10 @@ pub trait Messager: Send + Sync {
 
     // Called when a workflow finishes processing, with the outcome
     // Note that this *may* be called multiple times. The *first* time it is called should be considered the "true" outcome.
-    fn finish_workflow(&mut self, _outcome: &PackagedWorkflowOutcome) -> anyhow::Result<()>;
+    fn finish_workflow(
+        &mut self,
+        _outcome: &PackagedWorkflowOutcome,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
 
     // Get the current workflow outcome, if one has been set
     fn get_workflow_status(&mut self) -> anyhow::Result<Option<&PackagedWorkflowOutcome>>;


### PR DESCRIPTION
Improves on https://github.com/getgrit/gritql/pull/496/files#diff-01236225ab1672b374c0b02e4de9f4465b57385ebb9cc7e081dfe2af114e0127R176 by making emitters *safely* cloneable so we can spread them all over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asynchronous capabilities for multiple messenger types, improving responsiveness and non-blocking operations.
	- Added cloning functionality to various structs and enums for better state management in concurrent contexts.

- **Bug Fixes**
	- Improved the robustness of status management in the `StatusManager` struct, ensuring single assignment for workflow outcomes.

- **Refactor**
	- Streamlined logging processes and workflow execution handling, simplifying communication models and enhancing maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->