### PR TITLE
feat: use shallow clones for gritmodules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,11 +1392,11 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.17.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "libc",
  "libgit2-sys",
  "log",
@@ -2031,9 +2031,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.15.2+1.6.4"
+version = "0.17.0+1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
 dependencies = [
  "cc",
  "libc",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,7 +31,7 @@ indicatif-log-bridge = { version = "0.2.1" }
 colored = { version = "2.0.4" }
 log = { version = "0.4.19" }
 env_logger = { version = "0.10.0" }
-git2 = { version = "0.17.2" }
+git2 = { version = "0.19.0" }
 regex = { version = "1.7.3" }
 grit-util = { path = "../grit-util" }
 marzano-core = { path = "../core", features = [

--- a/crates/gritmodule/Cargo.toml
+++ b/crates/gritmodule/Cargo.toml
@@ -23,7 +23,7 @@ serde_yaml = { version = "0.9.25" }
 anyhow = { version = "1.0.70" }
 futures = { version = "0.3.29" }
 rand = { version = "0.8.5" }
-git2 = { version = "0.17.2", default-features = false, features = [
+git2 = { version = "0.19.0", default-features = false, features = [
   "vendored-openssl",
 ] }
 lazy_static = { version = "1.4.0" }

--- a/crates/gritmodule/src/fetcher.rs
+++ b/crates/gritmodule/src/fetcher.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Result};
-use git2::Repository;
+use git2::{build::RepoBuilder, FetchOptions, Repository};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -271,7 +271,12 @@ fn clone_repo<'a>(
         None => repo.remote.to_string(),
     };
 
-    match Repository::clone(&remote, target_dir) {
+    let mut cloner = RepoBuilder::new();
+    let mut options = FetchOptions::new();
+    options.depth(1);
+    cloner.fetch_options(options);
+
+    match cloner.clone(&remote, target_dir) {
         Ok(_) => {}
         Err(e) => {
             if !target_dir.exists() {
@@ -458,13 +463,17 @@ mod tests {
             provider_name: "github.com/getgrit/stdlib".to_string(),
         };
         let gritmodule_dir = fetcher.fetch_grit_module(&repo).unwrap();
-        assert_eq!(
-            gritmodule_dir,
-            dir.path()
-                .join("github.com/getgrit/stdlib")
-                .to_str()
-                .unwrap()
-        );
+        let module_dir = dir.path().join("github.com/getgrit/stdlib");
+        assert_eq!(gritmodule_dir, module_dir.to_str().unwrap());
+        let output = std::process::Command::new("git")
+            .arg("rev-parse")
+            .arg("--is-shallow-repository")
+            .current_dir(&module_dir)
+            .output()
+            .expect("Failed to execute git command");
+
+        let is_shallow = String::from_utf8_lossy(&output.stdout).trim() == "true";
+        assert!(is_shallow, "Repository is not shallow");
     }
 
     #[test]

--- a/crates/gritmodule/src/fetcher.rs
+++ b/crates/gritmodule/src/fetcher.rs
@@ -448,6 +448,26 @@ mod tests {
     }
 
     #[test]
+    fn shallow_clone() {
+        let dir = tempdir().unwrap();
+        let fetcher = CleanFetcher::new(dir.path().to_path_buf(), None);
+        let repo = ModuleRepo {
+            host: "github.com".to_string(),
+            full_name: "getgrit/stdlib".to_string(),
+            remote: "http://github.com/getgrit/stdlib.git".to_string(),
+            provider_name: "github.com/getgrit/stdlib".to_string(),
+        };
+        let gritmodule_dir = fetcher.fetch_grit_module(&repo).unwrap();
+        assert_eq!(
+            gritmodule_dir,
+            dir.path()
+                .join("github.com/getgrit/stdlib")
+                .to_str()
+                .unwrap()
+        );
+    }
+
+    #[test]
     fn module_repo_from_https_remote() {
         let remote = "https://github.com/getgrit/rewriter.git";
         let repo = ModuleRepo::from_remote(remote).unwrap();


### PR DESCRIPTION
Improves https://github.com/getgrit/gritql/issues/542 by using shallow clones (so we don't need full history).

Unfortunately sparse checkout isn't supported in libgit2 so we are stuck with the whole repository unless/until we skip libgit2 entirely: https://github.com/libgit2/libgit2/issues/2263

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
Hi! Looks like you've reached your API usage limit. You can increase it from your account settings page here: [app.greptile.com/settings/usage](https://app.greptile.com/settings/usage)

<!-- /greptile_comment -->