### PR TITLE
fix: Attempt to analyze file paths in the input without extension check

### DIFF
--- a/crates/cli/src/analyze.rs
+++ b/crates/cli/src/analyze.rs
@@ -205,6 +205,10 @@ where
                 if file.file_type().unwrap().is_dir() {
                     continue;
                 }
+                if my_input.paths.contains(&file.path().to_path_buf()) {
+                    file_paths_tx.send(file.path().to_path_buf()).unwrap();
+                    continue;
+                }
                 if !&compiled.language.match_extension(
                     file.path()
                         .extension()


### PR DESCRIPTION
- Attempts to immediately send file paths that are specified in the input to `file_path_tx`

/claim #485

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
Hi! Looks like you've reached your API usage limit. You can increase it from your account settings page here: [app.greptile.com/settings/usage](https://app.greptile.com/settings/usage)

<!-- /greptile_comment -->