### PR TITLE
perf: remove `im` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,15 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,7 +1431,6 @@ dependencies = [
  "elsa",
  "getrandom",
  "grit-util",
- "im",
  "itertools 0.10.5",
  "rand",
  "regex",
@@ -1803,20 +1793,6 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -2298,7 +2274,6 @@ dependencies = [
  "getrandom",
  "grit-pattern-matcher",
  "grit-util",
- "im",
  "insta",
  "itertools 0.10.5",
  "lazy_static",
@@ -3299,15 +3274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "rayon"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,16 +3797,6 @@ name = "similar"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,7 +29,6 @@ uuid = { version = "1.1", features = ["v4", "serde"] }
 regex = { version = "1.7.3" }
 anyhow = { version = "1.0.70" }
 itertools = { version = "0.10.5" }
-im = { version = "15.1.0" }
 serde_json = { version = "1.0.96" }
 serde = { version = "1.0.164", features = ["derive"] }
 sha2 = { version = "0.10.8" }

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -112,9 +112,7 @@ impl MatchResult {
         }
     }
 
-    pub(crate) fn file_to_match_result(
-        file: &Vec<&FileOwner<Tree>>,
-    ) -> Result<Option<MatchResult>> {
+    pub(crate) fn file_to_match_result(file: &[&FileOwner<Tree>]) -> Result<Option<MatchResult>> {
         if file.is_empty() {
             bail!("cannot have file with no versions")
         } else if file.len() == 1 {

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -3,7 +3,6 @@ use anyhow::{bail, Result};
 use grit_pattern_matcher::file_owners::FileOwner;
 pub use grit_util::ByteRange;
 use grit_util::{AnalysisLog as GritAnalysisLog, Ast, Position, Range, VariableMatch};
-use im::Vector;
 use marzano_language::grit_ts_node::grit_node_types;
 use marzano_language::language::{MarzanoLanguage, Tree};
 use serde::{Deserialize, Serialize};
@@ -114,7 +113,7 @@ impl MatchResult {
     }
 
     pub(crate) fn file_to_match_result(
-        file: &Vector<&FileOwner<Tree>>,
+        file: &Vec<&FileOwner<Tree>>,
     ) -> Result<Option<MatchResult>> {
         if file.is_empty() {
             bail!("cannot have file with no versions")
@@ -136,8 +135,8 @@ impl MatchResult {
             }
         } else {
             return Ok(Some(MatchResult::Rewrite(Rewrite::file_to_rewrite(
-                file.front().unwrap(),
-                file.back().unwrap(),
+                file.first().unwrap(),
+                file.last().unwrap(),
             )?)));
         }
     }

--- a/crates/core/src/built_in_functions.rs
+++ b/crates/core/src/built_in_functions.rs
@@ -13,7 +13,6 @@ use grit_pattern_matcher::{
     },
 };
 use grit_util::{AnalysisLogs, CodeRange, Language};
-use im::Vector;
 use itertools::Itertools;
 use rand::prelude::SliceRandom;
 use rand::Rng;
@@ -422,10 +421,10 @@ fn distinct_fn<'a>(
     let list = args.into_iter().next().unwrap();
     match list {
         Some(MarzanoResolvedPattern::List(list)) => {
-            let mut unique_list = Vector::new();
+            let mut unique_list = Vec::new();
             for item in list {
                 if !unique_list.contains(&item) {
-                    unique_list.push_back(item);
+                    unique_list.push(item);
                 }
             }
             Ok(MarzanoResolvedPattern::List(unique_list))
@@ -433,11 +432,11 @@ fn distinct_fn<'a>(
         Some(MarzanoResolvedPattern::Binding(binding)) => match binding.last() {
             Some(b) => {
                 if let Some(list_items) = b.list_items() {
-                    let mut unique_list = Vector::new();
+                    let mut unique_list = Vec::new();
                     for item in list_items {
                         let resolved = ResolvedPattern::from_node_binding(item);
                         if !unique_list.contains(&resolved) {
-                            unique_list.push_back(resolved);
+                            unique_list.push(resolved);
                         }
                     }
                     Ok(MarzanoResolvedPattern::List(unique_list))

--- a/crates/core/src/marzano_context.rs
+++ b/crates/core/src/marzano_context.rs
@@ -22,7 +22,6 @@ use grit_util::{
     error::{GritPatternError, GritResult},
     AnalysisLogs, Ast, FileOrigin, InputRanges, MatchRanges,
 };
-use im::vector;
 use marzano_language::{
     language::{MarzanoLanguage, Tree},
     target_language::TargetLanguage,
@@ -332,7 +331,7 @@ impl<'a> ExecContext<'a, MarzanoQueryContext> for MarzanoContext<'a> {
             };
         }
 
-        let Some(new_files) = state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
+        let Some(new_files) = state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
             .last()
             .and_then(|binding| binding[NEW_FILES_INDEX].value.as_ref())
             .and_then(ResolvedPattern::get_list_items)
@@ -375,9 +374,9 @@ impl<'a> ExecContext<'a, MarzanoQueryContext> for MarzanoContext<'a> {
             let _ = state.files.push_new_file(self.files().last().unwrap());
         }
 
-        state.effects = vector![];
-        let the_new_files = state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
-            .back_mut()
+        state.effects = vec![];
+        let the_new_files = state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
+            .last_mut()
             .unwrap()[NEW_FILES_INDEX]
             .as_mut();
         the_new_files.value = Some(ResolvedPattern::from_list_parts([].into_iter()));

--- a/crates/core/src/marzano_resolved_pattern.rs
+++ b/crates/core/src/marzano_resolved_pattern.rs
@@ -85,7 +85,7 @@ impl<'a> MarzanoResolvedPattern<'a> {
                     snippets.push(ResolvedSnippet::Text(" ".into()));
                 }
                 snippets.pop();
-                Ok(snippets.into())
+                Ok(snippets)
             }
             MarzanoResolvedPattern::Map(map) => {
                 let mut snippets = Vec::new();
@@ -97,7 +97,7 @@ impl<'a> MarzanoResolvedPattern<'a> {
                 }
                 snippets.pop();
                 snippets.push(ResolvedSnippet::Text("}".into()));
-                Ok(snippets.into())
+                Ok(snippets)
             }
             MarzanoResolvedPattern::File(_) => Err(GritPatternError::new(
                 "cannot convert ResolvedPattern::File to ResolvedSnippet",
@@ -412,7 +412,7 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
                 }
             }
         }
-        Ok(Self::Snippets(parts.into()))
+        Ok(Self::Snippets(parts))
     }
 
     fn from_dynamic_pattern(
@@ -448,7 +448,7 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
                 for element in &list.elements {
                     elements.push(Self::from_dynamic_pattern(element, state, context, logs)?);
                 }
-                Ok(Self::List(elements.into()))
+                Ok(Self::List(elements))
             }
             DynamicPattern::Snippet(snippet) => {
                 Self::from_dynamic_snippet(snippet, state, context, logs)

--- a/crates/core/src/marzano_resolved_pattern.rs
+++ b/crates/core/src/marzano_resolved_pattern.rs
@@ -18,7 +18,6 @@ use grit_util::{
     error::{GritPatternError, GritResult},
     AnalysisLogs, Ast, AstNode, CodeRange, EffectKind, Range,
 };
-use im::{vector, Vector};
 use marzano_language::{language::FieldId, target_language::TargetLanguage};
 use marzano_util::node_with_source::NodeWithSource;
 use std::{
@@ -29,9 +28,9 @@ use std::{
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MarzanoResolvedPattern<'a> {
-    Binding(Vector<MarzanoBinding<'a>>),
-    Snippets(Vector<ResolvedSnippet<'a, MarzanoQueryContext>>),
-    List(Vector<MarzanoResolvedPattern<'a>>),
+    Binding(Vec<MarzanoBinding<'a>>),
+    Snippets(Vec<ResolvedSnippet<'a, MarzanoQueryContext>>),
+    List(Vec<MarzanoResolvedPattern<'a>>),
     Map(BTreeMap<String, MarzanoResolvedPattern<'a>>),
     File(MarzanoFile<'a>),
     Files(Box<MarzanoResolvedPattern<'a>>),
@@ -65,21 +64,19 @@ impl<'a> MarzanoResolvedPattern<'a> {
         Ok(matches)
     }
 
-    fn to_snippets(&self) -> GritResult<Vector<ResolvedSnippet<'a, MarzanoQueryContext>>> {
+    fn to_snippets(&self) -> GritResult<Vec<ResolvedSnippet<'a, MarzanoQueryContext>>> {
         match self {
             MarzanoResolvedPattern::Snippets(snippets) => Ok(snippets.clone()),
-            MarzanoResolvedPattern::Binding(bindings) => {
-                Ok(vector![ResolvedSnippet::from_binding(
-                    bindings
-                        .last()
-                        .ok_or_else(|| {
-                            GritPatternError::new(
-                                "cannot create resolved snippet from unresolved binding",
-                            )
-                        })?
-                        .to_owned(),
-                )])
-            }
+            MarzanoResolvedPattern::Binding(bindings) => Ok(vec![ResolvedSnippet::from_binding(
+                bindings
+                    .last()
+                    .ok_or_else(|| {
+                        GritPatternError::new(
+                            "cannot create resolved snippet from unresolved binding",
+                        )
+                    })?
+                    .to_owned(),
+            )]),
             MarzanoResolvedPattern::List(elements) => {
                 // merge separated by space
                 let mut snippets = Vec::new();
@@ -109,7 +106,7 @@ impl<'a> MarzanoResolvedPattern<'a> {
                 "cannot convert ResolvedPattern::Files to ResolvedSnippet",
             )),
             MarzanoResolvedPattern::Constant(c) => {
-                Ok(vector![ResolvedSnippet::Text(c.to_string().into(),)])
+                Ok(vec![ResolvedSnippet::Text(c.to_string().into())])
             }
         }
     }
@@ -119,7 +116,7 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
     fn extend(
         &mut self,
         mut with: MarzanoResolvedPattern<'a>,
-        effects: &mut Vector<Effect<'a, MarzanoQueryContext>>,
+        effects: &mut Vec<Effect<'a, MarzanoQueryContext>>,
         language: &TargetLanguage,
     ) -> GritResult<()> {
         match self {
@@ -149,7 +146,7 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
                         let binding = binding.last().ok_or_else(|| {
                             GritPatternError::new("cannot extend with empty binding")
                         })?;
-                        snippets.push_back(ResolvedSnippet::Binding(binding.clone()));
+                        snippets.push(ResolvedSnippet::Binding(binding.clone()));
                     }
                     Self::List(_) => {
                         return Err(GritPatternError::new(
@@ -172,7 +169,7 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
                         ))
                     }
                     Self::Constant(c) => {
-                        snippets.push_back(ResolvedSnippet::Text(c.to_string().into()));
+                        snippets.push(ResolvedSnippet::Text(c.to_string().into()));
                     }
                 }
                 Ok(())
@@ -181,7 +178,7 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
             // for now not since don't know what shape we want,
             // but probably will soon
             Self::List(lst) => {
-                lst.push_back(with);
+                lst.push(with);
                 Ok(())
             }
             Self::File(_) => Err(GritPatternError::new("cannot extend ResolvedPattern::File")),
@@ -225,7 +222,7 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
     }
 
     fn from_binding(binding: MarzanoBinding<'a>) -> Self {
-        Self::Binding(vector![binding])
+        Self::Binding(vec![binding])
     }
 
     fn from_constant(constant: Constant) -> Self {
@@ -245,11 +242,11 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
     }
 
     fn from_string(string: String) -> Self {
-        Self::Snippets(vector![ResolvedSnippet::Text(string.into())])
+        Self::Snippets(vec![ResolvedSnippet::Text(string.into())])
     }
 
     fn from_resolved_snippet(snippet: ResolvedSnippet<'a, MarzanoQueryContext>) -> Self {
-        Self::Snippets(vector![snippet])
+        Self::Snippets(vec![snippet])
     }
 
     fn get_bindings(&self) -> Option<impl Iterator<Item = MarzanoBinding<'a>>> {
@@ -365,7 +362,7 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
             return Err(GritPatternError::new("can only push to bindings"));
         };
 
-        bindings.push_back(binding);
+        bindings.push(binding);
         Ok(())
     }
 
@@ -395,9 +392,9 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
                     parts.push(ResolvedSnippet::Text(string.into()));
                 }
                 DynamicSnippetPart::Variable(var) => {
-                    let content = &state.bindings[var.try_scope().unwrap().into()]
+                    let content = &state.bindings[var.try_scope().unwrap() as usize]
                         .last()
-                        .unwrap()[var.try_index().unwrap().into()];
+                        .unwrap()[var.try_index().unwrap() as usize];
                     let name = &content.name;
                     // feels weird not sure if clone is correct
                     let value = if let Some(value) = &content.value {
@@ -426,9 +423,9 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
     ) -> GritResult<Self> {
         match pattern {
             DynamicPattern::Variable(var) => {
-                let content = &state.bindings[var.try_scope().unwrap().into()]
+                let content = &state.bindings[var.try_scope().unwrap() as usize]
                     .last()
-                    .unwrap()[var.try_index().unwrap().into()];
+                    .unwrap()[var.try_index().unwrap() as usize];
                 let name = &content.name;
                 // feels weird not sure if clone is correct
                 if let Some(value) = &content.value {
@@ -513,16 +510,16 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
                 "cannot make resolved pattern from callback pattern {}",
                 callback.name()
             ))),
-            Pattern::StringConstant(string) => Ok(Self::Snippets(vector![ResolvedSnippet::Text(
+            Pattern::StringConstant(string) => Ok(Self::Snippets(vec![ResolvedSnippet::Text(
                 (&string.text).into(),
             )])),
             Pattern::IntConstant(int) => Ok(Self::Constant(Constant::Integer(int.value))),
             Pattern::FloatConstant(double) => Ok(Self::Constant(Constant::Float(double.value))),
             Pattern::BooleanConstant(bool) => Ok(Self::Constant(Constant::Boolean(bool.value))),
             Pattern::Variable(var) => {
-                let content = &state.bindings[var.try_scope().unwrap().into()]
+                let content = &state.bindings[var.try_scope().unwrap() as usize]
                     .last()
-                    .unwrap()[var.try_index().unwrap().into()];
+                    .unwrap()[var.try_index().unwrap() as usize];
                 let name = &content.name;
                 // feels weird not sure if clone is correct
                 if let Some(value) = &content.value {
@@ -540,7 +537,7 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
                 .patterns
                 .iter()
                 .map(|pattern| Self::from_pattern(pattern, state, context, logs))
-                .collect::<GritResult<Vector<_>>>()
+                .collect::<GritResult<Vec<_>>>()
                 .map(Self::List),
             Pattern::ListIndex(index) => Self::from_list_index(index, state, context, logs),
             Pattern::Map(map) => map
@@ -852,12 +849,12 @@ impl<'a> ResolvedPattern<'a, MarzanoQueryContext> for MarzanoResolvedPattern<'a>
         let Self::Snippets(ref mut snippets) = self else {
             return Ok(());
         };
-        let Some(ResolvedSnippet::Text(text)) = snippets.front() else {
+        let Some(ResolvedSnippet::Text(text)) = snippets.first() else {
             return Ok(());
         };
         if let Some(padding) = binding.get_insertion_padding(text, is_first, language) {
             if padding.chars().next() != binding.text(language)?.chars().last() {
-                snippets.push_front(ResolvedSnippet::Text(padding.into()));
+                snippets.insert(0, ResolvedSnippet::Text(padding.into()));
             }
         }
         Ok(())

--- a/crates/core/src/pattern_compiler/compiler.rs
+++ b/crates/core/src/pattern_compiler/compiler.rs
@@ -26,7 +26,6 @@ use grit_util::{
     error::GritPatternError, traverse, AnalysisLogs, Ast, AstNode, ByteRange, FileRange, Order,
     Range, VariableMatch,
 };
-use im::{vector, Vector};
 use itertools::Itertools;
 use marzano_language::{
     self, grit_parser::MarzanoGritParser, language::Tree, target_language::TargetLanguage,
@@ -716,11 +715,11 @@ impl VariableLocations {
 
     pub(crate) fn initial_bindings(
         &self,
-    ) -> Vector<Vector<Vector<Box<VariableContent<MarzanoQueryContext>>>>> {
+    ) -> Vec<Vec<Vec<Box<VariableContent<MarzanoQueryContext>>>>> {
         self.locations
             .iter()
             .map(|scope| {
-                vector![scope
+                vec![scope
                     .iter()
                     .map(|s| Box::new(VariableContent::new(s.name().to_string())))
                     .collect()]

--- a/crates/core/src/problem.rs
+++ b/crates/core/src/problem.rs
@@ -565,7 +565,7 @@ impl Problem {
         let mut state = State::new(bindings, file_registry);
 
         let the_new_files = state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
-            .back_mut()
+            .last_mut()
             .unwrap()[NEW_FILES_INDEX]
             .as_mut();
         the_new_files.value = Some(MarzanoResolvedPattern::from_list_parts([].into_iter()));

--- a/crates/core/src/text_unparser.rs
+++ b/crates/core/src/text_unparser.rs
@@ -6,7 +6,6 @@ use grit_pattern_matcher::{
     pattern::{FileRegistry, ResolvedPattern},
 };
 use grit_util::{error::GritResult, AnalysisLogs, Ast, CodeRange, Language};
-use im::Vector;
 use std::collections::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -28,7 +27,7 @@ type EffectOutcome = (
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn apply_effects<'a, Q: QueryContext>(
     code: &'a Q::Tree<'a>,
-    effects: Vector<Effect<'a, Q>>,
+    effects: Vec<Effect<'a, Q>>,
     files: &FileRegistry<'a, Q>,
     the_filename: &Path,
     new_filename: &mut PathBuf,

--- a/crates/grit-pattern-matcher/Cargo.toml
+++ b/crates/grit-pattern-matcher/Cargo.toml
@@ -18,7 +18,6 @@ rust.unused_crate_dependencies = "warn"
 elsa = { version = "1.9.0" }
 getrandom = { version = "0.2.11", optional = true }
 grit-util = { path = "../grit-util", version = "0.3.0" }
-im = { version = "15.1.0" }
 itertools = { version = "0.10.5" }
 rand = { version = "0.8.5" }
 regex = { version = "1.7.3" }

--- a/crates/grit-pattern-matcher/src/effects.rs
+++ b/crates/grit-pattern-matcher/src/effects.rs
@@ -23,21 +23,21 @@ pub fn insert_effect<'a, Q: QueryContext>(
     match left {
         PatternOrResolved::Pattern(Pattern::Variable(var)) => {
             let var = state.trace_var_mut(var);
-            if let Some(base) = state.bindings[var.try_scope().unwrap().into()]
-                .back_mut()
-                .unwrap()[var.try_index().unwrap().into()]
-            .value
-            .as_mut()
+            if let Some(base) = state.bindings[var.try_scope().unwrap() as usize]
+                .last_mut()
+                .unwrap()[var.try_index().unwrap() as usize]
+                .value
+                .as_mut()
             {
                 base.extend(replacement, &mut state.effects, context.language())?;
                 Ok(true)
             } else {
                 Err(GritPatternError::new(format!(
                     "Variable {} is not bound",
-                    state.bindings[var.try_scope().unwrap().into()]
+                    state.bindings[var.try_scope().unwrap() as usize]
                         .last()
-                        .unwrap()[var.try_index().unwrap().into()]
-                    .name
+                        .unwrap()[var.try_index().unwrap() as usize]
+                        .name
                 )))
             }
         }

--- a/crates/grit-pattern-matcher/src/pattern/accumulate.rs
+++ b/crates/grit-pattern-matcher/src/pattern/accumulate.rs
@@ -83,7 +83,7 @@ impl<Q: QueryContext> Evaluator<Q> for Accumulate<Q> {
             let append = ResolvedPattern::from_pattern(&self.right, state, context, logs)?;
             let scope = var.get_scope(state)?;
             let index = var.get_index(state)?;
-            if let Some(base) = state.bindings[scope.into()].back_mut().unwrap()[index.into()]
+            if let Some(base) = state.bindings[scope as usize].last_mut().unwrap()[index as usize]
                 .value
                 .as_mut()
             {
@@ -95,10 +95,10 @@ impl<Q: QueryContext> Evaluator<Q> for Accumulate<Q> {
             } else {
                 Err(GritPatternError::new(format!(
                     "Variable {} is not bound",
-                    state.bindings[var.try_scope().unwrap().into()]
+                    state.bindings[var.try_scope().unwrap() as usize]
                         .last()
-                        .unwrap()[var.try_index().unwrap().into()]
-                    .name
+                        .unwrap()[var.try_index().unwrap() as usize]
+                        .name
                 )))
             }
         } else {

--- a/crates/grit-pattern-matcher/src/pattern/container.rs
+++ b/crates/grit-pattern-matcher/src/pattern/container.rs
@@ -44,9 +44,9 @@ impl<Q: QueryContext> Container<Q> {
         match self {
             Container::Variable(v) => {
                 let var = state.trace_var_mut(v);
-                let content = &mut state.bindings[var.try_scope().unwrap().into()]
-                    .back_mut()
-                    .unwrap()[var.try_index().unwrap().into()];
+                let content = &mut state.bindings[var.try_scope().unwrap() as usize]
+                    .last_mut()
+                    .unwrap()[var.try_index().unwrap() as usize];
                 match content.pattern {
                     Some(Pattern::Accessor(a)) => a.set_resolved(state, lang, value),
                     Some(Pattern::ListIndex(l)) => l.set_resolved(state, lang, value),

--- a/crates/grit-pattern-matcher/src/pattern/contains.rs
+++ b/crates/grit-pattern-matcher/src/pattern/contains.rs
@@ -157,8 +157,8 @@ impl<Q: QueryContext> Matcher<Q> for Contains<Q> {
                 return Ok(false);
             }
 
-            init_state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
-                .back_mut()
+            init_state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
+                .last_mut()
                 .unwrap()[PROGRAM_INDEX]
                 .value = Some(file.binding(&init_state.files));
 

--- a/crates/grit-pattern-matcher/src/pattern/file_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/file_pattern.rs
@@ -51,20 +51,20 @@ impl<Q: QueryContext> Matcher<Q> for FilePattern<Q> {
             .execute(&file.name(&state.files), state, context, logs)?;
 
         // Fill in the variables now - this is a bit of a hack
-        state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
-            .back_mut()
+        state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
+            .last_mut()
             .unwrap()[PROGRAM_INDEX]
             .value = Some(file.binding(&state.files));
-        state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
-            .back_mut()
+        state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
+            .last_mut()
             .unwrap()[FILENAME_INDEX]
             .value = Some(file.name(&state.files));
-        state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
-            .back_mut()
+        state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
+            .last_mut()
             .unwrap()[ABSOLUTE_PATH_INDEX]
             .value = Some(file.name(&state.files));
-        state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
-            .back_mut()
+        state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
+            .last_mut()
             .unwrap()[ABSOLUTE_PATH_INDEX]
             .value = Some(file.absolute_path(&state.files, context.language())?);
 

--- a/crates/grit-pattern-matcher/src/pattern/log.rs
+++ b/crates/grit-pattern-matcher/src/pattern/log.rs
@@ -60,9 +60,9 @@ impl<Q: QueryContext> Log<Q> {
             if self.message.is_none() {
                 message.push_str(&format!("Logging {}\n", name));
             }
-            let var_content = &state.bindings[var.try_scope().unwrap().into()]
+            let var_content = &state.bindings[var.try_scope().unwrap() as usize]
                 .last()
-                .unwrap()[var.try_index().unwrap().into()];
+                .unwrap()[var.try_index().unwrap() as usize];
             let value = var_content.value.as_ref();
             let src = value
                 .map(|v| {

--- a/crates/grit-pattern-matcher/src/pattern/match.rs
+++ b/crates/grit-pattern-matcher/src/pattern/match.rs
@@ -40,9 +40,9 @@ impl<Q: QueryContext> Evaluator<Q> for Match<Q> {
         match &self.val {
             Container::Variable(var) => {
                 let var = state.trace_var_mut(var);
-                let var_content = &state.bindings[var.try_scope().unwrap().into()]
+                let var_content = &state.bindings[var.try_scope().unwrap() as usize]
                     .last()
-                    .unwrap()[var.try_index().unwrap().into()];
+                    .unwrap()[var.try_index().unwrap() as usize];
                 let predicator = if let Some(pattern) = &self.pattern {
                     if let Some(important_binding) = &var_content.value {
                         pattern.execute(&important_binding.clone(), state, context, logs)?

--- a/crates/grit-pattern-matcher/src/pattern/pattern_definition.rs
+++ b/crates/grit-pattern-matcher/src/pattern/pattern_definition.rs
@@ -88,8 +88,8 @@ impl<Q: QueryContext> PatternDefinition<Q> {
         let res = self.pattern.execute(binding, state, context, logs);
         state.exit_scope(tracker);
 
-        let fn_state = state.bindings[scope].pop_back().unwrap();
-        let cur_fn_state = state.bindings[scope].back_mut().unwrap();
+        let fn_state = state.bindings[scope].pop().unwrap();
+        let cur_fn_state = state.bindings[scope].last_mut().unwrap();
         for (cur, last) in cur_fn_state.iter_mut().zip(fn_state) {
             cur.value_history.extend(last.value_history)
         }

--- a/crates/grit-pattern-matcher/src/pattern/patterns.rs
+++ b/crates/grit-pattern-matcher/src/pattern/patterns.rs
@@ -235,8 +235,8 @@ impl<Q: QueryContext> Matcher<Q> for Pattern<Q> {
         logs: &mut AnalysisLogs,
     ) -> GritResult<bool> {
         if let Some(file) = binding.get_file() {
-            state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
-                .back_mut()
+            state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
+                .last_mut()
                 .unwrap()[FILENAME_INDEX]
                 .value = Some(file.name(&state.files));
         }

--- a/crates/grit-pattern-matcher/src/pattern/regex.rs
+++ b/crates/grit-pattern-matcher/src/pattern/regex.rs
@@ -81,9 +81,9 @@ impl<Q: QueryContext> RegexPattern<Q> {
 
             // we should really be making the resolved pattern first, and using
             // variable execute, instead of reimplementing here.
-            let variable_content = &mut state.bindings[variable.try_scope().unwrap().into()]
-                .back_mut()
-                .unwrap()[variable.try_index().unwrap().into()];
+            let variable_content = &mut state.bindings[variable.try_scope().unwrap() as usize]
+                .last_mut()
+                .unwrap()[variable.try_index().unwrap() as usize];
 
             if let Some(previous_value) = &variable_content.value {
                 if previous_value
@@ -111,9 +111,9 @@ impl<Q: QueryContext> RegexPattern<Q> {
                         return Ok(false);
                     }
                 }
-                let variable_content = &mut state.bindings[variable.try_scope().unwrap().into()]
-                    .back_mut()
-                    .unwrap()[variable.try_index().unwrap().into()];
+                let variable_content = &mut state.bindings[variable.try_scope().unwrap() as usize]
+                    .last_mut()
+                    .unwrap()[variable.try_index().unwrap() as usize];
                 variable_content.set_value(res);
             }
         }

--- a/crates/grit-pattern-matcher/src/pattern/resolved_pattern.rs
+++ b/crates/grit-pattern-matcher/src/pattern/resolved_pattern.rs
@@ -7,7 +7,6 @@ use super::{
 };
 use crate::{binding::Binding, constant::Constant, context::QueryContext, effects::Effect};
 use grit_util::{error::GritResult, AnalysisLogs, ByteRange, CodeRange, Range};
-use im::Vector;
 use itertools::Itertools;
 use std::{
     borrow::Cow,
@@ -104,7 +103,7 @@ pub trait ResolvedPattern<'a, Q: QueryContext>: Clone + Debug + PartialEq {
     fn extend(
         &mut self,
         with: Q::ResolvedPattern<'a>,
-        effects: &mut Vector<Effect<'a, Q>>,
+        effects: &mut Vec<Effect<'a, Q>>,
         language: &Q::Language<'a>,
     ) -> GritResult<()>;
 
@@ -297,7 +296,7 @@ impl<'a, Q: QueryContext> LazyBuiltIn<'a, Q> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct JoinFn<'a, Q: QueryContext> {
-    pub list: Vector<Q::ResolvedPattern<'a>>,
+    pub list: Vec<Q::ResolvedPattern<'a>>,
     separator: String,
 }
 

--- a/crates/grit-pattern-matcher/src/pattern/rewrite.rs
+++ b/crates/grit-pattern-matcher/src/pattern/rewrite.rs
@@ -74,9 +74,9 @@ impl<Q: QueryContext> Rewrite<Q> {
                         ..
                     }) = state
                         .bindings
-                        .get(var.try_scope().unwrap().into())
+                        .get(var.try_scope().unwrap() as usize)
                         .and_then(|scope| {
-                            scope.last().unwrap().get(var.try_index().unwrap().into())
+                            scope.last().unwrap().get(var.try_index().unwrap() as usize)
                         })
                         .cloned()
                         .map(|b| *b)

--- a/crates/grit-pattern-matcher/src/pattern/variable.rs
+++ b/crates/grit-pattern-matcher/src/pattern/variable.rs
@@ -211,9 +211,9 @@ impl Variable {
         state: &'b State<'a, Q>,
     ) -> GritResult<Option<PatternOrResolved<'a, 'b, Q>>> {
         let v = state.trace_var(self);
-        let content = &state.bindings[v.try_scope().unwrap().into()]
+        let content = &state.bindings[v.try_scope().unwrap() as usize]
             .last()
-            .unwrap()[v.try_index().unwrap().into()];
+            .unwrap()[v.try_index().unwrap() as usize];
         if let Some(pattern) = content.pattern {
             Ok(Some(PatternOrResolved::Pattern(pattern)))
         } else if let Some(resolved) = &content.value {
@@ -227,9 +227,9 @@ impl Variable {
         state: &'b mut State<'a, Q>,
     ) -> GritResult<Option<PatternOrResolvedMut<'a, 'b, Q>>> {
         let v = state.trace_var_mut(self);
-        let content = &mut state.bindings[v.try_scope().unwrap().into()]
-            .back_mut()
-            .unwrap()[v.try_index().unwrap().into()];
+        let content = &mut state.bindings[v.try_scope().unwrap() as usize]
+            .last_mut()
+            .unwrap()[v.try_index().unwrap() as usize];
         if let Some(pattern) = content.pattern {
             Ok(Some(PatternOrResolvedMut::Pattern(pattern)))
         } else if let Some(resolved) = &mut content.value {
@@ -255,10 +255,10 @@ impl Variable {
         state: &State<'a, Q>,
         lang: &Q::Language<'a>,
     ) -> GritResult<Cow<'a, str>> {
-        state.bindings[self.try_scope().unwrap().into()]
+        state.bindings[self.try_scope().unwrap() as usize]
             .last()
-            .unwrap()[self.try_index().unwrap().into()]
-        .text(state, lang)
+            .unwrap()[self.try_index().unwrap() as usize]
+            .text(state, lang)
     }
 
     fn execute_resolved<'a, Q: QueryContext>(
@@ -273,11 +273,11 @@ impl Variable {
             let index = self.get_index(state)?;
             let variable_content = state
                 .bindings
-                .get_mut(scope.into())
+                .get_mut(scope as usize)
                 .unwrap()
-                .back_mut()
+                .last_mut()
                 .unwrap()
-                .get_mut(index.into());
+                .get_mut(index as usize);
             let Some(variable_content) = variable_content else {
                 return Ok(None);
             };
@@ -317,11 +317,11 @@ impl Variable {
         for mirror in variable_mirrors {
             let mirror_content = &mut **(state
                 .bindings
-                .get_mut(mirror.scope.into())
+                .get_mut(mirror.scope as usize)
                 .unwrap()
-                .back_mut()
+                .last_mut()
                 .unwrap()
-                .get_mut(mirror.index.into())
+                .get_mut(mirror.index as usize)
                 .unwrap());
             if let Some(value) = &mut mirror_content.value {
                 if value.is_binding() {
@@ -362,11 +362,11 @@ impl<Q: QueryContext> Matcher<Q> for Variable {
 
         let variable_content = state
             .bindings
-            .get_mut(scope.into())
+            .get_mut(scope as usize)
             .unwrap()
-            .back_mut()
+            .last_mut()
             .unwrap()
-            .get_mut(index.into());
+            .get_mut(index as usize);
         let Some(variable_content) = variable_content else {
             logs.add_warning(
                 None,
@@ -383,11 +383,11 @@ impl<Q: QueryContext> Matcher<Q> for Variable {
         }
         let variable_content = &mut **(state
             .bindings
-            .get_mut(scope.into())
+            .get_mut(scope as usize)
             .unwrap()
-            .back_mut()
+            .last_mut()
             .unwrap()
-            .get_mut(index.into())
+            .get_mut(index as usize)
             .unwrap());
         variable_content.value = Some(resolved_pattern.clone());
         variable_content
@@ -401,7 +401,7 @@ pub fn get_absolute_file_name<'a, Q: QueryContext>(
     state: &State<'a, Q>,
     lang: &Q::Language<'a>,
 ) -> GritResult<String> {
-    let file = state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
+    let file = state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
         .last()
         .unwrap()[ABSOLUTE_PATH_INDEX]
         .value
@@ -416,7 +416,7 @@ pub fn get_file_name<'a, Q: QueryContext>(
     state: &State<'a, Q>,
     lang: &Q::Language<'a>,
 ) -> GritResult<String> {
-    let file = state.bindings[GLOBAL_VARS_SCOPE_INDEX.into()]
+    let file = state.bindings[GLOBAL_VARS_SCOPE_INDEX as usize]
         .last()
         .unwrap()[FILENAME_INDEX]
         .value


### PR DESCRIPTION
Gives rougly a 25-30% performance improvement on Biome's Grit benchmarks.

Heads-up: This changes a signature in [api.rs](https://github.com/getgrit/gritql/compare/main...arendjr:remove-im?expand=1#diff-2290d10881b8010042083f2b283329457b3f5f321cda8a1747e8bf0ae707a1ff). It looks like it should be easy enough for you to adapt, but let me know if you prefer me to revert to `im` there.

There's a bunch of `.iter()` => `as usize` changes that were unfortunately necessary due to ambiguities.

Would be great if 0.4 of the crates can be released after merging this: https://github.com/getgrit/gritql/pull/498

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
API usage limit has reached your account's monthly budget. API requests will be rejected.

<!-- /greptile_comment -->