### PR TITLE
chore: use native pattern builder instead of string interpolation

### DIFF
--- a/crates/cli/src/commands/format.rs
+++ b/crates/cli/src/commands/format.rs
@@ -206,7 +206,7 @@ fn format_grit_code(source: &str) -> Result<(Vec<MatchResult>, String)> {
 }
 
 mod yaml {
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
 
     use anyhow::{anyhow, bail, Context, Result};
     use grit_pattern_matcher::pattern::{
@@ -215,10 +215,8 @@ mod yaml {
     use marzano_core::api::MatchResult;
     use marzano_core::sdk::LanguageSdk;
     use marzano_gritmodule::config::ResolvedGritDefinition;
-    use marzano_language::target_language::{PatternLanguage, TargetLanguage};
+    use marzano_language::target_language::PatternLanguage;
     use marzano_util::{rich_path::RichFile, runtime::ExecutionContext};
-
-    use crate::resolver::GritModuleResolver;
 
     use super::format_grit_code;
 

--- a/crates/cli/src/commands/format.rs
+++ b/crates/cli/src/commands/format.rs
@@ -215,7 +215,7 @@ mod yaml {
     use marzano_core::api::MatchResult;
     use marzano_core::sdk::LanguageSdk;
     use marzano_gritmodule::config::ResolvedGritDefinition;
-    use marzano_language::target_language::TargetLanguage;
+    use marzano_language::target_language::{PatternLanguage, TargetLanguage};
     use marzano_util::{rich_path::RichFile, runtime::ExecutionContext};
 
     use crate::resolver::GritModuleResolver;
@@ -227,8 +227,7 @@ mod yaml {
         file_content: &str,
     ) -> Result<(Vec<MatchResult>, String)> {
         let mut results = vec![];
-        let mut sdk =
-            LanguageSdk::from_language(TargetLanguage::from_string("yaml", None).unwrap());
+        let mut sdk = LanguageSdk::from_language(PatternLanguage::Yaml.try_into().unwrap());
 
         // Build pattern for each grit definition
         let pattern_rewrites = patterns

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,7 +16,6 @@ mod foreign_function_definition;
 pub mod fs;
 mod inline_snippets;
 
-#[cfg(any(feature = "napi", feature = "wasm_core"))]
 pub mod sdk;
 
 mod limits;

--- a/crates/core/src/sdk/compiler.rs
+++ b/crates/core/src/sdk/compiler.rs
@@ -83,7 +83,7 @@ impl StatelessCompilerContext {
         for (name, pattern) in fields {
             let node_sort = self.lang.get_ts_language().node_kind_for_id(sort).unwrap();
             let field_id = self.lang.get_ts_language()
-                .field_id_for_name(&name)
+                .field_id_for_name(name)
                 .ok_or_else(|| {
                     if node_field_names.is_empty() {
                         anyhow!(

--- a/crates/core/src/sdk/compiler.rs
+++ b/crates/core/src/sdk/compiler.rs
@@ -1,9 +1,5 @@
-use anyhow::{bail, Result};
-use grit_pattern_matcher::pattern::{DynamicSnippetPart, Pattern, PatternDefinition, Variable};
-use grit_util::ByteRange;
-use marzano_language::target_language::TargetLanguage;
-
 use crate::{
+    ast_node::ASTNode,
     built_in_functions::BuiltIns,
     pattern_compiler::{
         compiler::{DefinitionInfo, SnippetCompilationContext},
@@ -11,6 +7,16 @@ use crate::{
     },
     problem::MarzanoQueryContext,
 };
+use anyhow::{anyhow, bail, Result};
+use grit_pattern_matcher::pattern::{DynamicSnippetPart, Pattern, PatternDefinition, Variable};
+use grit_util::ByteRange;
+use itertools::Itertools;
+use marzano_language::{
+    language::MarzanoLanguage, language::NodeTypes, target_language::TargetLanguage,
+};
+use std::collections::HashMap;
+
+const COMMENT_CONTENT_FIELD_ID: u16 = 10000;
 
 /// As opposed to our standard StatelessCompiler,
 /// the StatelessCompiler can handle snippets without needing to maintain scopes
@@ -32,6 +38,84 @@ impl StatelessCompilerContext {
         let range = ByteRange::new(0, content.len());
         let snippet = parse_snippet_content(content, range, self, false)?;
         Ok(snippet)
+    }
+
+    /// Creates a new AST node pattern with the given name and fields
+    pub fn node(
+        &self,
+        name: &str,
+        fields: HashMap<&str, Pattern<MarzanoQueryContext>>,
+    ) -> Result<Pattern<MarzanoQueryContext>> {
+        // Get the sort ID for the node type
+        let sort = self.lang.get_ts_language().id_for_node_kind(name, true);
+        if sort == 0 {
+            return Err(anyhow!("invalid node type: {}", name));
+        }
+
+        // Convert fields into (field_id, is_multiple, pattern) tuples
+        let mut args = Vec::new();
+
+        // Special handling for comment nodes
+        if self.lang.is_comment_sort(sort) {
+            if fields.len() > 1 {
+                return Err(anyhow!("comment node cannot have more than one field"));
+            }
+            if let Some(content) = fields.get("content") {
+                args.push((COMMENT_CONTENT_FIELD_ID, false, content.clone()));
+            }
+            return Ok(Pattern::AstNode(Box::new(ASTNode::new(sort, args))));
+        }
+
+        // Get node field information
+        let node_fields = &self.lang.node_types()[usize::from(sort)];
+        let node_field_names = node_fields
+            .iter()
+            .map(|f| {
+                self.lang
+                    .get_ts_language()
+                    .field_name_for_id(f.id())
+                    .unwrap()
+                    .to_string()
+            })
+            .join(", ");
+
+        // Process each field
+        for (name, pattern) in fields {
+            let node_sort = self.lang.get_ts_language().node_kind_for_id(sort).unwrap();
+            let field_id = self.lang.get_ts_language()
+                .field_id_for_name(&name)
+                .ok_or_else(|| {
+                    if node_field_names.is_empty() {
+                        anyhow!(
+                            "invalid field `{}` for AST node `{}`. `{}` does not expose any fields.",
+                            name,
+                            node_sort,
+                            node_sort,
+                        )
+                    } else {
+                        anyhow!(
+                            "invalid field `{}` for AST node `{}`, valid fields are: {}",
+                            name,
+                            node_sort,
+                            node_field_names
+                        )
+                    }
+                })?;
+
+            let field = node_fields
+                .iter()
+                .find(|f| f.id() == field_id)
+                .ok_or_else(|| anyhow!("field {} not found in node type {}", name, node_sort))?;
+
+            args.push((field_id, field.multiple(), pattern));
+        }
+
+        // Check for duplicate fields
+        if args.len() != args.iter().unique_by(|a| a.0).count() {
+            return Err(anyhow!("duplicate field in node"));
+        }
+
+        Ok(Pattern::AstNode(Box::new(ASTNode::new(sort, args))))
     }
 }
 

--- a/crates/core/src/sdk/language_sdk.rs
+++ b/crates/core/src/sdk/language_sdk.rs
@@ -25,14 +25,18 @@ pub struct LanguageSdk {
 impl Default for LanguageSdk {
     fn default() -> Self {
         let language = TargetLanguage::from_string("js", None).unwrap();
+        Self::from_language(language)
+    }
+}
+
+impl LanguageSdk {
+    pub fn from_language(language: TargetLanguage) -> Self {
         Self {
             compiler: StatelessCompilerContext::new(language),
             language,
         }
     }
-}
 
-impl LanguageSdk {
     pub fn compiler(&self) -> StatelessCompilerContext {
         StatelessCompilerContext::new(self.language)
     }
@@ -42,7 +46,12 @@ impl LanguageSdk {
         compiler.parse_snippet(snippet)
     }
 
-    pub fn build(
+    pub fn build(&mut self, pattern: Pattern<MarzanoQueryContext>) -> Result<Problem> {
+        let built_ins = BuiltIns::get_built_in_functions();
+        self.build_custom(built_ins, pattern)
+    }
+
+    pub fn build_custom(
         &mut self,
         built_ins: BuiltIns,
         pattern: Pattern<MarzanoQueryContext>,

--- a/crates/core/src/sdk/mod.rs
+++ b/crates/core/src/sdk/mod.rs
@@ -2,6 +2,7 @@ mod compiler;
 mod language_sdk;
 mod pattern_sdk;
 mod test_js;
+mod test_yaml;
 
 #[cfg(feature = "napi")]
 mod binding;

--- a/crates/core/src/sdk/pattern_sdk.rs
+++ b/crates/core/src/sdk/pattern_sdk.rs
@@ -115,7 +115,7 @@ impl UncompiledPatternBuilder {
         let mut compiler = sdk.compiler();
 
         let compiled = self.compile(&mut compiler)?;
-        let built = sdk.build(compiler.built_ins, compiled)?;
+        let built = sdk.build_custom(compiler.built_ins, compiled)?;
         Ok(built)
     }
 

--- a/crates/core/src/sdk/snapshots/marzano_core__sdk__test_yaml__tests__rewrite.snap
+++ b/crates/core/src/sdk/snapshots/marzano_core__sdk__test_yaml__tests__rewrite.snap
@@ -1,0 +1,25 @@
+---
+source: crates/core/src/sdk/test_yaml.rs
+expression: after
+---
+version: 0.0.1
+patterns:
+  - name: github.com/getgrit/stdlib#*
+  - name: other_pattern
+    level: error
+    body: |
+      language toml
+
+      other_pattern() where $filename <: includes "test.yaml"
+  - name: target_pattern
+    level: error
+    body: replacement body
+  - name: our_cargo_use_long_dependency
+    level: error
+    body: |
+      language toml
+
+      cargo_use_long_dependency() where $filename <: not includes or {
+        "language-submodules",
+        "language-metavariables"
+      }

--- a/crates/core/src/sdk/test_yaml.rs
+++ b/crates/core/src/sdk/test_yaml.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use grit_pattern_matcher::pattern::{Contains, DynamicPattern, FilePattern, Pattern, Rewrite};
     use insta::assert_snapshot;
     use itertools::Itertools;
@@ -45,6 +47,64 @@ mod tests {
                 SyntheticFile::new("bad.yaml".to_owned(), "bar: baz\n".to_owned(), true),
             ],
         );
+
+        assert!(
+            results
+                .iter()
+                .filter(|r| matches!(r, MatchResult::Match(_)))
+                .exactly_one()
+                .is_ok(),
+            "should have exactly one match"
+        );
+    }
+
+    #[test]
+    fn test_yaml_patterns() {
+        let mut sdk =
+            LanguageSdk::from_language(TargetLanguage::from_string("yaml", None).unwrap());
+
+        let yaml_content = r#"version: 0.0.1
+patterns:
+  - name: github.com/getgrit/stdlib#*
+  - name: other_pattern
+    level: error
+    body: |
+      language toml
+
+      other_pattern() where $filename <: includes "test.yaml"
+  - name: target_pattern
+    level: error
+    body: |
+      language foolhardy
+  - name: our_cargo_use_long_dependency
+    level: error
+    body: |
+      language toml
+
+      cargo_use_long_dependency() where $filename <: not includes or {
+        "language-submodules",
+        "language-metavariables"
+      }"#;
+
+        let our_name = sdk
+            .compiler()
+            .node("block_mapping_pair", HashMap::from([("key", Pattern::Top)]))
+            .unwrap();
+
+        let file = Pattern::File(Box::new(FilePattern::new(
+            Pattern::Top,
+            Contains::new_pattern(our_name, None),
+        )));
+
+        let results = run_on_test_files(
+            &sdk.build(file).unwrap(),
+            &[
+                SyntheticFile::new("test.yaml".to_owned(), yaml_content.to_owned(), true),
+                SyntheticFile::new("bad.yaml".to_owned(), "funky\n".to_owned(), true),
+            ],
+        );
+
+        println!("{:?}", results);
 
         assert!(
             results

--- a/crates/core/src/sdk/test_yaml.rs
+++ b/crates/core/src/sdk/test_yaml.rs
@@ -3,7 +3,7 @@ mod tests {
     use std::collections::HashMap;
 
     use grit_pattern_matcher::pattern::{
-        Contains, DynamicPattern, FilePattern, Pattern, Rewrite, StringConstant,
+        Contains, DynamicPattern, FilePattern, Pattern, StringConstant,
     };
     use insta::assert_snapshot;
     use itertools::Itertools;

--- a/crates/core/src/sdk/test_yaml.rs
+++ b/crates/core/src/sdk/test_yaml.rs
@@ -2,7 +2,9 @@
 mod tests {
     use std::collections::HashMap;
 
-    use grit_pattern_matcher::pattern::{Contains, DynamicPattern, FilePattern, Pattern, Rewrite};
+    use grit_pattern_matcher::pattern::{
+        Contains, DynamicPattern, FilePattern, Pattern, Rewrite, StringConstant,
+    };
     use insta::assert_snapshot;
     use itertools::Itertools;
     use marzano_language::target_language::TargetLanguage;
@@ -88,7 +90,13 @@ patterns:
 
         let our_name = sdk
             .compiler()
-            .node("block_mapping_pair", HashMap::from([("key", Pattern::Top)]))
+            .node(
+                "block_mapping_pair",
+                HashMap::from([(
+                    "key",
+                    Pattern::StringConstant(StringConstant::new("name".to_owned())),
+                )]),
+            )
             .unwrap();
 
         let file = Pattern::File(Box::new(FilePattern::new(
@@ -100,7 +108,7 @@ patterns:
             &sdk.build(file).unwrap(),
             &[
                 SyntheticFile::new("test.yaml".to_owned(), yaml_content.to_owned(), true),
-                SyntheticFile::new("bad.yaml".to_owned(), "funky\n".to_owned(), true),
+                SyntheticFile::new("bad.yaml".to_owned(), "no: name\n".to_owned(), true),
             ],
         );
 

--- a/crates/core/src/sdk/test_yaml.rs
+++ b/crates/core/src/sdk/test_yaml.rs
@@ -98,10 +98,20 @@ patterns:
                 )]),
             )
             .unwrap();
+        let our_block = sdk
+            .compiler()
+            .node(
+                "block_mapping",
+                HashMap::from([(
+                    "items",
+                    Pattern::Some(Box::new(grit_pattern_matcher::pattern::Some::new(our_name))),
+                )]),
+            )
+            .unwrap();
 
         let file = Pattern::File(Box::new(FilePattern::new(
             Pattern::Top,
-            Contains::new_pattern(our_name, None),
+            Contains::new_pattern(our_block, None),
         )));
 
         let results = run_on_test_files(

--- a/crates/core/src/sdk/test_yaml.rs
+++ b/crates/core/src/sdk/test_yaml.rs
@@ -1,0 +1,58 @@
+#[cfg(test)]
+mod tests {
+    use grit_pattern_matcher::pattern::{Contains, DynamicPattern, FilePattern, Pattern, Rewrite};
+    use insta::assert_snapshot;
+    use itertools::Itertools;
+    use marzano_language::target_language::TargetLanguage;
+
+    use crate::{
+        api::MatchResult,
+        sdk::language_sdk::LanguageSdk,
+        test_utils::{run_on_test_files, SyntheticFile},
+    };
+
+    #[test]
+    fn test_basic_file_contains() {
+        let mut sdk =
+            LanguageSdk::from_language(TargetLanguage::from_string("yaml", None).unwrap());
+
+        let console = sdk.snippet("foo: bar").unwrap();
+
+        let file = Pattern::File(Box::new(FilePattern::new(
+            Pattern::Top,
+            Contains::new_pattern(console, None),
+        )));
+
+        let results = run_on_test_files(
+            &sdk.build(file).unwrap(),
+            &[
+                SyntheticFile::new(
+                    "test.yaml".to_owned(),
+                    "stuff:
+  bar:
+    baz:
+      qux: quux
+      foo: bar
+      corge:
+        - grault
+        - garply
+      waldo:
+        fred: plugh
+        xyzzy: thud\n"
+                        .to_owned(),
+                    true,
+                ),
+                SyntheticFile::new("bad.yaml".to_owned(), "bar: baz\n".to_owned(), true),
+            ],
+        );
+
+        assert!(
+            results
+                .iter()
+                .filter(|r| matches!(r, MatchResult::Match(_)))
+                .exactly_one()
+                .is_ok(),
+            "should have exactly one match"
+        );
+    }
+}


### PR DESCRIPTION
Hopefully makes the yaml less error-prone, follow up to https://github.com/getgrit/gritql/pull/606.