### PR TITLE
fix: add repository URL to npm package.json files for provenance

### DIFF
--- a/js/gritql/npm/android-arm64/package.json
+++ b/js/gritql/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-android-arm64",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "android"
   ],
@@ -14,5 +14,6 @@
   "license": "MIT",
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/darwin-arm64/package.json
+++ b/js/gritql/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-darwin-arm64",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "darwin"
   ],
@@ -14,5 +14,6 @@
   "license": "MIT",
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/darwin-universal/package.json
+++ b/js/gritql/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-darwin-universal",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "darwin"
   ],
@@ -11,5 +11,6 @@
   "license": "MIT",
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/darwin-x64/package.json
+++ b/js/gritql/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-darwin-x64",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "darwin"
   ],
@@ -14,5 +14,6 @@
   "license": "MIT",
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/freebsd-x64/package.json
+++ b/js/gritql/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-freebsd-x64",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "freebsd"
   ],
@@ -14,5 +14,6 @@
   "license": "MIT",
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/linux-arm64-gnu/package.json
+++ b/js/gritql/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-linux-arm64-gnu",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],
@@ -17,5 +17,6 @@
   },
   "libc": [
     "glibc"
-  ]
+  ],
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/linux-arm64-musl/package.json
+++ b/js/gritql/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-linux-arm64-musl",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],
@@ -17,5 +17,6 @@
   },
   "libc": [
     "musl"
-  ]
+  ],
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/linux-riscv64-gnu/package.json
+++ b/js/gritql/npm/linux-riscv64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-linux-riscv64-gnu",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],
@@ -17,5 +17,6 @@
   },
   "libc": [
     "glibc"
-  ]
+  ],
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/linux-x64-gnu/package.json
+++ b/js/gritql/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-linux-x64-gnu",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],
@@ -17,5 +17,6 @@
   },
   "libc": [
     "glibc"
-  ]
+  ],
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/linux-x64-musl/package.json
+++ b/js/gritql/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-linux-x64-musl",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],
@@ -17,5 +17,6 @@
   },
   "libc": [
     "musl"
-  ]
+  ],
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/win32-arm64-msvc/package.json
+++ b/js/gritql/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-win32-arm64-msvc",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "win32"
   ],
@@ -14,5 +14,6 @@
   "license": "MIT",
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/npm/win32-x64-msvc/package.json
+++ b/js/gritql/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql-win32-x64-msvc",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "win32"
   ],
@@ -14,5 +14,6 @@
   "license": "MIT",
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "repository": "https://github.com/biomejs/gritql"
 }

--- a/js/gritql/package.json
+++ b/js/gritql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgrit/gritql",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "__generated__/index.js",
   "types": "__generated__/index.d.ts",
   "napi": {
@@ -28,18 +28,18 @@
     "@napi-rs/cli": "^2.18.4"
   },
   "optionalDependencies": {
-    "@getgrit/gritql-win32-x64-msvc": "0.0.2",
-    "@getgrit/gritql-darwin-x64": "0.0.2",
-    "@getgrit/gritql-linux-x64-gnu": "0.0.2",
-    "@getgrit/gritql-darwin-arm64": "0.0.2",
-    "@getgrit/gritql-linux-x64-musl": "0.0.2",
-    "@getgrit/gritql-linux-arm64-gnu": "0.0.2",
-    "@getgrit/gritql-linux-arm64-musl": "0.0.2",
-    "@getgrit/gritql-win32-arm64-msvc": "0.0.2",
-    "@getgrit/gritql-darwin-universal": "0.0.2",
-    "@getgrit/gritql-android-arm64": "0.0.2",
-    "@getgrit/gritql-freebsd-x64": "0.0.2",
-    "@getgrit/gritql-linux-riscv64-gnu": "0.0.2"
+    "@getgrit/gritql-win32-x64-msvc": "0.0.3",
+    "@getgrit/gritql-darwin-x64": "0.0.3",
+    "@getgrit/gritql-linux-x64-gnu": "0.0.3",
+    "@getgrit/gritql-darwin-arm64": "0.0.3",
+    "@getgrit/gritql-linux-x64-musl": "0.0.3",
+    "@getgrit/gritql-linux-arm64-gnu": "0.0.3",
+    "@getgrit/gritql-linux-arm64-musl": "0.0.3",
+    "@getgrit/gritql-win32-arm64-msvc": "0.0.3",
+    "@getgrit/gritql-darwin-universal": "0.0.3",
+    "@getgrit/gritql-android-arm64": "0.0.3",
+    "@getgrit/gritql-freebsd-x64": "0.0.3",
+    "@getgrit/gritql-linux-riscv64-gnu": "0.0.3"
   },
   "engines": {
     "node": ">= 10"
@@ -55,5 +55,6 @@
     "version": "napi version",
     "example:search": "bun run examples/search.ts",
     "example:search:node": "node examples/search.js"
-  }
+  },
+  "repository": "https://github.com/biomejs/gritql"
 }


### PR DESCRIPTION
## Problem

The publish workflow fails with:

```
E422 - Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: "repository.url" is "", expected to match "https://github.com/biomejs/gritql" from provenance
```

npm's provenance verification requires the `repository` field in `package.json` to match the GitHub repository that built the package.

## Fix

1. Add `"repository": "https://github.com/biomejs/gritql"` to the main `js/gritql/package.json` and all 12 platform-specific `js/gritql/npm/*/package.json` files
2. Bump all package versions from `0.0.2` to `0.0.3` (including `optionalDependencies`) since the `v0.0.2` release tag already exists from the previous failed publish attempt