### PR TITLE
fix: change download url for darwin

### DIFF
--- a/python/gritql/installer.py
+++ b/python/gritql/installer.py
@@ -45,7 +45,7 @@ def find_install() -> Path:
         _debug(f"'grit' found in PATH at {grit_path}")
         return Path(grit_path)
 
-    platform = "macos" if sys.platform == "darwin" else "linux"
+    platform = "apple-darwin" if sys.platform == "darwin" else "linux"
 
     dir_name = _cache_dir() / "grit"
     install_dir = dir_name / ".install"


### PR DESCRIPTION
### Description
- Updated the platform variable to map correctly to the valid release download URLs based on the operating system (macOS).

### Changes
- AS-IS
https://github.com/getgrit/gritql/releases/latest/download/marzano-aarc64-macos.tar.gz
- TO-BE
https://github.com/getgrit/gritql/releases/latest/download/marzano-aarc64-apple-darwin.tar.gz

### Issues
#515 