### PR TITLE
fix: attempt to add trace context to logs

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -156,5 +156,6 @@ grit_beta = [
   "remote_workflows",
   "workflow_server",
   # "grit_timing",
+  # "grit_tracing",
 ]
 grit_timing = []

--- a/crates/cli/src/tracing_bridge.rs
+++ b/crates/cli/src/tracing_bridge.rs
@@ -167,11 +167,7 @@ where
     P: LoggerProvider<Logger = L> + Send + Sync + 'static,
     L: Logger + Send + Sync + 'static,
 {
-    fn on_event(
-        &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
         #[cfg(feature = "experimental_metadata_attributes")]
         let normalized_meta = event.normalized_metadata();
         #[cfg(feature = "experimental_metadata_attributes")]
@@ -186,7 +182,24 @@ where
 
         // Extract the trace_id & span_id from the opentelemetry extension.
         // This isn't really working for us.
-        // set_trace_context(&mut log_record, &_ctx);
+        if let Some((trace_id, span_id)) = ctx.lookup_current().and_then(|span| {
+            span.extensions()
+                .get::<tracing_opentelemetry::OtelData>()
+                .and_then(|ext| ext.builder.trace_id.zip(ext.builder.span_id))
+        }) {
+            log_record.trace_context = Some(opentelemetry::logs::TraceContext::from(
+                &opentelemetry::trace::SpanContext::new(
+                    trace_id,
+                    span_id,
+                    opentelemetry::trace::TraceFlags::default(),
+                    false,
+                    opentelemetry::trace::TraceState::default(),
+                ),
+            ));
+            eprintln!("trace_id: {:?}, span_id: {:?}", trace_id, span_id);
+        } else {
+            eprintln!("No trace_id or span_id found");
+        }
 
         // Not populating ObservedTimestamp, instead relying on OpenTelemetry
         // API to populate it with current time.


### PR DESCRIPTION
More context:
- https://github.com/tokio-rs/tracing-opentelemetry/issues/174#issuecomment-2427353525
- https://github.com/jpramosi/opentelemetry-rust/blob/dbd359c6107afb86ee823667369d97b8e16d09a0/opentelemetry-appender-tracing/src/layer.rs#L188

The problem seems to be that opentelemetry doesn't fully track the context well across all async boundaries when using `instrument` from tracing.

Therefore, I instead just rely directly on retrieving the current trace from `tracing`.


<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
Hi! Looks like you've reached your API usage limit. You can increase it from your account settings page here: [app.greptile.com/settings/usage](https://app.greptile.com/settings/usage)

<!-- /greptile_comment -->