### PR TITLE
fix: properly capture Rust array expressions

### DIFF
--- a/resources/language-metavariables/tree-sitter-rust/grammar.js
+++ b/resources/language-metavariables/tree-sitter-rust/grammar.js
@@ -1055,13 +1055,15 @@ module.exports = grammar({
       repeat($.attribute_item),
       choice(
         seq(
-          $._expression,
+          field('repeat', $._expression),
           ';',
           field('length', $._expression)
         ),
-        seq(
-          sepBy(',', $._expression),
-          optional(',')
+	      field('elements',
+          seq(
+            sepBy(',', $._expression),
+            optional(',')
+          )
         )
       ),
       ']'

--- a/resources/language-metavariables/tree-sitter-rust/src/grammar.json
+++ b/resources/language-metavariables/tree-sitter-rust/src/grammar.json
@@ -5936,8 +5936,12 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "_expression"
+                  "type": "FIELD",
+                  "name": "repeat",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
                 },
                 {
                   "type": "STRING",
@@ -5954,54 +5958,58 @@
               ]
             },
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_expression"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": ","
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "_expression"
-                              }
-                            ]
+              "type": "FIELD",
+              "name": "elements",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": ","
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "_expression"
+                                }
+                              ]
+                            }
                           }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           ]
         },

--- a/resources/language-metavariables/tree-sitter-rust/src/node-types.json
+++ b/resources/language-metavariables/tree-sitter-rust/src/node-types.json
@@ -523,7 +523,31 @@
     "type": "array_expression",
     "named": true,
     "fields": {
+      "elements": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
       "length": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "repeat": {
         "multiple": false,
         "required": false,
         "types": [
@@ -538,10 +562,6 @@
       "multiple": true,
       "required": false,
       "types": [
-        {
-          "type": "_expression",
-          "named": true
-        },
         {
           "type": "attribute_item",
           "named": true

--- a/resources/node-types/rust-node-types.json
+++ b/resources/node-types/rust-node-types.json
@@ -523,10 +523,34 @@
     "type": "array_expression",
     "named": true,
     "fields": {
+      "repeat": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
       "length": {
         "multiple": false,
         "required": false,
         "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "elements": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
           {
             "type": "_expression",
             "named": true


### PR DESCRIPTION
# Issue
Contents of Rust `array_expression`s is ignored. E.g. the following pattern:

```
language rust
`[foo, bar, baz]`
```

Matches every line of the following snippet:
```rust
[];
[a];
[a, b, c];
```

# Cause
It seems that the cause is that the `array_expression` rule captures only the `length` field (e.g., `32` in `[0u8; 32]`), but not anything else.
https://github.com/getgrit/gritql/blob/5af841f57592f287bdd736a87ec4008c77d88603/resources/node-types/rust-node-types.json#L522-L536

# Fix in this PR
This PR adds fields `repeat` (e.g., `0u8` in `[0u8; 32]`) and `elements` (e.g. `a,b,c` in `[a,b,c]`).
Related Rust reference page: https://doc.rust-lang.org/reference/expressions/array-expr.html