### PR TITLE
fix: 423 missing file message

### DIFF
--- a/crates/cli_bin/fixtures/pattern_non_existent/.grit/grit.yaml
+++ b/crates/cli_bin/fixtures/pattern_non_existent/.grit/grit.yaml
@@ -1,0 +1,3 @@
+version: 0.0.1
+patterns:
+  - file: patterns/non_existent.md

--- a/crates/cli_bin/tests/patterns_test.rs
+++ b/crates/cli_bin/tests/patterns_test.rs
@@ -194,14 +194,18 @@ patterns:
     thread::sleep(Duration::from_secs(3));
 
     let mut cmd = get_test_cmd()?;
-    cmd.arg("patterns").arg("test").current_dir(&temp_fixture_path);
+    cmd.arg("patterns")
+        .arg("test")
+        .current_dir(&temp_fixture_path);
     let output = cmd.output()?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
     println!("stdout: {}", stdout);
     println!("stderr: {}", stderr);
 
-    assert!(stderr.contains("Failed to find pattern at .grit/patterns/non_existent.md. Does it exist?"));
+    assert!(
+        stderr.contains("Failed to find pattern at .grit/patterns/non_existent.md. Does it exist?")
+    );
 
     Ok(())
 }

--- a/crates/cli_bin/tests/patterns_test.rs
+++ b/crates/cli_bin/tests/patterns_test.rs
@@ -182,16 +182,7 @@ fn fails_recursion() -> Result<()> {
 
 #[test]
 fn fails_to_find_non_existent_file() -> Result<()> {
-    let (_temp_dir, temp_fixture_path) = get_fixture("patterns_test", false)?;
-    let test_yaml_path = temp_fixture_path.join(".grit/grit.yaml");
-    // Update it to a config with a non-existent file
-    let yaml_str = r#"
-version: 0.0.1
-patterns:
-  - file: patterns/non_existent.md
-"#;
-    fs::write(&test_yaml_path, yaml_str)?;
-    thread::sleep(Duration::from_secs(3));
+    let (_temp_dir, temp_fixture_path) = get_fixture("pattern_non_existent", false)?;
 
     let mut cmd = get_test_cmd()?;
     cmd.arg("patterns")

--- a/crates/gritmodule/src/parser.rs
+++ b/crates/gritmodule/src/parser.rs
@@ -98,10 +98,17 @@ pub async fn get_patterns_from_file(
     ext: PatternFileExt,
     overrides: GritDefinitionOverrides,
 ) -> Result<Vec<ModuleGritPattern>> {
-    let repo_root = find_repo_root_from(path.clone()).await?;
-    let content = fs::read_to_string(&path).await?;
+    let path_str = path.to_string_lossy();
+    let repo_root = find_repo_root_from(path.clone()).await.context(format!(
+        "Failed to find repository root from path {}",
+        path_str
+    ))?;
+    let content = fs::read_to_string(&path).await.context(format!(
+        "Failed to find pattern at {}. Does it exist?",
+        extract_relative_path(&path_str, &repo_root)
+    ))?;
     let mut file = RichFile {
-        path: path.to_string_lossy().to_string(),
+        path: path_str.to_string(),
         content,
     };
     ext.get_patterns(&mut file, &source_module, &repo_root, overrides)


### PR DESCRIPTION
/claim #423

- test(patterns_test): add fails_to_find_non_existent_file() test that will fail until the better missing file message is implemented
  - see #423
- fix(parser): add anyhow::Context messages to get_patterns_from_file() awaits if the function fails to find the repo root or fails to read the file path
  - fixes #423



<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
Hi! Looks like you've reached your API usage limit. You can increase it from your account settings page here: [app.greptile.com/settings/usage](https://app.greptile.com/settings/usage)

<!-- /greptile_comment -->