### PR TITLE
feat(lang): add C# language support with modern features

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,6 @@
 [submodule "resources/language-submodules/tree-sitter-php"]
 	path = resources/language-submodules/tree-sitter-php
 	url = https://github.com/tree-sitter/tree-sitter-php
+[submodule "resources/language-submodules/tree-sitter-c"]
+	path = resources/language-submodules/tree-sitter-c
+	url = https://github.com/tree-sitter/tree-sitter-c

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "grit"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "fs-err",
+ "fs_extra",
+ "insta",
+ "marzano-cli",
+ "marzano-gritmodule",
+ "marzano-util",
+ "ntest",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "predicates",
+ "rayon",
+ "regex",
+ "reqwest 0.11.24",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "grit-pattern-matcher"
 version = "0.5.0"
 dependencies = [
@@ -2149,34 +2177,6 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "marzano"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "assert_cmd",
- "fs-err",
- "fs_extra",
- "insta",
- "marzano-cli",
- "marzano-gritmodule",
- "marzano-util",
- "ntest",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
- "predicates",
- "rayon",
- "regex",
- "reqwest 0.11.24",
- "serde_json",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/language/src/csharp.rs
+++ b/crates/language/src/csharp.rs
@@ -3,8 +3,7 @@ use grit_util::Language;
 use marzano_util::node_with_source::NodeWithSource;
 use std::sync::OnceLock;
 
-static NODE_TYPES_STRING: &str =
-    include_str!("../../../resources/node-types/csharp-node-types.json");
+static NODE_TYPES_STRING: &str = include_str!("../../../resources/node-types/csharp-node-types.json");
 static NODE_TYPES: OnceLock<Vec<Vec<Field>>> = OnceLock::new();
 static LANGUAGE: OnceLock<TSLanguage> = OnceLock::new();
 
@@ -14,6 +13,7 @@ fn language() -> TSLanguage {
         "tree-sitter parser must be initialized before use when [builtin-parser] is off."
     )
 }
+
 #[cfg(feature = "builtin-parser")]
 fn language() -> TSLanguage {
     tree_sitter_c_sharp::language().into()
@@ -40,6 +40,7 @@ impl CSharp {
             language,
         }
     }
+
     pub(crate) fn is_initialized() -> bool {
         LANGUAGE.get().is_some()
     }
@@ -59,7 +60,17 @@ impl Language for CSharp {
     }
 
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
-        &[("", "")]
+        &[
+            ("", ""),
+            ("class Program { void Method() { ", " } }"),
+            ("class Program { void Method() { ", "; } }"),
+            ("class Program { ", " }"),
+            ("class Program { object Method() { return ", "; } }"),
+            ("class Program { void Method() { if (", ") { } } }"),
+            ("class Program { var x = ", "; }"),
+            ("class Program { Action a = ", "; }"),
+            ("class Program { IEnumerable<object> Method() { return ", "; } }"),
+        ]
     }
 }
 
@@ -74,5 +85,344 @@ impl<'a> MarzanoLanguage<'a> for CSharp {
 
     fn metavariable_sort(&self) -> SortId {
         self.metavariable_sort
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language::nodes_from_indices;
+
+    #[test]
+    fn method_call_snippet() {
+        let snippet = "$obj.$method($args)";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn using_statement_snippet() {
+        let snippet = "using $namespace;";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn class_declaration_snippet() {
+        let snippet = "public class $name : $baseClass { }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn method_with_attributes_snippet() {
+        let snippet = "[$attribute] public async Task<$returnType> $name($params) { }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn namespace_declaration_snippet() {
+        let snippet = "namespace $name { }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn property_accessor_snippet() {
+        let snippet = "public $type $name { get => $expr; set => $field = value; }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn linq_expression_snippet() {
+        let snippet = "from $item in $collection where $condition select $result";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn async_await_snippet() {
+        let snippet = "await $obj.$method($args)";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn generic_type_declaration_snippet() {
+        let snippet = "public class $name<$T> where $T : $constraint { }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn attribute_declaration_snippet() {
+        let snippet = "[System.AttributeUsage($target)] public class $nameAttribute : Attribute { }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn interface_declaration_snippet() {
+        let snippet = "public interface $name { $type $method($params); }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn lambda_expression_snippet() {
+        let snippet = "($params) => $expression";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn complex_linq_query_snippet() {
+        let snippet = "from $x in $collection where $x.$prop == $value group $x by $x.$key into $g select new { Key = $g.Key, Count = $g.Count() }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn generic_method_declaration_snippet() {
+        let snippet = "public $returnType $name<$T>($params) where $T : $constraint { }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn multiple_attributes_snippet() {
+        let snippet = "[$attr1, $attr2($param)] public class $name { }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn expression_bodied_member_snippet() {
+        let snippet = "public $type $name => $expression;";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn switch_expression_snippet() {
+        let snippet = "$value switch { $pattern => $result, _ => $default }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn record_declaration_snippet() {
+        let snippet = "public record $name($type $prop1, $type $prop2);";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn pattern_matching_snippet() {
+        let snippet = "$obj is $type";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn pattern_matching_with_variable_snippet() {
+        let snippet = "$obj is $type $name";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn top_level_statements_snippet() {
+        let snippet = "using $namespace; var $name = $expr;";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn init_only_property_snippet() {
+        let snippet = "public $type $name { get; init; }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn file_scoped_namespace_snippet() {
+        let snippet = "namespace $name;";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn target_typed_new_snippet() {
+        let snippet = "$var = new($args);";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn enhanced_pattern_matching_snippet() {
+        let snippet = "$expr is not null and >= $min and <= $max";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn record_with_init_snippet() {
+        let snippet = "var $var = new $record { $prop1 = $val1, $prop2 = $val2 };";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn positional_record_snippet() {
+        let snippet = "public record $name($type1 $prop1, $type2 $prop2);";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn required_members_snippet() {
+        let snippet = "public required $type $name { get; set; }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn global_using_snippet() {
+        let snippet = "global using $namespace;";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn extended_property_pattern_snippet() {
+        let snippet = "if (obj is { $prop1: $val1, $prop2.Length: > $len })";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn raw_string_literal_snippet() {
+        let snippet = "var $var = \"\"\"$content\"\"\";";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn list_pattern_snippet() {
+        let snippet = "if ($list is [$first, .., $last])";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn static_abstract_interface_snippet() {
+        let snippet = "public interface $name { static abstract $type $method($params); }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn primary_constructor_snippet() {
+        let snippet = "public class $name($type $param) { }";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn collection_expression_snippet() {
+        let snippet = "var $var = [$item1, $item2, ..$rest];";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn constant_interpolated_string_snippet() {
+        let snippet = "const string $var = $\"Hello {$name}\";";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn migration_pattern_snippet() {
+        let snippet = "var $var = $obj switch { $oldPattern => $newPattern };";
+        let lang = CSharp::new(None);
+        let snippets = lang.parse_snippet_contexts(snippet);
+        let nodes = nodes_from_indices(&snippets);
+        assert!(!nodes.is_empty());
     }
 }

--- a/resources/metavariable-grammars/c-sharp.js
+++ b/resources/metavariable-grammars/c-sharp.js
@@ -1,0 +1,504 @@
+// Based on tree-sitter-c-sharp grammar
+module.exports = grammar({
+  name: 'c_sharp',
+
+  externals: $ => [
+    $._preproc_directive_trivia,
+    $.string_start,
+    $.string_content,
+    $.string_end,
+    $.verbatim_string_start,
+    $.interpolation_start,
+    $.interpolation_end,
+    $.comment,
+  ],
+
+  extras: $ => [
+    $.comment,
+    /\s/
+  ],
+
+  rules: {
+    // Base metavariable support
+    identifier: $ => choice(
+      $.grit_metavariable,
+      /[A-Za-z_][A-Za-z0-9_]*/
+    ),
+
+    // Type system support
+    type: $ => choice(
+      $.grit_metavariable,
+      $.simple_type,
+      $.array_type,
+      $.pointer_type,
+      $.function_pointer_type,
+      $.nullable_type,
+      $.tuple_type,
+      $.generic_type
+    ),
+
+    generic_type: $ => seq(
+      field('type', choice($.identifier, $.qualified_name)),
+      field('type_arguments', $.type_argument_list)
+    ),
+
+    type_argument_list: $ => seq(
+      '<',
+      choice($.grit_metavariable, commaSep1($.type)),
+      '>'
+    ),
+
+    // Method and property declarations
+    method_declaration: $ => seq(
+      optional($.attributes),
+      repeat($.modifier),
+      field('type', $.type),
+      field('name', choice($.identifier, $.grit_metavariable)),
+      field('parameters', $.parameter_list),
+      choice(
+        field('body', $.block),
+        ';',
+        '=>',
+        field('expression_body', $._expression)
+      )
+    ),
+
+    property_declaration: $ => seq(
+      optional($.attributes),
+      repeat($.modifier),
+      field('type', $.type),
+      field('name', choice($.identifier, $.grit_metavariable)),
+      choice(
+        seq(
+          '{',
+          optional($.accessor_list),
+          '}'
+        ),
+        seq(
+          '=>',
+          field('expression', $._expression),
+          ';'
+        )
+      )
+    ),
+
+    // Expression support
+    _expression: $ => choice(
+      $.grit_metavariable,
+      $.binary_expression,
+      $.assignment_expression,
+      $.conditional_expression,
+      $.unary_expression,
+      $.cast_expression,
+      $.await_expression,
+      $.primary_expression,
+      $.lambda_expression,
+      $.query_expression,
+      $.is_pattern_expression,
+      $.grit_metavariable
+    ),
+
+    // LINQ support
+    query_expression: $ => seq(
+      'from',
+      field('range_variable', choice($.identifier, $.grit_metavariable)),
+      'in',
+      field('collection', choice($._expression, $.grit_metavariable)),
+      repeat(choice(
+        $.where_clause,
+        $.join_clause,
+        $.let_clause,
+        $.group_clause,
+        $.select_clause,
+        $.orderby_clause
+      ))
+    ),
+
+    where_clause: $ => seq(
+      'where',
+      field('condition', choice($._expression, $.grit_metavariable))
+    ),
+
+    group_clause: $ => seq(
+      'group',
+      field('element', choice($._expression, $.grit_metavariable)),
+      'by',
+      field('key', choice($._expression, $.grit_metavariable))
+    ),
+
+    // Statement support
+    statement: $ => choice(
+      $.grit_metavariable,
+      $.block,
+      $.break_statement,
+      $.checked_statement,
+      $.continue_statement,
+      $.do_statement,
+      $.empty_statement,
+      $.expression_statement,
+      $.fixed_statement,
+      $.for_statement,
+      $.foreach_statement,
+      $.goto_statement,
+      $.if_statement,
+      $.labeled_statement,
+      $.local_declaration_statement,
+      $.local_function_statement,
+      $.lock_statement,
+      $.return_statement,
+      $.switch_statement,
+      $.throw_statement,
+      $.try_statement,
+      $.unsafe_statement,
+      $.using_statement,
+      $.while_statement,
+      $.yield_statement
+    ),
+
+    // Attribute support
+    attributes: $ => repeat1($.attribute_list),
+    
+    attribute_list: $ => seq(
+      '[',
+      choice(
+        $.grit_metavariable,
+        commaSep1($.attribute)
+      ),
+      ']'
+    ),
+
+    // Base metavariable rule
+    grit_metavariable: $ => /\$[A-Za-z_][A-Za-z0-9_]*/,
+
+    // C# 9.0+ top-level statements
+    compilation_unit: $ => choice(
+      $.grit_metavariable,
+      seq(
+        repeat(choice(
+          $.extern_alias_directive,
+          $.using_directive
+        )),
+        repeat(choice(
+          $.statement,
+          $.declaration
+        ))
+      )
+    ),
+
+    // Init-only setters and properties
+    accessor_declaration: $ => seq(
+      optional($.attributes),
+      repeat($.modifier),
+      choice(
+        'get',
+        'set',
+        'init',  // C# 9.0 init accessor
+        'add',
+        'remove'
+      ),
+      choice(
+        field('body', $.block),
+        ';',
+        '=>',
+        field('expression_body', $._expression)
+      )
+    ),
+
+    // File-scoped namespaces
+    file_scoped_namespace_declaration: $ => seq(
+      'namespace',
+      field('name', choice($.identifier, $.qualified_name, $.grit_metavariable)),
+      ';',
+      repeat($.declaration)
+    ),
+
+    // Target-typed new expressions
+    object_creation_expression: $ => choice(
+      $.grit_metavariable,
+      seq(
+        'new',
+        optional(field('type', $.type)),  // Optional for target-typed new
+        field('arguments', $.argument_list),
+        optional(field('initializer', $.initializer_expression))
+      )
+    ),
+
+    // Enhanced pattern matching
+    pattern: $ => choice(
+      $.grit_metavariable,
+      $.constant_pattern,
+      $.declaration_pattern,
+      $.var_pattern,
+      $.discard_pattern,
+      $.recursive_pattern,
+      $.property_pattern,
+      $.relational_pattern,
+      $.logical_pattern,
+      $.parenthesized_pattern,
+      $.list_pattern
+    ),
+
+    logical_pattern: $ => choice(
+      seq($.pattern, 'and', $.pattern),
+      seq($.pattern, 'or', $.pattern),
+      seq('not', $.pattern)
+    ),
+
+    relational_pattern: $ => seq(
+      choice('>', '<', '>=', '<=', '==', '!='),
+      choice($._expression, $.grit_metavariable)
+    ),
+
+    property_pattern: $ => seq(
+      '{',
+      optional(commaSep1($.subpattern)),
+      '}'
+    ),
+
+    subpattern: $ => choice(
+      $.grit_metavariable,
+      seq(
+        field('name', choice(
+          $.identifier,
+          $.grit_metavariable,
+          seq($.identifier, '.', $.identifier)  // Support nested properties
+        )),
+        ':',
+        field('pattern', choice($.pattern, $._expression))
+      )
+    ),
+
+    // Lambda expressions
+    lambda_expression: $ => choice(
+      $.grit_metavariable,
+      seq(
+        field('parameters', choice(
+          $.identifier,
+          $.parameter_list,
+          seq('(', commaSep1(choice($.parameter, $.grit_metavariable)), ')'),
+          $.grit_metavariable
+        )),
+        '=>',
+        field('body', choice($._expression, $.block, $.grit_metavariable))
+      )
+    ),
+
+    // Switch expressions
+    switch_expression: $ => seq(
+      field('value', choice($._expression, $.grit_metavariable)),
+      'switch',
+      '{',
+      commaSep1($.switch_expression_arm),
+      optional(','),
+      '}'
+    ),
+
+    switch_expression_arm: $ => seq(
+      field('pattern', choice($.pattern, $.grit_metavariable)),
+      '=>',
+      field('expression', choice($._expression, $.grit_metavariable))
+    ),
+
+    // List patterns
+    list_pattern: $ => seq(
+      '[',
+      optional(seq(
+        commaSep1(choice($.pattern, $.grit_metavariable)),
+        optional('..')
+      )),
+      ']'
+    ),
+
+    // Record support
+    record_declaration: $ => seq(
+      optional($.attributes),
+      repeat($.modifier),
+      choice('record', 'record class', 'record struct'),
+      field('name', choice($.identifier, $.grit_metavariable)),
+      optional(field('type_parameters', $.type_parameter_list)),
+      optional(field('parameters', $.parameter_list)),
+      optional(seq(':', commaSep1($.base_list))),
+      optional(field('constraints', $.type_parameter_constraints_clauses)),
+      choice(
+        field('body', $.declaration_list),
+        ';'
+      )
+    ),
+
+    // C# 10 global using directives
+    global_using_directive: $ => seq(
+      'global',
+      $.using_directive
+    ),
+
+    // C# 10 file-scoped namespace with usings
+    file_scoped_namespace_with_usings: $ => seq(
+      repeat(choice($.using_directive, $.global_using_directive)),
+      $.file_scoped_namespace_declaration
+    ),
+
+    // C# 10 extended property patterns
+    property_pattern: $ => seq(
+      '{',
+      choice(
+        $.grit_metavariable,
+        commaSep1($.subpattern)
+      ),
+      '}'
+    ),
+
+    // C# 10 constant interpolated strings
+    interpolated_string_expression: $ => choice(
+      $.grit_metavariable,
+      seq(
+        '$"',
+        repeat(choice(
+          $.interpolated_string_text,
+          $.interpolation
+        )),
+        '"'
+      )
+    ),
+
+    // C# 11 raw string literals
+    raw_string_literal: $ => choice(
+      $.grit_metavariable,
+      seq(
+        '"""',
+        repeat(choice($.raw_string_text, $.interpolation)),
+        '"""'
+      )
+    ),
+
+    // C# 11 list patterns
+    list_pattern: $ => choice(
+      $.grit_metavariable,
+      seq(
+        '[',
+        commaSep1($.pattern),
+        optional('..'),
+        ']'
+      )
+    ),
+
+    // C# 11 required members
+    required_member: $ => seq(
+      'required',
+      choice(
+        $.field_declaration,
+        $.property_declaration,
+        $.event_field_declaration
+      )
+    ),
+
+    // C# 11 static abstract members in interfaces
+    interface_member_declaration: $ => choice(
+      $.grit_metavariable,
+      seq(
+        optional($.attributes),
+        repeat($.modifier),
+        choice(
+          'static',
+          'abstract'
+        ),
+        choice(
+          $.method_declaration,
+          $.property_declaration,
+          $.event_declaration,
+          $.indexer_declaration
+        )
+      )
+    ),
+
+    // C# 12 primary constructors
+    class_declaration_with_primary_constructor: $ => seq(
+      optional($.attributes),
+      repeat($.modifier),
+      'class',
+      field('name', choice($.identifier, $.grit_metavariable)),
+      field('constructor_parameters', $.parameter_list),
+      optional(field('base_list', seq(':', commaSep1($.base_type)))),
+      field('body', $.declaration_list)
+    ),
+
+    // C# 12 collection expressions
+    collection_expression: $ => choice(
+      $.grit_metavariable,
+      seq(
+        '[',
+        optional(commaSep1($._expression)),
+        optional('..'),
+        ']'
+      )
+    ),
+
+    // Enhanced LINQ support with more granular rules
+    query_expression: $ => seq(
+      'from',
+      field('range_variable', choice($.identifier, $.grit_metavariable)),
+      'in',
+      field('collection', choice($._expression, $.grit_metavariable)),
+      repeat(choice(
+        $.where_clause,
+        $.join_clause,
+        $.let_clause,
+        $.group_clause,
+        $.select_clause,
+        $.orderby_clause
+      ))
+    ),
+
+    select_clause: $ => seq(
+      'select',
+      field('expression', choice(
+        $._expression,
+        $.anonymous_object_creation_expression,
+        $.grit_metavariable
+      ))
+    ),
+
+    anonymous_object_creation_expression: $ => seq(
+      'new',
+      '{',
+      commaSep1($.anonymous_object_member_declaration),
+      '}'
+    ),
+
+    anonymous_object_member_declaration: $ => choice(
+      $.grit_metavariable,
+      seq(
+        optional(field('name', $.identifier)),
+        '=',
+        field('expression', $._expression)
+      )
+    ),
+
+    // Pattern matching expressions
+    is_pattern_expression: $ => seq(
+      field('expression', choice($._expression, $.grit_metavariable)),
+      'is',
+      field('pattern', choice(
+        $.constant_pattern,
+        $.declaration_pattern,
+        $.var_pattern,
+        $.type_pattern,
+        $.property_pattern,
+        $.grit_metavariable
+      ))
+    ),
+
+    declaration_pattern: $ => seq(
+      field('type', choice($.type, $.grit_metavariable)),
+      field('designation', choice($.identifier, $.grit_metavariable))
+    ),
+
+    type_pattern: $ => choice(
+      $.type,
+      $.grit_metavariable
+    ),
+  }
+});
+
+function commaSep1(rule) {
+  return seq(rule, repeat(seq(',', rule)))
+} 


### PR DESCRIPTION
Fixes: #438 
/claim #438 

- Add C# language implementation with tree-sitter grammar
- Add comprehensive test suite for language features
- Include pattern matching, LINQ, and records support

<!-- greptile_comment -->

## Greptile Summary

**This is an auto-generated summary**
--
Hi! Looks like you've reached your API usage limit. You can increase it from your account settings page here: [app.greptile.com/settings/usage](https://app.greptile.com/settings/usage)

<!-- /greptile_comment -->