### PR TITLE
fix: add padding to MonacoEditor height

### DIFF
--- a/docs/src/components/editor/monaco-editor.tsx
+++ b/docs/src/components/editor/monaco-editor.tsx
@@ -40,9 +40,11 @@ export const MonacoEditor = ({
   const [didMount, setDidMount] = useState(false);
   const [isClient, setIsClient] = useState(false);
 
+  const mergedOptions = merge(editorOptions, readOnly && { ...readOnlyOptions }, options)
+  const verticalPadding = mergedOptions.padding.top + mergedOptions.padding.bottom;
   const height = useMemo(() => {
-    return getHeight(value ?? '', maxLines, minLines);
-  }, [value, maxLines, minLines]);
+    return getHeight(value ?? '', maxLines, minLines) + verticalPadding;
+  }, [value, maxLines, minLines, verticalPadding]);
 
   const handleEditorDidMount: OnMount = async (editor, monaco) => {
     editorRef.current = editor;
@@ -68,7 +70,7 @@ export const MonacoEditor = ({
       theme='grit'
       loading={<Loading value={value ?? 'Loading...'} />}
       height={noCliff ? '100%' : `${height}px`}
-      options={merge(editorOptions, readOnly && { ...readOnlyOptions }, options)}
+      options={mergedOptions}
       onChange={(value, editor) => {
         const hasFocus = editorRef.current?.hasTextFocus();
         if (hasFocus) onChange(value, editor);


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes
The text in MonacoEditor was getting cut off because its height doesn't account for padding. 
To fix this, I added vertical padding to the height of the editor.

## How to verify that this has the expected result
Check  `/cli/quickstart`. I've attached a screenshot for your reference.

**before**
<img width="715" alt="スクリーンショット 2025-05-28 23 31 13" src="https://github.com/user-attachments/assets/c44c0466-1d6f-4708-995e-9e99bfaed56e" />

**after**
<img width="713" alt="スクリーンショット 2025-05-28 23 30 58" src="https://github.com/user-attachments/assets/b59a9416-c413-422f-a5cb-b2044c3814fc" />
