### PR TITLE
feat: use npm trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/napi.yaml
+++ b/.github/workflows/napi.yaml
@@ -453,6 +453,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - name: Update npm for trusted publishing support
+        run: npm i -g npm@11.6.1
       - name: Install dependencies
         run: npm install --ignore-scripts
         working-directory: ${{ env.WORKING_DIR }}
@@ -485,17 +488,14 @@ jobs:
       - name: Publish
         if: steps.version_check.outputs.should_publish == 'true' || github.event.inputs.publish == 'true'
         run: |
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-          npm config set provenance true
           LOCAL_VERSION="${{ steps.version_check.outputs.local_version }}"
           if echo "$LOCAL_VERSION" | grep -q "-"; then
             echo "Publishing $LOCAL_VERSION as next"
-            npm publish --tag next --access public
+            npm publish --tag next --access public --provenance
           else
             echo "Publishing $LOCAL_VERSION as latest"
-            npm publish --access public
+            npm publish --access public --provenance
           fi
         working-directory: ${{ env.WORKING_DIR }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Switch from `NPM_TOKEN`-based authentication to [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) for publishing to npm. This eliminates the need for long-lived npm access tokens and improves security.

## Changes

- Add `registry-url: 'https://registry.npmjs.org'` to `actions/setup-node` — required for OIDC token exchange
- Install `npm@11.6.1` which supports trusted publishing (reference: [nx-plugin-for-aws CI](https://github.com/aws/nx-plugin-for-aws/blob/main/.github/actions/init-monorepo/action.yml))
- Remove manual `.npmrc` token configuration (`echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc`)
- Remove `NPM_TOKEN` secret usage — no longer needed with OIDC
- Pass `--provenance` flag directly to `npm publish` commands
- Keep existing `id-token: write` permission (already present)

## How it works

Trusted publishing creates a trust relationship between npm and GitHub Actions using OIDC. When configured, npm accepts publishes from the authorized workflow using short-lived, cryptographically-signed tokens instead of long-lived access tokens. The npm CLI automatically detects the OIDC environment and uses it for authentication.

## Setup steps

Before merging this PR, the platform-specific npm packages need to be created for the first time (most don't exist yet). Here's the suggested approach:

1. **Add an `NPM_TOKEN` to GitHub secrets** and run the existing workflow as-is — this will publish all the new packages for the first time
2. **Set up trusted publishing** for each of the npm packages via the [npm website](https://www.npmjs.com) (package settings → Trusted Publishers → add `biomejs/gritql` repo with `.github/workflows/napi.yaml` workflow)
3. **Merge this PR** and delete the `NPM_TOKEN` secret — trusted publishing handles auth from here on

### Packages that already exist
- ✅ `@getgrit/gritql` (v0.0.1)
- ✅ `@getgrit/gritql-darwin-arm64` (v0.0.0)

### Packages that need to be created first (11)
`@getgrit/gritql-win32-x64-msvc`, `@getgrit/gritql-darwin-x64`, `@getgrit/gritql-darwin-universal`, `@getgrit/gritql-linux-x64-gnu`, `@getgrit/gritql-linux-x64-musl`, `@getgrit/gritql-linux-arm64-gnu`, `@getgrit/gritql-linux-arm64-musl`, `@getgrit/gritql-win32-arm64-msvc`, `@getgrit/gritql-android-arm64`, `@getgrit/gritql-freebsd-x64`, `@getgrit/gritql-linux-riscv64-gnu`