### PR TITLE
fix: make compound snippets work with stateless compiler

### DIFF
--- a/crates/core/src/ast_node.rs
+++ b/crates/core/src/ast_node.rs
@@ -65,6 +65,7 @@ impl Matcher<MarzanoQueryContext> for ASTNode {
         let Some(node) = binding.singleton() else {
             return Ok(false);
         };
+
         if binding.is_list() {
             return self.execute(
                 &ResolvedPattern::from_node_binding(node),

--- a/crates/core/src/lazy.rs
+++ b/crates/core/src/lazy.rs
@@ -107,7 +107,7 @@ mod test {
             let pattern = Pattern::Contains(Box::new(Contains::new(
                 StatelessCompilerContext::new(TargetLanguage::default())
                     // console.log does not work yet
-                    .parse_snippet("name")?,
+                    .parse_snippet("console.log")?,
                 None,
             )));
 

--- a/crates/core/src/lazy.rs
+++ b/crates/core/src/lazy.rs
@@ -1,9 +1,11 @@
 #[cfg(test)]
 mod test {
-    use grit_pattern_matcher::pattern::ResolvedPattern;
+    use grit_pattern_matcher::context::ExecContext;
     use grit_pattern_matcher::pattern::{Pattern, StringConstant};
+    use grit_pattern_matcher::pattern::{PatternOrResolved, ResolvedPattern};
     use grit_pattern_matcher::{constants::DEFAULT_FILE_NAME, pattern::Contains};
     use marzano_language::{grit_parser::MarzanoGritParser, target_language::TargetLanguage};
+    use std::any::Any;
     use std::sync::atomic::AtomicUsize;
     use std::{
         path::Path,
@@ -16,6 +18,11 @@ mod test {
         pattern_compiler::{CompilationResult, PatternBuilder},
         test_utils::{run_on_test_files, SyntheticFile},
     };
+
+    /// Just shorthand for Contains
+    fn p_contains(pattern: Pattern<MarzanoQueryContext>) -> Pattern<MarzanoQueryContext> {
+        Pattern::Contains(Box::new(Contains::new(pattern, None)))
+    }
 
     #[test]
     fn test_callback_with_variable() {
@@ -84,59 +91,157 @@ mod test {
     }
 
     #[test]
-    fn test_find_pattern() {
+    fn test_callback_with_contains_ast_node() {
         let src = r#"language js
 
-    function()"#;
+    function_declaration()"#;
         let mut parser = MarzanoGritParser::new().unwrap();
         let src_tree = parser
             .parse_file(src, Some(Path::new(DEFAULT_FILE_NAME)))
             .unwrap();
         let lang = TargetLanguage::from_tree(&src_tree).unwrap();
 
-        let console_builder =
-            PatternBuilder::start_empty("call_expression()", TargetLanguage::default()).unwrap();
-        let console_pattern = console_builder
-            .compile(None, None, false)
-            .unwrap()
-            .root_pattern();
+        let this_lang = TargetLanguage::from_string("js", None).unwrap();
+        assert_eq!(lang.type_id(), this_lang.type_id());
+
+        let matches_found = Arc::new(AtomicUsize::new(0));
+        let matches_found_clone = Arc::clone(&matches_found);
 
         let mut builder = PatternBuilder::start_empty(src, lang).unwrap();
-        let builder = builder.matches(Pattern::Contains(Box::new(Contains::new(
-            console_pattern,
-            None,
-        ))));
 
+        builder = builder.matches_callback(Box::new(move |binding, context, state, logs| {
+            let this_lang = TargetLanguage::from_string("js", None).unwrap();
+
+            let console_builder =
+                PatternBuilder::start_empty("call_expression()", this_lang).unwrap();
+            let console_pattern = console_builder
+                .compile(None, None, false)
+                .unwrap()
+                .root_pattern();
+
+            let contains_pattern = p_contains(console_pattern);
+
+            println!("contains pattern: {:?}", contains_pattern);
+
+            if binding
+                .matches(&contains_pattern, state, context, logs)
+                .unwrap()
+            {
+                matches_found_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+            Ok(true)
+        }));
         let CompilationResult { problem, .. } = builder.compile(None, None, true).unwrap();
 
-        println!("final pattern: {:?}", problem.pattern);
-
-        let test_files = vec![
-            SyntheticFile::new(
-                "file.js".to_owned(),
-                r#"
-            function notHere() {
-                console.error("sam");
+        let test_files = vec![SyntheticFile::new(
+            "file.js".to_owned(),
+            r#"function notMatch() {
+                // call nothing
             }
 
             function myLogger() {
                 console.log(name);
             }"#
-                .to_owned(),
-                true,
-            ),
-            SyntheticFile::new(
-                "file.js".to_owned(),
-                r#"
-            function myLogger() {
-                console.error(name);
-            }"#
-                .to_owned(),
-                true,
-            ),
-        ];
+            .to_owned(),
+            true,
+        )];
         let results = run_on_test_files(&problem, &test_files);
-        println!("results: {:?}", results);
-        assert_eq!(results.len(), 3);
+        assert_eq!(results.len(), 2);
+        assert_eq!(matches_found.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_callback_with_contains_snippet() {
+        let src = r#"language js
+
+    function_declaration()"#;
+        let mut parser = MarzanoGritParser::new().unwrap();
+        let src_tree = parser
+            .parse_file(src, Some(Path::new(DEFAULT_FILE_NAME)))
+            .unwrap();
+        let lang = TargetLanguage::from_tree(&src_tree).unwrap();
+
+        let this_lang = TargetLanguage::from_string("js", None).unwrap();
+        assert_eq!(lang.type_id(), this_lang.type_id());
+
+        let matches_found = Arc::new(AtomicUsize::new(0));
+        let matches_found_clone = Arc::clone(&matches_found);
+
+        let mut builder = PatternBuilder::start_empty(src, lang).unwrap();
+
+        builder = builder.matches_callback(Box::new(move |binding, context, state, logs| {
+            let this_lang = TargetLanguage::from_string("js", None).unwrap();
+
+            let console_builder =
+                PatternBuilder::start_empty("`console.log(name)`", this_lang.clone()).unwrap();
+            let console_pattern = console_builder
+                .compile(None, None, false)
+                .unwrap()
+                .root_pattern();
+
+            let contains_pattern = p_contains(console_pattern);
+
+            if binding
+                .matches(&contains_pattern, state, context, logs)
+                .unwrap()
+            {
+                matches_found_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+                // Ok we are operating on the right function, now verify more things
+                let mut compiler = StatelessCompilerContext::new(this_lang.clone());
+                let standalone_snippet = compiler.parse_snippet("console.log(name)").unwrap();
+                let standalone_contains = p_contains(standalone_snippet);
+
+                assert_eq!(
+                    format!("{:?}", standalone_contains),
+                    format!("{:?}", contains_pattern)
+                );
+
+                let also_contained = binding
+                    .matches(&standalone_contains, state, context, logs)
+                    .unwrap();
+                assert!(also_contained, "standalone snippet should match");
+
+                // Let's also make sure we can match a variable
+                let contains_var = p_contains(compiler.parse_snippet("console.log($msg)").unwrap());
+                assert!(
+                    binding
+                        .matches(&contains_var, state, context, logs)
+                        .unwrap(),
+                    "variable should match"
+                );
+
+                let our_name = state
+                    .find_var_in_scope("$msg")
+                    .unwrap()
+                    .get_pattern_or_resolved(state)
+                    .unwrap();
+                let resolved = our_name.unwrap();
+                let PatternOrResolved::Resolved(resolved) = resolved else {
+                    panic!("No resolved pattern found");
+                };
+                let text = resolved.text(&state.files, context.language()).unwrap();
+                assert_eq!(text, "\"my name is bob\"");
+            }
+            Ok(true)
+        }));
+        let CompilationResult { problem, .. } = builder.compile(None, None, true).unwrap();
+
+        let test_files = vec![SyntheticFile::new(
+            "file.js".to_owned(),
+            r#"function notMatch() {
+                // call nothing
+            }
+
+            function myLogger() {
+                console.log("my name is bob");
+                console.log(name);
+            }"#
+            .to_owned(),
+            true,
+        )];
+        let results = run_on_test_files(&problem, &test_files);
+        assert_eq!(results.len(), 2);
+        assert_eq!(matches_found.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 }

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -18,8 +18,8 @@ use anyhow::{anyhow, bail, Result};
 use grit_pattern_matcher::{
     constants::{DEFAULT_FILE_NAME, GLOBAL_VARS_SCOPE_INDEX},
     pattern::{
-        DynamicSnippetPart, GritFunctionDefinition, PatternDefinition, PredicateDefinition,
-        Variable, VariableSourceLocations,
+        DynamicSnippetPart, GritFunctionDefinition, Pattern, PatternDefinition,
+        PredicateDefinition, Variable, VariableSourceLocations,
     },
 };
 use grit_util::{
@@ -636,6 +636,12 @@ fn find_definition_if_exists(
 pub struct CompilationResult {
     pub compilation_warnings: AnalysisLogs,
     pub problem: Problem,
+}
+
+impl CompilationResult {
+    pub fn root_pattern(self) -> Pattern<MarzanoQueryContext> {
+        self.problem.pattern
+    }
 }
 
 #[cfg_attr(

--- a/crates/core/src/stateless.rs
+++ b/crates/core/src/stateless.rs
@@ -60,7 +60,7 @@ mod tests {
     use marzano_language::target_language::TargetLanguage;
 
     use crate::{
-        pattern_compiler::{compiler::NodeCompilationContext, PatternBuilder},
+        pattern_compiler::{compiler::NodeCompilationContext, CompilationResult, PatternBuilder},
         stateless::StatelessCompilerContext,
     };
 
@@ -85,9 +85,9 @@ mod tests {
         let pattern = compiler.parse_snippet("console.log").unwrap();
 
         // Check how the traditional compiler compiles the same snippet
-        let builder = PatternBuilder::start_empty("`console.log`", language);
-
-        // parse_snippet_content(content, range.into(), context, false);
+        let builder =
+            PatternBuilder::start_empty("`console.log`", TargetLanguage::default()).unwrap();
+        let pattern2 = builder.compile(None, None, false).unwrap().root_pattern();
 
         assert_eq!(format!("{:?}", pattern), format!("{:?}", pattern2));
     }

--- a/crates/core/src/stateless.rs
+++ b/crates/core/src/stateless.rs
@@ -54,3 +54,41 @@ impl SnippetCompilationContext for StatelessCompilerContext {
         Ok(Variable::new_dynamic(name))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use marzano_language::target_language::TargetLanguage;
+
+    use crate::{
+        pattern_compiler::{compiler::NodeCompilationContext, PatternBuilder},
+        stateless::StatelessCompilerContext,
+    };
+
+    #[test]
+    fn test_stateless_snippet_compiler_self_equivalence() {
+        let language = TargetLanguage::default();
+        let mut compiler = StatelessCompilerContext::new(language);
+        let pattern = compiler.parse_snippet("console.log").unwrap();
+
+        // Second instance
+        let pattern2 = compiler.parse_snippet("console.log").unwrap();
+        println!("pattern: {:?}", pattern);
+        println!("pattern2: {:?}", pattern2);
+
+        assert_eq!(format!("{:?}", pattern), format!("{:?}", pattern2));
+    }
+
+    #[test]
+    fn test_stateless_snippet_compiler_equivalence() {
+        let language = TargetLanguage::default();
+        let mut compiler = StatelessCompilerContext::new(language);
+        let pattern = compiler.parse_snippet("console.log").unwrap();
+
+        // Check how the traditional compiler compiles the same snippet
+        let builder = PatternBuilder::start_empty("`console.log`", language);
+
+        // parse_snippet_content(content, range.into(), context, false);
+
+        assert_eq!(format!("{:?}", pattern), format!("{:?}", pattern2));
+    }
+}

--- a/crates/core/src/stateless.rs
+++ b/crates/core/src/stateless.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use grit_pattern_matcher::pattern::{Contains, DynamicSnippetPart, Pattern, Variable};
+use grit_pattern_matcher::pattern::{DynamicSnippetPart, Pattern, Variable};
 use grit_util::ByteRange;
 use marzano_language::target_language::TargetLanguage;
 
@@ -59,7 +59,7 @@ mod tests {
     use marzano_language::target_language::TargetLanguage;
 
     use crate::{
-        pattern_compiler::{compiler::NodeCompilationContext, CompilationResult, PatternBuilder},
+        pattern_compiler::{PatternBuilder},
         stateless::StatelessCompilerContext,
     };
 

--- a/crates/grit-pattern-matcher/src/pattern/contains.rs
+++ b/crates/grit-pattern-matcher/src/pattern/contains.rs
@@ -47,6 +47,7 @@ fn execute_until<'a, Q: QueryContext>(
         let node_lhs = ResolvedPattern::from_node_binding(node);
 
         let state = cur_state.clone();
+
         if the_contained.execute(&node_lhs, &mut cur_state, context, logs)? {
             did_match = true;
         } else {
@@ -92,10 +93,6 @@ impl<Q: QueryContext> Matcher<Q> for Contains<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> GritResult<bool> {
-        println!(
-            "executing contains: {:?}, {:?}",
-            resolved_pattern, self.contains
-        );
         if let Some(binding) = resolved_pattern.get_last_binding() {
             if let Some(node) = binding.as_node() {
                 execute_until(

--- a/crates/grit-pattern-matcher/src/pattern/contains.rs
+++ b/crates/grit-pattern-matcher/src/pattern/contains.rs
@@ -92,6 +92,10 @@ impl<Q: QueryContext> Matcher<Q> for Contains<Q> {
         context: &'a Q::ExecContext<'a>,
         logs: &mut AnalysisLogs,
     ) -> GritResult<bool> {
+        println!(
+            "executing contains: {:?}, {:?}",
+            resolved_pattern, self.contains
+        );
         if let Some(binding) = resolved_pattern.get_last_binding() {
             if let Some(node) = binding.as_node() {
                 execute_until(


### PR DESCRIPTION
Make sure we can do `binding.match("console.log")`.

Follow up from https://github.com/getgrit/gritql/pull/512