### PR TITLE
fix: improve error for nodes with invalid fields

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -46,13 +46,14 @@ pub use sdk::UncompiledPatternBuilder;
 #[cfg(feature = "wasm_core")]
 use getrandom as _;
 #[cfg(test)]
-mod test_callback;
-#[cfg(test)]
-mod test_notebooks;
-
-#[cfg(test)]
 mod test;
 #[cfg(test)]
+mod test_callback;
+#[cfg(test)]
+mod test_errors;
+#[cfg(test)]
 mod test_files;
+#[cfg(test)]
+mod test_notebooks;
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_utils;

--- a/crates/core/src/pattern_compiler/ast_node_compiler.rs
+++ b/crates/core/src/pattern_compiler/ast_node_compiler.rs
@@ -72,12 +72,21 @@ impl AstNodeCompiler {
                         .node_kind_for_id(sort)
                         .unwrap()
                         .to_string();
-                    anyhow!(
-                        "invalid field `{}` for node `{}`, valid fields are: {}",
-                        name,
-                        node_sort,
-                        node_field_names
-                    )
+                    if node_field_names.is_empty() {
+                        anyhow!(
+                            "invalid field `{}` for AST node `{}`. `{}` does not expose any fields.",
+                            name,
+                            node_sort,
+                            node_sort,
+                        )
+                    } else {
+                        anyhow!(
+                            "invalid field `{}` for AST node `{}`, valid fields are: {}",
+                            name,
+                            node_sort,
+                            node_field_names
+                        )
+                    }
                 })?;
 
             let field = node_fields.iter().find(|f| f.id() == id).ok_or_else(|| {
@@ -88,12 +97,21 @@ impl AstNodeCompiler {
                     .node_kind_for_id(sort)
                     .unwrap()
                     .to_string();
-                anyhow!(
-                    "invalid field `{}` for node `{}`, valid fields are: {}",
-                    name,
-                    node_sort,
-                    node_field_names
-                )
+                if node_field_names.is_empty() {
+                    anyhow!(
+                        "invalid field `{}` for AST node `{}`. `{}` does not expose any fields.",
+                        name,
+                        node_sort,
+                        node_sort
+                    )
+                } else {
+                    anyhow!(
+                        "invalid field `{}` for AST node `{}`, valid fields are: {}",
+                        name,
+                        node_sort,
+                        node_field_names
+                    )
+                }
             })?;
 
             let pattern = ListCompiler::from_node_in_context(&node, field, context, is_rhs)?;

--- a/crates/core/src/test_errors.rs
+++ b/crates/core/src/test_errors.rs
@@ -1,0 +1,30 @@
+use marzano_language::target_language::TargetLanguage;
+
+use self::pattern_compiler::src_to_problem_libs;
+
+use super::*;
+use std::collections::BTreeMap;
+
+#[test]
+fn test_error_invalid_field() {
+    let pattern_src = r#"
+        string_fragment(fragment=$d)
+        "#;
+    let libs = BTreeMap::new();
+
+    let err = src_to_problem_libs(
+        pattern_src.to_string(),
+        &libs,
+        TargetLanguage::default(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .err()
+    .unwrap();
+    assert_eq!(
+        err.to_string(),
+        "invalid field `fragment` for AST node `string_fragment`. `string_fragment` does not expose any fields."
+    );
+}


### PR DESCRIPTION
If the node doesn't accept any field parameters, make that clearer.